### PR TITLE
Refactor: move gradle kotlin compile options to compilation script.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,16 +17,12 @@ android {
         applicationId = appId
         minSdkVersion(AndroidSdk.min)
         targetSdkVersion(AndroidSdk.target)
-        versionCode = 1
-        versionName = "1.0"
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        versionCode = AndroidSdk.versionCode
+        versionName = AndroidSdk.versionName
+        testInstrumentationRunner = AndroidSdk.testInstrumentationRunner
     }
 
     sourceSets { map { it.java.srcDir("src/${it.name}/kotlin") } }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,6 @@
 private object Dependencies {
-    const val AndroidBuildTools = "com.android.tools.build:gradle:4.0.0"
+    const val AndroidBuildTools  = "com.android.tools.build:gradle:4.0.0"
+    const val KotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
 }
 
 plugins {
@@ -14,4 +15,5 @@ repositories {
 
 dependencies {
     implementation(Dependencies.AndroidBuildTools)
+    implementation(Dependencies.KotlinGradlePlugin)
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,6 +18,11 @@ object AndroidSdk {
     const val min = 21
     const val compile = 29
     const val target = compile
+
+    const val versionCode = 1
+    const val versionName = "1.0"
+
+    const val testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 }
 
 object Libraries {

--- a/buildSrc/src/main/kotlin/core/android.gradle.kts
+++ b/buildSrc/src/main/kotlin/core/android.gradle.kts
@@ -2,4 +2,5 @@ package core
 
 plugins {
     id("com.android.application") apply false
+    id("kotlin-android") apply false
 }

--- a/buildSrc/src/main/kotlin/scripts/compilation.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/compilation.gradle.kts
@@ -15,4 +15,8 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+    }
 }


### PR DESCRIPTION
This PR aims to clean up and refactor kotlin compile options to ```compilation.gradle.kts``` pre-compile Kotlin DSL gradle script. 

```kotlin
    kotlinOptions {
        jvmTarget = JavaVersion.VERSION_1_8.toString()
    }
```

This fixes a tiny discussion from another PR:
https://github.com/wireapp/wire-android-reloaded/pull/11/files#r440705611

There are also some cosmetic extractions to ```Depedencies.kt```