### PR TITLE
WIP: Consider Locale when formatting date and time

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/extension/OffsetDateTime.kt
+++ b/app/src/main/kotlin/com/wire/android/core/extension/OffsetDateTime.kt
@@ -5,6 +5,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.temporal.ChronoUnit
+import java.util.Locale
 import kotlin.math.absoluteValue
 
 fun OffsetDateTime.isSameDay(offsetDateTime: OffsetDateTime): Boolean =
@@ -19,20 +20,17 @@ fun OffsetDateTime.isMoreThanSixtyMinutesApartOf(anotherOffsetDateTime: OffsetDa
 fun OffsetDateTime.isWithinTheLastMinutes(minutes: Long) =
     ChronoUnit.MINUTES.between(this, OffsetDateTime.now()) < minutes
 
-fun OffsetDateTime.timeFromOffsetDateTime(): String {
-    val fmt: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
-    return fmt.format(this)
-}
+fun OffsetDateTime.timeFromOffsetDateTime(): String = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+    .withLocale(Locale.getDefault())
+    .format(this)
 
-//TODO display localized date without year
-fun OffsetDateTime.dateWithoutYear(): String {
-    val fmt: DateTimeFormatter = DateTimeFormatter.ofPattern("EEE, MMM d, HH:mm")
-    return fmt.format(this)
-}
+fun OffsetDateTime.dateWithoutYear(): String = DateTimeFormatter.ofPattern("EEE, MMM d, HH:mm")
+    .withLocale(Locale.getDefault())
+    .format(this)
 
-fun OffsetDateTime.dateWithYear(): String {
-    val fmt: DateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG).withZone(ZoneId.systemDefault())
-    return fmt.format(this)
-}
+fun OffsetDateTime.dateWithYear(): String = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG)
+    .withZone(ZoneId.systemDefault())
+    .withLocale(Locale.getDefault())
+    .format(this)
 
 private const val SIXTY_MINUTES = 60L

