### PR TITLE
Fix package structure for androidTest folder

### DIFF
--- a/app/src/androidTest/kotlin/com/wire/android/FunctionalTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/FunctionalTest.kt
@@ -1,4 +1,4 @@
-package com.android.wire
+package com.wire.android
 
 import android.app.Activity
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/androidTest/kotlin/com/wire/android/InstrumentationTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/InstrumentationTest.kt
@@ -1,4 +1,4 @@
-package com.android.wire
+package com.wire.android
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith

--- a/app/src/androidTest/kotlin/com/wire/android/MainActivityTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/MainActivityTest.kt
@@ -1,11 +1,9 @@
-package com.android.wire
+package com.wire.android
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import com.wire.android.MainActivity
-import com.wire.android.R
 import org.junit.Test
 
 class MainActivityTest : FunctionalTest(MainActivity::class.java) {

--- a/app/src/androidTest/kotlin/com/wire/android/WireApplicationTest.kt
+++ b/app/src/androidTest/kotlin/com/wire/android/WireApplicationTest.kt
@@ -1,6 +1,7 @@
-package com.android.wire
+package com.wire.android
 
 import androidx.test.platform.app.InstrumentationRegistry
+import com.wire.android.InstrumentationTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/infrastructure.gradle.kts
@@ -17,7 +17,7 @@ tasks.register("runUnitTests") {
 }
 
 tasks.register("runAcceptanceTests") {
-    description = "Runs all Acceptance Tests."
+    description = "Runs all Acceptance Tests in the connected device."
     dependsOn(":app:connectedAndroidTest")
 }
 


### PR DESCRIPTION
This PR moves classes around (```androidTest```) in order to be consistent with the rest of the application package structure.

EXTRA BALL: Added extra information to its corresponding ```gradle``` task. 