### PR TITLE
CryptoBoxClient Update: QualifiedId and easier utilization without prekeys

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/crypto/CryptoBoxClient.kt
+++ b/app/src/main/kotlin/com/wire/android/core/crypto/CryptoBoxClient.kt
@@ -18,14 +18,18 @@ import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.flatMap
 import com.wire.android.core.functional.map
 import com.wire.android.core.functional.suspending
+import com.wire.android.shared.user.QualifiedId
 import com.wire.cryptobox.CryptoBox
 import com.wire.cryptobox.CryptoException
 import com.wire.cryptobox.CryptoSession
 
+/**
+ * TODO: Improve support for multiple accounts (userIds). Maybe don't use CryptoBoxClient directly, and use CryptoBoxProvider instead.
+ */
 class CryptoBoxClient(
     context: Context,
     private val clientPropertyStorage: CryptoBoxClientPropertyStorage,
-    private val userId: UserId,
+    private val userId: QualifiedId,
     private val cryptoPreKeyMapper: CryptoPreKeyMapper,
     private val exceptionMapper: CryptoExceptionMapper,
     private val cryptoBoxProvider: CryptoBoxProvider
@@ -54,7 +58,7 @@ class CryptoBoxClient(
     fun createInitialPreKeys(): Either<Failure, PreKeyInitialization> = useBox {
         val lastKey = cryptoPreKeyMapper.fromCryptoBoxModel(newLastPreKey())
         val keys = newPreKeys(0, PRE_KEYS_COUNT).map(cryptoPreKeyMapper::fromCryptoBoxModel)
-        clientPropertyStorage.updateLastPreKeyId(userId, keys.last().id)
+        clientPropertyStorage.updateLastPreKeyId(UserId(userId.id), keys.last().id)
         PreKeyInitialization(keys, lastKey)
     }
 

--- a/app/src/main/kotlin/com/wire/android/core/crypto/data/CryptoBoxClientPropertyStorage.kt
+++ b/app/src/main/kotlin/com/wire/android/core/crypto/data/CryptoBoxClientPropertyStorage.kt
@@ -13,11 +13,12 @@ class CryptoBoxClientPropertyStorage(private val context: Context) {
         )
         return prefs.apply()
     }
-
+    //TODO Use QualifiedUserId
     fun updateLastPreKeyId(userId: UserId, preKeyId: Int) = sharedPreferencesForUser(userId) {
         edit().putInt(LAST_PRE_KEY_PREF_ID, preKeyId).apply()
     }
 
+    //TODO Use QualifiedUserId
     fun lastPreKeyId(userId: UserId): Int? = sharedPreferencesForUser(userId) {
         getInt(LAST_PRE_KEY_PREF_ID, Int.MIN_VALUE)
             .takeUnless { it == Int.MIN_VALUE }

--- a/app/src/main/kotlin/com/wire/android/core/crypto/model/CryptoSessionId.kt
+++ b/app/src/main/kotlin/com/wire/android/core/crypto/model/CryptoSessionId.kt
@@ -1,5 +1,7 @@
 package com.wire.android.core.crypto.model
 
-data class CryptoSessionId(val userId: UserId, val cryptoClientId: CryptoClientId) {
+import com.wire.android.shared.user.QualifiedId
+
+data class CryptoSessionId(val userId: QualifiedId, val cryptoClientId: CryptoClientId) {
     val value: String = "${userId}_${cryptoClientId}"
 }

--- a/app/src/main/kotlin/com/wire/android/core/crypto/model/CryptoSessionId.kt
+++ b/app/src/main/kotlin/com/wire/android/core/crypto/model/CryptoSessionId.kt
@@ -3,5 +3,6 @@ package com.wire.android.core.crypto.model
 import com.wire.android.shared.user.QualifiedId
 
 data class CryptoSessionId(val userId: QualifiedId, val cryptoClientId: CryptoClientId) {
-    val value: String = "${userId}_${cryptoClientId}"
+    //TODO Take domain into consideration here too
+    val value: String = "${userId.id}_${cryptoClientId}"
 }

--- a/app/src/main/kotlin/com/wire/android/core/di/Modules.kt
+++ b/app/src/main/kotlin/com/wire/android/core/di/Modules.kt
@@ -16,7 +16,6 @@ import com.wire.android.core.crypto.DefaultCryptoBoxProvider
 import com.wire.android.core.crypto.data.CryptoBoxClientPropertyStorage
 import com.wire.android.core.crypto.mapper.CryptoExceptionMapper
 import com.wire.android.core.crypto.mapper.CryptoPreKeyMapper
-import com.wire.android.core.crypto.model.UserId
 import com.wire.android.core.date.DateStringMapper
 import com.wire.android.core.io.FileSystem
 import com.wire.android.core.logger.Logger
@@ -28,6 +27,7 @@ import com.wire.android.core.ui.navigation.UriNavigationHandler
 import com.wire.android.core.ui.recyclerview.ViewHolderInflater
 import com.wire.android.shared.config.DeviceClassMapper
 import com.wire.android.shared.config.DeviceTypeMapper
+import com.wire.android.shared.user.QualifiedId
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.dsl.module
@@ -82,7 +82,7 @@ val cryptoBoxModule = module {
     factory { CryptoBoxClientPropertyStorage(androidContext()) }
     single<CryptoBoxProvider> { DefaultCryptoBoxProvider }
     //TODO hardcoded UserId should be replaced with real userId value (AR-711)
-    factory { CryptoBoxClient(androidContext(), get(), UserId("dummy-id"), get(), get(), get()) }
+    factory { CryptoBoxClient(androidContext(), get(), QualifiedId("domain", "dummy-id"), get(), get(), get()) }
 }
 
 val dateModule = module {

--- a/app/src/main/kotlin/com/wire/android/core/events/Event.kt
+++ b/app/src/main/kotlin/com/wire/android/core/events/Event.kt
@@ -5,6 +5,7 @@ sealed class Event {
         data class MessageEvent(
             val id: String,
             val conversationId: String,
+            // TODO Use QualifiedUserId
             val senderClientId: String,
             val senderUserId: String,
             val content: String,

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/content/EncryptedMessageEnvelope.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/content/EncryptedMessageEnvelope.kt
@@ -5,6 +5,7 @@ import java.time.OffsetDateTime
 data class EncryptedMessageEnvelope(
     val id: String,
     val conversationId: String,
+    // TODO use Qualified ID
     val senderUserId: String,
     val clientId: String?,
     val content: String,

--- a/app/src/main/kotlin/com/wire/android/feature/conversation/content/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/conversation/content/mapper/MessageMapper.kt
@@ -4,13 +4,13 @@ import com.wire.android.core.crypto.model.CryptoClientId
 import com.wire.android.core.crypto.model.CryptoSessionId
 import com.wire.android.core.crypto.model.EncryptedMessage
 import com.wire.android.core.crypto.model.PlainMessage
-import com.wire.android.core.crypto.model.UserId
 import com.wire.android.core.date.DateStringMapper
 import com.wire.android.core.events.Event
 import com.wire.android.feature.conversation.content.EncryptedMessageEnvelope
 import com.wire.android.feature.conversation.content.Message
 import com.wire.android.feature.conversation.content.Sent
 import com.wire.android.feature.conversation.content.datasources.local.MessageEntity
+import com.wire.android.shared.user.QualifiedId
 
 class MessageMapper(
     private val messageContentMapper: MessageContentMapper,
@@ -71,7 +71,12 @@ class MessageMapper(
         )
 
     fun cryptoSessionFromEncryptedEnvelope(message: EncryptedMessageEnvelope) =
-        CryptoSessionId(UserId(message.senderUserId), CryptoClientId(message.clientId!!))
+        CryptoSessionId(QualifiedId(TEMP_HARDCODED_DOMAIN, message.senderUserId), CryptoClientId(message.clientId!!))
 
     fun encryptedMessageFromDecodedContent(decodedContent: ByteArray) = EncryptedMessage(decodedContent)
+
+    companion object {
+        //TODO Remove hardcoded ID
+        private const val TEMP_HARDCODED_DOMAIN = "domain"
+    }
 }

--- a/app/src/test/kotlin/com/wire/android/core/crypto/CryptoBoxClientTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/crypto/CryptoBoxClientTest.kt
@@ -18,6 +18,7 @@ import com.wire.android.core.exception.UnknownCryptoFailure
 import com.wire.android.core.functional.Either
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
+import com.wire.android.shared.user.QualifiedId
 import com.wire.cryptobox.CryptoBox
 import com.wire.cryptobox.CryptoException
 import com.wire.cryptobox.CryptoSession
@@ -50,7 +51,7 @@ class CryptoBoxClientTest : AndroidTest() {
 
     lateinit var subject: CryptoBoxClient
 
-    private val userId = UserId("abc")
+    private val userId = QualifiedId("domain", "abc")
 
     @Before
     fun setup() {
@@ -117,7 +118,7 @@ class CryptoBoxClientTest : AndroidTest() {
 
         subject.createInitialPreKeys()
 
-        verify(exactly = 1) { propertyStorage.updateLastPreKeyId(userId, lastRegularKey.id) }
+        verify(exactly = 1) { propertyStorage.updateLastPreKeyId(UserId(userId.id), lastRegularKey.id) }
     }
 
     @Test
@@ -302,7 +303,7 @@ class CryptoBoxClientTest : AndroidTest() {
     }
 
     companion object {
-        private val CRYPTO_SESSION_ID = CryptoSessionId(UserId("a"), CryptoClientId("b"))
+        private val CRYPTO_SESSION_ID = CryptoSessionId(QualifiedId("domain", "a"), CryptoClientId("b"))
         private val ENCRYPTED_MESSAGE = EncryptedMessage(byteArrayOf())
         private val PLAIN_MESSAGE = PlainMessage(byteArrayOf())
     }

--- a/app/src/test/kotlin/com/wire/android/feature/conversation/content/mapper/MessageMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/conversation/content/mapper/MessageMapperTest.kt
@@ -11,6 +11,7 @@ import com.wire.android.feature.conversation.content.EncryptedMessageEnvelope
 import com.wire.android.feature.conversation.content.Message
 import com.wire.android.feature.conversation.content.Sent
 import com.wire.android.feature.conversation.content.datasources.local.MessageEntity
+import com.wire.android.shared.user.QualifiedId
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
@@ -142,7 +143,7 @@ class MessageMapperTest : UnitTest() {
     }
 
     @Test
-    fun `given cryptoSessionFromMessage is called, then maps the Message and returns a CryptoSessionId`() {
+    fun `given an EncryptedMessageEnvelope, when mapping to a CryptoSession, then return a CryptoSessionId`() {
         val message = mockk<EncryptedMessageEnvelope>().also {
             every { it.senderUserId } returns TEST_SENDER_USER_ID
             every { it.clientId } returns TEST_SENDER_ID
@@ -153,7 +154,7 @@ class MessageMapperTest : UnitTest() {
 
         result.let {
             it shouldBeInstanceOf CryptoSessionId::class
-            it.userId shouldBeInstanceOf UserId::class
+            it.userId shouldBeInstanceOf QualifiedId::class
             it.cryptoClientId shouldBeInstanceOf CryptoClientId::class
             it.value shouldBeEqualTo expected
         }


### PR DESCRIPTION
# UserId vs QualifiedId

### The problem
`CryptoBoxClient` is using `userId` (String), instead of the new `QualifiedId`. Better to fix this now than re-factor later in the future.

### The fix 
I changed the internals, replacing `userId: String` with `userId: QualifiedId`.
I've also identified some touching points (like when dealing with user-specific `SharedPreferences` and `MessageEvent`, for example) that remain using `userId`, but goes too far out of the scope of this PR.

# Encrypt messages without PreKeys

### The problem
It is currently impossible to make sure a session exists without calling the `assertSession`. And that requires a `PreKey`, something the sender may not have yet, and may not even need, if the session is already established.

### The fix
I renamed `assertSession` to `createSessionIfNeeded` (@gizemb was right, the old name sucks).
I added a function `doesSessionExists` that enables us to easily check if a session already exists. We can fetch PreKeys only if the session doesn't exist. 