--- a/app/src/test/kotlin/com/wire/android/core/extension/OffsetDateTimeExtensionTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/extension/OffsetDateTimeExtensionTest.kt
@@ -5,15 +5,35 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Before
-import org.junit.Test
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
+import java.util.Locale
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
 
 class OffsetDateTimeExtensionTest : UnitTest() {
+
+    companion object {
+        private lateinit var defaultLocale: Locale
+
+        @BeforeClass
+        @JvmStatic
+        fun setupClass() {
+            defaultLocale = Locale.getDefault()
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun resetClass() {
+            Locale.setDefault(defaultLocale)
+        }
+    }
 
     @MockK
     private lateinit var offsetDateTime1: OffsetDateTime
@@ -21,11 +41,18 @@ class OffsetDateTimeExtensionTest : UnitTest() {
     @MockK
     private lateinit var offsetDateTime2: OffsetDateTime
 
-    private val offsetDateTime = OffsetDateTime.of(2021,7,20,10,10,59,10, ZoneOffset.UTC)
+    private val offsetDateTime = OffsetDateTime.of(2021, 7, 20, 10, 10, 59, 10, ZoneOffset.UTC)
 
     @Before
     fun setUp() {
         mockkStatic(OffsetDateTime::class)
+    }
+
+    private fun <T> withLocale(locale: Locale, block: () -> T): T {
+        Locale.setDefault(locale)
+        return block().also {
+            Locale.setDefault(defaultLocale)
+        }
     }
 
     @Test
@@ -117,7 +144,7 @@ class OffsetDateTimeExtensionTest : UnitTest() {
     }
 
     @Test
-    fun `given isMoreThanSixtyMinutes is called, when the amount of time between 2 dates is greater than 60 minutes, then return false`(){
+    fun `given isMoreThanSixtyMinutes is called, when the amount of time between 2 dates is greater than 60 minutes, then return false`() {
         every { offsetDateTime2.until(offsetDateTime1, ChronoUnit.MINUTES) } returns 10L
         every { offsetDateTime1.until(offsetDateTime2, ChronoUnit.MINUTES) } returns 500L
 
@@ -138,7 +165,7 @@ class OffsetDateTimeExtensionTest : UnitTest() {
 
     @Test
     fun `given isWithinTheLastMinutes is called, when the input date is within the last 2 minutes, then return true`() {
-        val date = OffsetDateTime.of(2021,7,20,10,9,59,10, ZoneOffset.UTC)
+        val date = OffsetDateTime.of(2021, 7, 20, 10, 9, 59, 10, ZoneOffset.UTC)
 
         every { OffsetDateTime.now() } returns offsetDateTime
 
@@ -149,7 +176,7 @@ class OffsetDateTimeExtensionTest : UnitTest() {
 
     @Test
     fun `given isWithinTheLastMinutes is called, when the input date is not within the last 2 minutes, then return false`() {
-        val date = OffsetDateTime.of(2021,7,20,10,5,59,10, ZoneOffset.UTC)
+        val date = OffsetDateTime.of(2021, 7, 20, 10, 5, 59, 10, ZoneOffset.UTC)
         every { OffsetDateTime.now() } returns offsetDateTime
 
         val result = date.isWithinTheLastMinutes(2L)
@@ -159,7 +186,7 @@ class OffsetDateTimeExtensionTest : UnitTest() {
 
     @Test
     fun `given isWithinTheLastMinutes is called, when the input date is within the last 60 minutes, then return true`() {
-        val date = OffsetDateTime.of(2021,7,20,9,11,59,10, ZoneOffset.UTC)
+        val date = OffsetDateTime.of(2021, 7, 20, 9, 11, 59, 10, ZoneOffset.UTC)
         every { OffsetDateTime.now() } returns offsetDateTime
 
         val result = date.isWithinTheLastMinutes(60L)
@@ -170,7 +197,7 @@ class OffsetDateTimeExtensionTest : UnitTest() {
 
     @Test
     fun `given isWithinTheLastMinutes is called, when the input date is not within the last 60 minutes, then return false`() {
-        val date = OffsetDateTime.of(2021,7,20,9,10,59,10, ZoneOffset.UTC)
+        val date = OffsetDateTime.of(2021, 7, 20, 9, 10, 59, 10, ZoneOffset.UTC)
         every { OffsetDateTime.now() } returns offsetDateTime
 
         val result = date.isWithinTheLastMinutes(60L)
@@ -179,8 +206,10 @@ class OffsetDateTimeExtensionTest : UnitTest() {
     }
 
     @Test
-    fun `given timeFromOffsetDateTime is called, when offsetDateTime is valid, then return time`() {
-        val result = offsetDateTime.timeFromOffsetDateTime()
+    fun `given an US locale, when getting timeFromOffsetDateTime, then return time with AM~PM`() {
+        val result = withLocale(Locale.US) {
+            offsetDateTime.timeFromOffsetDateTime()
+        }
 
         val expected = "10:10 AM"
         result shouldBeEqualTo expected
@@ -195,10 +224,30 @@ class OffsetDateTimeExtensionTest : UnitTest() {
     }
 
     @Test
-    fun `given dateWithYear is called, when offsetDateTime is valid, then return date with year`() {
-        val result = offsetDateTime.dateWithYear()
+    fun `given English locale and UTC timezone, when getting dateWithYear, then return date with year in UTC and with AM~PM`() {
+        mockkStatic(ZoneId::class) {
+            every { ZoneId.systemDefault() } returns ZoneId.of("UTC")
 
-        val expected = "July 20, 2021 10:10:59 AM UTC"
-        result shouldBeEqualTo expected
+            val result = withLocale(Locale.ENGLISH) {
+                offsetDateTime.dateWithYear()
+            }
+
+            val expected = "July 20, 2021 at 10:10:59 AM UTC"
+            result shouldBeEqualTo expected
+        }
+    }
+
+    @Test
+    fun `given PT-BR locale and BRT timezone, when getting dateWithYear, then return date with year in Portuguese and BRT`() {
+        mockkStatic(ZoneId::class) {
+            every { ZoneId.systemDefault() } returns ZoneId.of("America/Sao_Paulo")
+
+            val result = withLocale(Locale("pt", "br")) {
+                offsetDateTime.dateWithYear()
+            }
+
+            val expected = "20 de julho de 2021 07:10:59 BRT"
+            result shouldBeEqualTo expected
+        }
     }
 }


### PR DESCRIPTION
# Work In Progress

## The problem

Since flying to Brazil some weeks ago, I've been having issues with one test that was asserting `UTC` Timezone and `US` Locale.

My system is currently at `BRT` timezone and the language is in German. So this test was **always** failing.

We should mock/set locale when testing this.

## The solution

I've made sure all of our date formatting functions take the system locale into consideration and added a helping function that executes a block using a given Locale and returns it back to default when testing this.

### The remaining problem

Different JVM have different implementations of localization and date-time formatting.
For the same date and Locale:
On OpenJDK 8 : `20 de Julho de 2021 7h10min59s BRT`
On OpenJDK 11:   `20 de julho de 2021 07:10:59 BRT`

## Observations

Ideally, I think we should have a home-coocked `DateTimeFormatter` that takes a `UserLocaleProvider` as dependency (so we can override system locale based on user preferences). And use this home-coocked `DateTimeFormatter` instead of static functions.