### PR TITLE
Registration #6: Add email validation logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(Libraries.constraintLayout)
     implementation(Libraries.material)
     implementation(Libraries.livedataKtx)
+    implementation(Libraries.viewModelKtx)
     implementation(Libraries.Koin.androidCore)
     implementation(Libraries.Koin.viewModel)
 
@@ -45,6 +46,7 @@ dependencies {
     testImplementation(TestLibraries.mockito)
     testImplementation(TestLibraries.robolectric)
     testImplementation(TestLibraries.assertJ)
+    testImplementation(TestLibraries.coroutinesTest)
 
     // Acceptance/Functional tests dependencies
     androidTestImplementation(TestLibraries.testRunner)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     // Application dependencies
-    implementation(Libraries.kotlinStdLib)
+    implementation(Libraries.Kotlin.stdLib)
     implementation(Libraries.appCompat)
     implementation(Libraries.ktxCore)
     implementation(Libraries.constraintLayout)
@@ -40,6 +40,8 @@ dependencies {
     implementation(Libraries.viewModelKtx)
     implementation(Libraries.Koin.androidCore)
     implementation(Libraries.Koin.viewModel)
+    implementation(Libraries.Kotlin.coroutinesCore)
+    implementation(Libraries.Kotlin.coroutinesAndroid)
 
     // Unit/Android tests dependencies
     testImplementation(TestLibraries.junit4)

--- a/app/src/main/kotlin/com/wire/android/core/exception/Failure.kt
+++ b/app/src/main/kotlin/com/wire/android/core/exception/Failure.kt
@@ -1,0 +1,10 @@
+package com.wire.android.core.exception
+
+/**
+ * Base Class for handling errors/failures/exceptions.
+ * Every feature specific failure should extend [FeatureFailure] class.
+ */
+sealed class Failure
+
+/** Extend this class for UseCase specific failures.*/
+abstract class FeatureFailure : Failure()

--- a/app/src/main/kotlin/com/wire/android/core/functional/Either.kt
+++ b/app/src/main/kotlin/com/wire/android/core/functional/Either.kt
@@ -1,0 +1,103 @@
+package com.wire.android.core.functional
+
+/**
+ * Represents a value of one of two possible types (a disjoint union).
+ * Instances of [Either] are either an instance of [Left] or [Right].
+ * FP Convention dictates that [Left] is used for "failure"
+ * and [Right] is used for "success".
+ *
+ * @see Left
+ * @see Right
+ */
+sealed class Either<out L, out R> {
+    /** * Represents the left side of [Either] class which by convention is a "Failure". */
+    data class Left<out L>(val a: L) : Either<L, Nothing>()
+
+    /** * Represents the right side of [Either] class which by convention is a "Success". */
+    data class Right<out R>(val b: R) : Either<Nothing, R>()
+
+    /**
+     * Returns true if this is a Right, false otherwise.
+     * @see Right
+     */
+    val isRight get() = this is Right<R>
+
+    /**
+     * Returns true if this is a Left, false otherwise.
+     * @see Left
+     */
+    val isLeft get() = this is Left<L>
+
+    /**
+     * Creates a Left type.
+     * @see Left
+     */
+    fun <L> left(a: L) = Either.Left(a)
+
+    /**
+     * Creates a Left type.
+     * @see Right
+     */
+    fun <R> right(b: R) = Either.Right(b)
+
+    /**
+     * Applies fnL if this is a Left or fnR if this is a Right.
+     * @see Left
+     * @see Right
+     */
+    fun <T> fold(fnL: (L) -> T?, fnR: (R) -> T?): T? =
+        when (this) {
+            is Left -> fnL(a)
+            is Right -> fnR(b)
+        }
+}
+
+/**
+ * Composes 2 functions
+ * See <a href="https://proandroiddev.com/kotlins-nothing-type-946de7d464fb">Credits to Alex Hart.</a>
+ */
+fun <A, B, C> ((A) -> B).c(f: (B) -> C): (A) -> C = {
+    f(this(it))
+}
+
+/**
+ * Right-biased flatMap() FP convention which means that Right is assumed to be the default case
+ * to operate on. If it is Left, operations like map, flatMap, ... return the Left value unchanged.
+ */
+fun <T, L, R> Either<L, R>.flatMap(fn: (R) -> Either<L, T>): Either<L, T> =
+    when (this) {
+        is Either.Left -> Either.Left(a)
+        is Either.Right -> fn(b)
+    }
+
+/**
+ * Left-biased onFailure() FP convention dictates that when this class is Left, it'll perform
+ * the onFailure functionality passed as a parameter, but, overall will still return an either
+ * object so you chain calls.
+ */
+fun <L, R> Either<L, R>.onFailure(fn: (failure: L) -> Unit): Either<L, R> =
+    this.apply { if (this is Either.Left) fn(a) }
+
+/**
+ * Right-biased onSuccess() FP convention dictates that when this class is Right, it'll perform
+ * the onSuccess functionality passed as a parameter, but, overall will still return an either
+ * object so you chain calls.
+ */
+fun <L, R> Either<L, R>.onSuccess(fn: (success: R) -> Unit): Either<L, R> =
+    this.apply { if (this is Either.Right) fn(b) }
+
+/**
+ * Right-biased map() FP convention which means that Right is assumed to be the default case
+ * to operate on. If it is Left, operations like map, flatMap, ... return the Left value unchanged.
+ */
+fun <T, L, R> Either<L, R>.map(fn: (R) -> (T)): Either<L, T> = this.flatMap(fn.c(::right))
+
+/**
+ * Returns the value from this `Right` or the given argument if this is a `Left`.
+ *  Right(12).getOrElse(17) RETURNS 12 and Left(12).getOrElse(17) RETURNS 17
+ */
+fun <L, R> Either<L, R>.getOrElse(value: R): R =
+    when (this) {
+        is Either.Left -> value
+        is Either.Right -> b
+    }

--- a/app/src/main/kotlin/com/wire/android/core/functional/Either.kt
+++ b/app/src/main/kotlin/com/wire/android/core/functional/Either.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2019 Fernando Cejas Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.wire.android.core.functional
 
 /**
@@ -94,7 +109,7 @@ fun <T, L, R> Either<L, R>.map(fn: (R) -> (T)): Either<L, T> = this.flatMap(fn.c
 
 /**
  * Returns the value from this `Right` or the given argument if this is a `Left`.
- *  Right(12).getOrElse(17) RETURNS 12 and Left(12).getOrElse(17) RETURNS 17
+ * Right(12).getOrElse(17) RETURNS 12 and Left(12).getOrElse(17) RETURNS 17
  */
 fun <L, R> Either<L, R>.getOrElse(value: R): R =
     when (this) {

--- a/app/src/main/kotlin/com/wire/android/core/usecase/UseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/core/usecase/UseCase.kt
@@ -1,0 +1,8 @@
+package com.wire.android.core.usecase
+
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.functional.Either
+
+interface UseCase<out Type, in Params> {
+    suspend fun run(params: Params): Either<Failure, Type>
+}

--- a/app/src/main/kotlin/com/wire/android/core/usecase/UseCaseExecutor.kt
+++ b/app/src/main/kotlin/com/wire/android/core/usecase/UseCaseExecutor.kt
@@ -1,0 +1,29 @@
+package com.wire.android.core.usecase
+
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.functional.Either
+import kotlinx.coroutines.*
+
+interface UseCaseExecutor {
+    operator fun <T, P> UseCase<T, P>.invoke(
+        scope: CoroutineScope,
+        params: P,
+        dispatcher: CoroutineDispatcher = Dispatchers.IO,
+        onResult: (Either<Failure, T>) -> Unit = {}
+    )
+}
+
+class DefaultUseCaseExecutor : UseCaseExecutor {
+
+    override operator fun <T, P> UseCase<T, P>.invoke(
+        scope: CoroutineScope,
+        params: P,
+        dispatcher: CoroutineDispatcher,
+        onResult: (Either<Failure, T>) -> Unit
+    ) {
+        val backgroundJob = scope.async(dispatcher) { run(params) }
+        scope.launch {
+            onResult(backgroundJob.await())
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/di/RegistrationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/di/RegistrationModule.kt
@@ -1,10 +1,12 @@
 package com.wire.android.feature.auth.registration.di
 
 import com.wire.android.feature.auth.registration.personal.email.CreatePersonalAccountEmailViewModel
+import com.wire.android.shared.user.email.ValidateEmailUseCase
 import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
 val registrationModule: Module = module {
-    viewModel { CreatePersonalAccountEmailViewModel() }
+    viewModel { CreatePersonalAccountEmailViewModel(get()) }
+    factory { ValidateEmailUseCase() }
 }

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/CreatePersonalAccountFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/CreatePersonalAccountFragment.kt
@@ -20,10 +20,7 @@ class CreatePersonalAccountFragment : Fragment(R.layout.fragment_create_personal
             getString(R.string.authentication_tab_layout_title_email),
             getString(R.string.authentication_tab_layout_title_phone)
         )
-        createPersonalAccountViewPager.adapter = CreatePersonalAccountViewPagerAdapter(
-            childFragmentManager,
-            titles
-        )
+        createPersonalAccountViewPager.adapter = CreatePersonalAccountViewPagerAdapter(childFragmentManager, titles)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailFragment.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailFragment.kt
@@ -9,9 +9,7 @@ import com.wire.android.R
 import kotlinx.android.synthetic.main.fragment_create_personal_account_email.*
 import org.koin.android.viewmodel.ext.android.viewModel
 
-class CreatePersonalAccountEmailFragment : Fragment(
-    R.layout.fragment_create_personal_account_email
-) {
+class CreatePersonalAccountEmailFragment : Fragment(R.layout.fragment_create_personal_account_email) {
 
     //TODO Add loading status
     private val emailViewModel: CreatePersonalAccountEmailViewModel by viewModel()

--- a/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModel.kt
@@ -3,21 +3,35 @@ package com.wire.android.feature.auth.registration.personal.email
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.usecase.DefaultUseCaseExecutor
+import com.wire.android.core.usecase.UseCaseExecutor
+import com.wire.android.shared.user.email.ValidateEmailError
+import com.wire.android.shared.user.email.ValidateEmailParams
+import com.wire.android.shared.user.email.ValidateEmailUseCase
+import kotlinx.coroutines.Dispatchers
 
 //TODO: add use cases & layers below
-class CreatePersonalAccountEmailViewModel : ViewModel() {
+class CreatePersonalAccountEmailViewModel(
+    private val validateEmailUseCase: ValidateEmailUseCase
+) : ViewModel(), UseCaseExecutor by DefaultUseCaseExecutor() {
 
     private val _isValidEmailLiveData = MutableLiveData<Boolean>()
 
     val isValidEmailLiveData: LiveData<Boolean> = _isValidEmailLiveData
 
     fun validateEmail(email: String) {
-//        validateEmailUseCase(viewModelScope, ValidateEmailParams(email), Dispatchers.Default) {
-//            it.fold(::validateEmailFailure) { updateEmailValidationStatus(true) }
-//        }
-        updateEmailValidationStatus(email.length > 3) //dummy check
+        validateEmailUseCase(viewModelScope, ValidateEmailParams(email), Dispatchers.Default) {
+            it.fold(::validateEmailFailure) { updateEmailValidationStatus(true) }
+        }
     }
 
+    private fun validateEmailFailure(failure: Failure) {
+        if (failure is ValidateEmailError) {
+            updateEmailValidationStatus(false)
+        }
+    }
 
     private fun updateEmailValidationStatus(status: Boolean) {
         _isValidEmailLiveData.value = status

--- a/app/src/main/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCase.kt
@@ -1,0 +1,32 @@
+package com.wire.android.shared.user.email
+
+import androidx.core.util.PatternsCompat
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.exception.FeatureFailure
+import com.wire.android.core.functional.Either
+import com.wire.android.core.usecase.UseCase
+import java.util.regex.Pattern
+
+sealed class ValidateEmailError : FeatureFailure()
+object EmailTooShort : ValidateEmailError()
+object EmailInvalid : ValidateEmailError()
+
+class ValidateEmailUseCase : UseCase<Unit, ValidateEmailParams> {
+
+    override suspend fun run(params: ValidateEmailParams): Either<Failure, Unit> = when {
+        !emailCharactersValid(params.email) -> Either.Left(EmailInvalid)
+        isEmailTooShort(params.email) -> Either.Left(EmailTooShort)
+        else -> Either.Right(Unit)
+    }
+
+    private fun emailCharactersValid(email: String) =
+        PatternsCompat.EMAIL_ADDRESS.matcher(email).matches()
+
+    private fun isEmailTooShort(email: String) = email.length < EMAIL_MIN_LENGTH
+
+    companion object {
+        private const val EMAIL_MIN_LENGTH = 5
+    }
+}
+
+data class ValidateEmailParams(val email: String)

--- a/app/src/test/kotlin/com/wire/android/MockitoKotlin.kt
+++ b/app/src/test/kotlin/com/wire/android/MockitoKotlin.kt
@@ -1,0 +1,24 @@
+package com.wire.android
+
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito
+
+/**
+ * Returns Mockito.eq() as nullable type to avoid java.lang.IllegalStateException when
+ * null is returned.
+ *
+ * Generic T is nullable because implicitly bounded by Any?.
+ */
+fun <T> eq(obj: T): T = Mockito.eq<T>(obj)
+
+/**
+ * Returns Mockito.any() as nullable type to avoid java.lang.IllegalStateException when
+ * null is returned.
+ */
+fun <T> any(): T = Mockito.any<T>()
+
+/**
+ * Returns ArgumentCaptor.capture() as nullable type to avoid java.lang.IllegalStateException
+ * when null is returned.
+ */
+fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()

--- a/app/src/test/kotlin/com/wire/android/core/usecase/DefaultUseCaseExecutorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/usecase/DefaultUseCaseExecutorTest.kt
@@ -1,0 +1,42 @@
+package com.wire.android.core.usecase
+
+import com.wire.android.UnitTest
+import com.wire.android.core.functional.Either
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+@ExperimentalCoroutinesApi
+class DefaultUseCaseExecutorTest : UnitTest() {
+
+    private lateinit var executor: DefaultUseCaseExecutor
+
+    @Mock
+    private lateinit var useCase: UseCase<String, Int>
+
+    @Before
+    fun setUp() {
+        executor = DefaultUseCaseExecutor()
+    }
+
+    @Test
+    fun `given a scope and a use case, when invoke is called on use case, then applies onResult to returned value`() {
+        runBlockingTest {
+            val param = 3
+            val result = Either.Right("3")
+            `when`(useCase.run(param)).thenReturn(result)
+
+            with(executor) {
+                useCase.invoke(this@runBlockingTest, param, Dispatchers.IO) {
+                    assertThat(it).isEqualTo(result)
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/CreatePersonalAccountViewPagerAdapterTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/CreatePersonalAccountViewPagerAdapterTest.kt
@@ -26,7 +26,7 @@ class CreatePersonalAccountViewPagerAdapterTest : UnitTest() {
     @Test
     fun `given getCount() is called, then return the size of the adapter`() {
         `when`(titles.size).thenReturn(TEST_SIZE)
-        assertThat(TEST_SIZE).isEqualTo(createPersonalAccountViewPagerAdapter.count)
+        assertThat(createPersonalAccountViewPagerAdapter.count).isEqualTo(TEST_SIZE)
     }
 
     @Test
@@ -35,8 +35,8 @@ class CreatePersonalAccountViewPagerAdapterTest : UnitTest() {
         `when`(titles[1]).thenReturn(TEST_TITLE_PHONE)
 
         with(createPersonalAccountViewPagerAdapter) {
-            assertThat(TEST_TITLE_EMAIL.toUpperCase()).isEqualTo(getPageTitle(0))
-            assertThat(TEST_TITLE_PHONE.toUpperCase()).isEqualTo(getPageTitle(1))
+            assertThat(getPageTitle(0)).isEqualTo(TEST_TITLE_EMAIL.toUpperCase())
+            assertThat(getPageTitle(1)).isEqualTo(TEST_TITLE_PHONE.toUpperCase())
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/auth/registration/personal/email/CreatePersonalAccountEmailViewModelTest.kt
@@ -1,0 +1,66 @@
+package com.wire.android.feature.auth.registration.personal.email
+
+import com.wire.android.UnitTest
+import com.wire.android.any
+import com.wire.android.core.functional.Either
+import com.wire.android.framework.livedata.awaitValue
+import com.wire.android.shared.user.email.EmailInvalid
+import com.wire.android.shared.user.email.EmailTooShort
+import com.wire.android.shared.user.email.ValidateEmailUseCase
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+class CreatePersonalAccountEmailViewModelTest: UnitTest() {
+
+    private lateinit var emailViewModel: CreatePersonalAccountEmailViewModel
+
+    @Mock
+    private lateinit var validateEmailUseCase: ValidateEmailUseCase
+
+    @Before
+    fun setUp() {
+        emailViewModel = CreatePersonalAccountEmailViewModel(validateEmailUseCase)
+    }
+
+    @Test
+    fun `given validateEmail is called, when the validation succeeds then isValidEmail should be true`() {
+        runBlocking {
+            `when`(validateEmailUseCase.run(any())).thenReturn(Either.Right(Unit))
+
+            emailViewModel.validateEmail(TEST_EMAIL)
+
+            assertThat(emailViewModel.isValidEmailLiveData.awaitValue())
+        }
+    }
+
+    @Test
+    fun `given validateEmail is called, when the validation fails with EmailTooShort error then isValidEmail should be false`() {
+        runBlocking {
+            `when`(validateEmailUseCase.run(any())).thenReturn(Either.Left(EmailTooShort))
+
+            emailViewModel.validateEmail(TEST_EMAIL)
+
+            assertThat(emailViewModel.isValidEmailLiveData.awaitValue()).isFalse
+        }
+    }
+
+    @Test
+    fun `given validateEmail is called, when the validation fails with EmailInvalid error then isValidEmail should be false`() {
+        runBlocking {
+            `when`(validateEmailUseCase.run(any())).thenReturn(Either.Left(EmailInvalid))
+
+            emailViewModel.validateEmail(TEST_EMAIL)
+
+            assertThat(emailViewModel.isValidEmailLiveData.awaitValue()).isFalse
+        }
+    }
+
+    companion object {
+        private const val TEST_EMAIL = "test@wire.com"
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/framework/livedata/Observers.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/livedata/Observers.kt
@@ -1,0 +1,47 @@
+package com.wire.android.framework.livedata
+
+import androidx.lifecycle.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * A function that suspends the current coroutine until the LiveData's value changes. Then it
+ * resumes the coroutine with the new value.
+ *
+ * @throws TimeoutException if the value of LiveData is not updated within [timeout] seconds.
+ */
+suspend fun <T> LiveData<T>.awaitValue(timeout: Long = 2L): T = suspendCoroutine { cont ->
+    val latch = CountDownLatch(1)
+
+    val observer = OneTimeObserver<T> {
+        latch.countDown()
+        cont.resume(it)
+    }
+    this.observe(observer, observer)
+
+    if (!latch.await(timeout, TimeUnit.SECONDS)) {
+        cont.resumeWithException(
+            TimeoutException("Didn't receive LiveData value after $timeout seconds")
+        )
+    }
+}
+
+
+private class OneTimeObserver<T>(private val handler: (T) -> Unit) : Observer<T>, LifecycleOwner {
+    private val lifecycle = LifecycleRegistry(this)
+
+    init {
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+    }
+
+    override fun getLifecycle(): Lifecycle = lifecycle
+
+    override fun onChanged(t: T) {
+        handler(t)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCaseTest.kt
@@ -1,16 +1,14 @@
 package com.wire.android.shared.user.email
 
 import com.wire.android.UnitTest
+import com.wire.android.core.functional.Either
 import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runBlockingTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.any
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 @ExperimentalCoroutinesApi
 class ValidateEmailUseCaseTest : UnitTest() {
@@ -26,21 +24,21 @@ class ValidateEmailUseCaseTest : UnitTest() {
     }
 
     @Test
-    fun `Given run is executed, when email doesn't match regex, then return failure`() {
+    fun `Given run is executed, when email doesn't match regex, then return EmailInvalid failure`() {
         `when`(validateEmailParams.email).thenReturn("email")
 
         runBlockingTest {
-            assertThat(validationEmailUseCase.run(validateEmailParams).isLeft).isTrue()
+            assertThat(validationEmailUseCase.run(validateEmailParams)).isEqualTo(Either.Left(EmailInvalid))
         }
     }
 
     @Test
-    fun `Given run is executed, when email length is smaller than 5, then return failure`() {
+    fun `Given run is executed, when email length is smaller than 5, then return EmailTooShort failure`() {
         val email = "t"
         `when`(validateEmailParams.email).thenReturn(email)
 
         runBlockingTest {
-            assertThat(validationEmailUseCase.run(validateEmailParams).isLeft).isTrue()
+            assertThat(validationEmailUseCase.run(validateEmailParams)).isEqualTo(Either.Left(EmailTooShort))
         }
     }
 
@@ -49,7 +47,7 @@ class ValidateEmailUseCaseTest : UnitTest() {
         `when`(validateEmailParams.email).thenReturn(VALID_TEST_EMAIL)
 
         runBlockingTest {
-            assertThat(validationEmailUseCase.run(validateEmailParams).isRight).isTrue()
+            assertThat(validationEmailUseCase.run(validateEmailParams)).isEqualTo(Either.Right(Unit))
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/shared/user/email/ValidateEmailUseCaseTest.kt
@@ -1,0 +1,59 @@
+package com.wire.android.shared.user.email
+
+import com.wire.android.UnitTest
+import kotlinx.coroutines.*
+import kotlinx.coroutines.test.runBlockingTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+@ExperimentalCoroutinesApi
+class ValidateEmailUseCaseTest : UnitTest() {
+
+    @Mock
+    private lateinit var validateEmailParams: ValidateEmailParams
+
+    private lateinit var validationEmailUseCase: ValidateEmailUseCase
+
+    @Before
+    fun setup() {
+        validationEmailUseCase = ValidateEmailUseCase()
+    }
+
+    @Test
+    fun `Given run is executed, when email doesn't match regex, then return failure`() {
+        `when`(validateEmailParams.email).thenReturn("email")
+
+        runBlockingTest {
+            assertThat(validationEmailUseCase.run(validateEmailParams).isLeft).isTrue()
+        }
+    }
+
+    @Test
+    fun `Given run is executed, when email length is smaller than 5, then return failure`() {
+        val email = "t"
+        `when`(validateEmailParams.email).thenReturn(email)
+
+        runBlockingTest {
+            assertThat(validationEmailUseCase.run(validateEmailParams).isLeft).isTrue()
+        }
+    }
+
+    @Test
+    fun `Given run is executed, when email matches regex and email fits requirements then return success`() {
+        `when`(validateEmailParams.email).thenReturn(VALID_TEST_EMAIL)
+
+        runBlockingTest {
+            assertThat(validationEmailUseCase.run(validateEmailParams).isRight).isTrue()
+        }
+    }
+
+    companion object {
+        private const val VALID_TEST_EMAIL = "test@wire.com"
+    }
+}

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -21,16 +21,16 @@ object AndroidSdk {
 }
 
 object Libraries {
-    private object Versions {
+    object Versions {
         const val jetpack = "1.1.0"
         const val constraintLayout = "1.1.3"
         const val ktx = "1.3.0"
         const val material = "1.1.0"
         const val koin = "2.1.6"
         const val lifecycleKtx = "2.2.0"
+        const val coroutines = "1.3.7"
     }
 
-    const val kotlinStdLib     = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     const val appCompat        = "androidx.appcompat:appcompat:${Versions.jetpack}"
     const val constraintLayout = "androidx.constraintlayout:constraintlayout:${Versions.constraintLayout}"
     const val ktxCore          = "androidx.core:core-ktx:${Versions.ktx}"
@@ -41,6 +41,12 @@ object Libraries {
     object Koin {
         const val androidCore  = "org.koin:koin-android:${Versions.koin}"
         const val viewModel    = "org.koin:koin-android-viewmodel:${Versions.koin}"
+    }
+
+    object Kotlin {
+        const val stdLib            = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
+        const val coroutinesCore    = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
+        const val coroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
     }
 }
 
@@ -55,7 +61,6 @@ object TestLibraries {
         const val testExtensions = "1.1.1"
         const val testRules = "1.1.0"
         const val uiAutomator = "2.2.0"
-        const val coroutines = "1.3.7"
     }
 
     const val junit4         = "junit:junit:${Versions.junit4}"
@@ -68,7 +73,7 @@ object TestLibraries {
     const val testRules      = "androidx.test:rules:${Versions.testRules}"
     const val mockitoAndroid = "org.mockito:mockito-android:${Versions.mockito}"
     const val uiAutomator    = "androidx.test.uiautomator:uiautomator:${Versions.uiAutomator}"
-    const val coroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"
+    const val coroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Libraries.Versions.coroutines}"
 }
 
 object DevLibraries {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -35,7 +35,8 @@ object Libraries {
     const val constraintLayout = "androidx.constraintlayout:constraintlayout:${Versions.constraintLayout}"
     const val ktxCore          = "androidx.core:core-ktx:${Versions.ktx}"
     const val material         = "com.google.android.material:material:${Versions.material}"
-    const val livedataKtx     = "androidx.lifecycle:lifecycle-livedata-ktx:${Versions.lifecycleKtx}"
+    const val livedataKtx      = "androidx.lifecycle:lifecycle-livedata-ktx:${Versions.lifecycleKtx}"
+    const val viewModelKtx     = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.lifecycleKtx}"
 
     object Koin {
         const val androidCore  = "org.koin:koin-android:${Versions.koin}"
@@ -46,7 +47,7 @@ object Libraries {
 object TestLibraries {
     private object Versions {
         const val junit4 = "4.13"
-        const val mockito = "2.7.22"
+        const val mockito = "3.3.0"
         const val robolectric = "4.3.1"
         const val assertJ = "3.16.1"
         const val testRunner = "1.1.0"
@@ -54,6 +55,7 @@ object TestLibraries {
         const val testExtensions = "1.1.1"
         const val testRules = "1.1.0"
         const val uiAutomator = "2.2.0"
+        const val coroutines = "1.3.7"
     }
 
     const val junit4         = "junit:junit:${Versions.junit4}"
@@ -66,6 +68,7 @@ object TestLibraries {
     const val testRules      = "androidx.test:rules:${Versions.testRules}"
     const val mockitoAndroid = "org.mockito:mockito-android:${Versions.mockito}"
     const val uiAutomator    = "androidx.test.uiautomator:uiautomator:${Versions.uiAutomator}"
+    const val coroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"
 }
 
 object DevLibraries {


### PR DESCRIPTION
Adds validation logic for email
Adds UseCase, Either, Failure
Bumps mockito version to 3.3.0 which has better support for coroutine testing
Fixes unit test assertions to conform to `assertThat(actual).isEqual(expected)` form.