### PR TITLE
Remove local.properties file from remote repo - Part 1

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Fri Jun 05 12:10:20 CEST 2020
-sdk.dir=/home/fernando/Android/Sdk


### PR DESCRIPTION
local.properties file should not be pushed to remote repo because it contains environment specific settings.