### PR TITLE
Refactor: Provide more control over network requests

### DIFF
--- a/app/src/main/kotlin/com/wire/android/core/network/ApiService.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/ApiService.kt
@@ -1,6 +1,17 @@
 package com.wire.android.core.network
 
-import com.wire.android.core.exception.*
+import com.wire.android.core.exception.BadRequest
+import com.wire.android.core.exception.Cancelled
+import com.wire.android.core.exception.Conflict
+import com.wire.android.core.exception.EmptyResponseBody
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.exception.Forbidden
+import com.wire.android.core.exception.InternalServerError
+import com.wire.android.core.exception.NetworkConnection
+import com.wire.android.core.exception.NotFound
+import com.wire.android.core.exception.ServerError
+import com.wire.android.core.exception.TooManyRequests
+import com.wire.android.core.exception.Unauthorized
 import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.suspending
 import kotlinx.coroutines.CancellationException

--- a/app/src/main/kotlin/com/wire/android/core/network/ApiService.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/ApiService.kt
@@ -23,16 +23,12 @@ abstract class ApiService {
     abstract val networkHandler: NetworkHandler
 
     suspend fun <T> rawRequest(
-        onResponseError: (suspend (response: Response<T>) -> Either<Failure, Response<T>>)? = null,
+        onResponseError: (suspend (response: Response<T>) -> Either<Failure, Response<T>>) = { handleRequestError(it) },
         call: suspend () -> Response<T>
     ): Either<Failure, Response<T>> = suspending {
         performRequest(call).flatMap { response ->
-            if (response.isSuccessful) {
-                Either.Right(response)
-            } else {
-                onResponseError?.invoke(response)
-                    ?: handleRequestError(response)
-            }
+            if (response.isSuccessful) Either.Right(response)
+            else onResponseError.invoke(response)
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/core/network/ApiService.kt
+++ b/app/src/main/kotlin/com/wire/android/core/network/ApiService.kt
@@ -1,19 +1,8 @@
 package com.wire.android.core.network
 
-import com.wire.android.core.exception.BadRequest
-import com.wire.android.core.exception.Cancelled
-import com.wire.android.core.exception.Conflict
-import com.wire.android.core.exception.EmptyResponseBody
-import com.wire.android.core.exception.Failure
-import com.wire.android.core.exception.Forbidden
-import com.wire.android.core.exception.InternalServerError
-import com.wire.android.core.exception.NetworkConnection
-import com.wire.android.core.exception.NotFound
-import com.wire.android.core.exception.ServerError
-import com.wire.android.core.exception.TooManyRequests
-import com.wire.android.core.exception.Unauthorized
+import com.wire.android.core.exception.*
 import com.wire.android.core.functional.Either
-import com.wire.android.core.functional.flatMap
+import com.wire.android.core.functional.suspending
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -22,29 +11,42 @@ import retrofit2.Response
 abstract class ApiService {
     abstract val networkHandler: NetworkHandler
 
-    suspend fun <T> rawRequest(call: suspend () -> Response<T>): Either<Failure, Response<T>> =
-        withContext(Dispatchers.IO) {
-            return@withContext when (networkHandler.isConnected()) {
-                true -> performRequest(call)
-                false -> Either.Left(NetworkConnection)
-            }
-        }
-
-    suspend fun <T> request(default: T? = null, call: suspend () -> Response<T>): Either<Failure, T> =
-        rawRequest(call).flatMap { response ->
-            response.body()?.let { Either.Right(it) }
-                ?: default?.let { Either.Right(it) }
-                ?: Either.Left(EmptyResponseBody)
-        }
-
-    @Suppress("TooGenericExceptionCaught")
-    private suspend fun <T> performRequest(call: suspend () -> Response<T>): Either<Failure, Response<T>> {
-        return try {
-            val response = call()
+    suspend fun <T> rawRequest(
+        onResponseError: (suspend (response: Response<T>) -> Either<Failure, Response<T>>)? = null,
+        call: suspend () -> Response<T>
+    ): Either<Failure, Response<T>> = suspending {
+        performRequest(call).flatMap { response ->
             if (response.isSuccessful) {
                 Either.Right(response)
             } else {
+                onResponseError?.invoke(response)
+                    ?: handleRequestError(response)
+            }
+        }
+    }
+
+    suspend fun <T> request(
+        handleEmptyBody: (suspend (response: Response<T>) -> Either<Failure, T>)? = null,
+        call: suspend () -> Response<T>
+    ): Either<Failure, T> = suspending {
+        performRequest(call).flatMap { response ->
+            if (response.isSuccessful) {
+                response.body()?.let { Either.Right(it) }
+                    ?: handleEmptyBody?.invoke(response)
+                    ?: Either.Left(EmptyResponseBody)
+            } else {
                 handleRequestError(response)
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun <T> performRequest(call: suspend () -> Response<T>): Either<Failure, Response<T>> = withContext(Dispatchers.IO) {
+        try {
+            if (!networkHandler.isConnected()) {
+                Either.Left(NetworkConnection)
+            } else {
+                Either.Right(call())
             }
         } catch (exception: Throwable) {
             when (exception) {
@@ -54,7 +56,7 @@ abstract class ApiService {
         }
     }
 
-    private fun <T> handleRequestError(response: Response<T>): Either<Failure, Response<T>> =
+    private fun <T> handleRequestError(response: Response<T>): Either.Left<Failure> =
         Either.Left(buildFailure(response.code()))
 
     private fun buildFailure(errorCode: Int): Failure =

--- a/app/src/test/kotlin/com/wire/android/core/network/ApiServiceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/network/ApiServiceTest.kt
@@ -1,7 +1,16 @@
 package com.wire.android.core.network
 
 import com.wire.android.UnitTest
-import com.wire.android.core.exception.*
+import com.wire.android.core.exception.BadRequest
+import com.wire.android.core.exception.EmptyResponseBody
+import com.wire.android.core.exception.Failure
+import com.wire.android.core.exception.Forbidden
+import com.wire.android.core.exception.InternalServerError
+import com.wire.android.core.exception.NetworkConnection
+import com.wire.android.core.exception.NotFound
+import com.wire.android.core.exception.ServerError
+import com.wire.android.core.exception.TooManyRequests
+import com.wire.android.core.exception.Unauthorized
 import com.wire.android.core.functional.Either
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
@@ -59,7 +68,12 @@ class ApiServiceTest : UnitTest() {
         every { response.isSuccessful } returns true
         every { response.body() } returns TEST_BODY
 
-        val result = runBlocking { apiService.request(handleEmptyBody = TEST_ON_REQUEST_FAILURE, call = ::testCall) }
+        val result = runBlocking {
+            apiService.request(
+                handleEmptyBody = TEST_ON_REQUEST_FAILURE,
+                call = ::testCall
+            )
+        }
 
         result shouldSucceed { it shouldBe TEST_BODY }
     }
@@ -69,7 +83,12 @@ class ApiServiceTest : UnitTest() {
         every { response.isSuccessful } returns true
         every { response.body() } returns null
 
-        val result = runBlocking { apiService.request(handleEmptyBody = TEST_ON_REQUEST_FAILURE, call = ::testCall) }
+        val result = runBlocking {
+            apiService.request(
+                handleEmptyBody = TEST_ON_REQUEST_FAILURE,
+                call = ::testCall
+            )
+        }
 
         result shouldSucceed { it shouldBe TEST_DEFAULT_RESULT }
     }

--- a/app/src/test/kotlin/com/wire/android/core/network/ApiServiceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/core/network/ApiServiceTest.kt
@@ -1,16 +1,8 @@
 package com.wire.android.core.network
 
 import com.wire.android.UnitTest
-import com.wire.android.core.exception.BadRequest
-import com.wire.android.core.exception.EmptyResponseBody
-import com.wire.android.core.exception.Failure
-import com.wire.android.core.exception.Forbidden
-import com.wire.android.core.exception.InternalServerError
-import com.wire.android.core.exception.NetworkConnection
-import com.wire.android.core.exception.NotFound
-import com.wire.android.core.exception.ServerError
-import com.wire.android.core.exception.TooManyRequests
-import com.wire.android.core.exception.Unauthorized
+import com.wire.android.core.exception.*
+import com.wire.android.core.functional.Either
 import com.wire.android.framework.functional.shouldFail
 import com.wire.android.framework.functional.shouldSucceed
 import io.mockk.Called
@@ -43,88 +35,88 @@ class ApiServiceTest : UnitTest() {
     }
 
     @Test
-    fun `given rawRequest is called, when there's no network connection, then returns NetworkConnection failure immediately`() {
+    fun `given there's no network connection, when rawRequest is called, then returns NetworkConnection failure immediately`() {
         val responseFunc: suspend () -> Response<String> = mockk(relaxed = true)
         every { networkHandler.isConnected() } returns false
 
-        val result = runBlocking { apiService.rawRequest(responseFunc) }
+        val result = runBlocking { apiService.rawRequest { responseFunc() } }
 
         verify { responseFunc wasNot Called }
         result shouldFail { it shouldBe NetworkConnection }
     }
 
     @Test
-    fun `given rawRequest is called, when response is successful, then returns the response`() {
+    fun `given response is successful, when safeRawRequest is called, then returns the response`() {
         every { response.isSuccessful } returns true
 
-        val result = runBlocking { apiService.rawRequest(::testCall) }
+        val result = runBlocking { apiService.rawRequest { testCall() } }
 
         result shouldSucceed { it shouldBe response }
     }
 
     @Test
-    fun `given request is called with a default value, when response is successful and has a body, then returns the body`() {
+    fun `given response is successful and has a body, when request is called with a default value, then returns the body`() {
         every { response.isSuccessful } returns true
         every { response.body() } returns TEST_BODY
 
-        val result = runBlocking { apiService.request(default = TEST_DEFAULT_ARGUMENT, call = ::testCall) }
+        val result = runBlocking { apiService.request(handleEmptyBody = TEST_ON_REQUEST_FAILURE, call = ::testCall) }
 
         result shouldSucceed { it shouldBe TEST_BODY }
     }
 
     @Test
-    fun `given request is called with a default value, when response is successful but has no body, then returns default value`() {
+    fun `given response is successful but has no body, when request is called with a default value, then returns default value`() {
         every { response.isSuccessful } returns true
         every { response.body() } returns null
 
-        val result = runBlocking { apiService.request(default = TEST_DEFAULT_ARGUMENT, call = ::testCall) }
+        val result = runBlocking { apiService.request(handleEmptyBody = TEST_ON_REQUEST_FAILURE, call = ::testCall) }
 
-        result shouldSucceed { it shouldBe TEST_DEFAULT_ARGUMENT }
+        result shouldSucceed { it shouldBe TEST_DEFAULT_RESULT }
     }
 
     @Test
-    fun `given request is called without default value, when response successful but has no body, then returns EmptyResponseBody error`() {
+    fun `given response successful but has no body, when request is called without default value, then returns EmptyResponseBody error`() {
         every { response.isSuccessful } returns true
         every { response.body() } returns null
 
-        val result = runBlocking { apiService.request(default = null, call = ::testCall) }
+        val result = runBlocking { apiService.request(handleEmptyBody = null, call = ::testCall) }
 
         result shouldFail { it shouldBe EmptyResponseBody }
     }
 
     @Test
-    fun `given rawRequest is called, when call fails with http 400 error, then returns BadRequest failure`() =
+    fun `given call fails with http 400 error, when rawRequest is called, then returns BadRequest failure`() =
         shouldTriggerHttpError(400, BadRequest)
 
     @Test
-    fun `given rawRequest is called, when call fails with http 401 error, then returns Unauthorized failure`() =
+    fun `given call fails with http 401 error, when rawRequest is called, then returns Unauthorized failure`() =
         shouldTriggerHttpError(401, Unauthorized)
 
     @Test
-    fun `given rawRequest is called, when call fails with http 403 error, then returns Forbidden failure`() =
+    fun `given call fails with http 403 error, when rawRequest is called, then returns Forbidden failure`() =
         shouldTriggerHttpError(403, Forbidden)
 
     @Test
-    fun `given rawRequest is called, when call fails with http 404 error, then returns NotFound failure`() =
+    fun `given call fails with http 404 error, when rawRequest is called, then returns NotFound failure`() =
         shouldTriggerHttpError(404, NotFound)
 
     @Test
-    fun `given rawRequest is called, when call fails with http 429 error, then returns TooManyRequests failure`() =
+    fun `given call fails with http 429 error, when rawRequest is called, then returns TooManyRequests failure`() =
         shouldTriggerHttpError(429, TooManyRequests)
 
     @Test
-    fun `given rawRequest is called, when call fails with http 500 error, then returns InternalServerError failure`() =
+    fun `given call fails with http 500 error, when rawRequest is called, then returns InternalServerError failure`() =
         shouldTriggerHttpError(500, InternalServerError)
 
     @Test
-    fun `given rawRequest is called, when call fails with any other error, then returns ServerError failure`() =
+    fun `given call fails with any other error, when rawRequest is called, then returns ServerError failure`() =
         shouldTriggerHttpError(-1, ServerError)
 
     private fun shouldTriggerHttpError(httpErrorCode: Int, failure: Failure) {
         every { response.isSuccessful } returns false
         every { response.code() } returns httpErrorCode
 
-        val result = runBlocking { apiService.rawRequest(::testCall) }
+        val result = runBlocking { apiService.rawRequest { testCall() } }
 
         result shouldFail { it shouldBe failure }
     }
@@ -132,7 +124,8 @@ class ApiServiceTest : UnitTest() {
     private suspend fun testCall(): Response<String> = response
 
     companion object {
-        private const val TEST_DEFAULT_ARGUMENT = "default"
+        private const val TEST_DEFAULT_RESULT = "default"
+        private val TEST_ON_REQUEST_FAILURE: suspend (Response<String>) -> Either<Failure, String> = { Either.Right(TEST_DEFAULT_RESULT) }
         private const val TEST_BODY = """ { "email": "test@wire.com" } """
     }
 }

--- a/app/src/test/kotlin/com/wire/android/feature/messaging/datasource/remote/MessageRemoteDataSourceTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/messaging/datasource/remote/MessageRemoteDataSourceTest.kt
@@ -35,10 +35,10 @@ class MessageRemoteDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given sendMessage was called, when calling api sendMessage, then the mapper result should be passed as parameter`() {
+    fun `given the mapper result, when calling sendMessage, then the mapper result should be passed as parameter`() {
         val mappedValue: Otr.NewOtrMessage = mockk()
         every { otrNewMessageMapper.fromMessageEnvelope(any()) } returns mappedValue
-        coEvery { messageApi.sendMessage(any(), any()) } returns mockk()
+        coEvery { messageApi.sendMessage(any(), any()) } returns mockNetworkResponse()
 
         runBlocking { subject.sendMessage(any(), any()) }
 
@@ -46,10 +46,10 @@ class MessageRemoteDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given sendMessage was called, when calling api sendMessage, then conversationId should be forwarded as parameter`() {
+    fun `given a conversationId, when calling sendMessage, then conversationId should be forwarded as parameter`() {
         val conversationId = "Conversation-ID"
         every { otrNewMessageMapper.fromMessageEnvelope(any()) } returns mockk()
-        coEvery { messageApi.sendMessage(any(), any()) } returns mockk()
+        coEvery { messageApi.sendMessage(any(), any()) } returns mockNetworkResponse()
 
         runBlocking { subject.sendMessage(conversationId, any()) }
 
@@ -57,7 +57,7 @@ class MessageRemoteDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given sendMessage was called, when api sendMessage succeeds, then the success is returned`() {
+    fun `given api sendMessage succeeds, when calling sendMessage, then the success is returned`() {
         every { otrNewMessageMapper.fromMessageEnvelope(any()) } returns mockk()
         coEvery { messageApi.sendMessage(any(), any()) } returns mockNetworkResponse()
 
@@ -66,7 +66,7 @@ class MessageRemoteDataSourceTest : UnitTest() {
     }
 
     @Test
-    fun `given sendMessage was called, when api sendMessage fails, then the failure is returned`() {
+    fun `given api sendMessage fails, when calling sendMessage, then the failure is returned`() {
         every { otrNewMessageMapper.fromMessageEnvelope(any()) } returns mockk()
         coEvery { messageApi.sendMessage(any(), any()) } returns mockNetworkError()
 


### PR DESCRIPTION
## Current Issues

1. The method `rawRequest` is currently very far from "raw", as it calls `performRequest` internally, handling all the HTTP errors and does not allow us to intercept the HTTP result at all.
It is only "raw" when the request succeeds, returning the response.

2. The `default` argument in the method `request` is too strong.
Maybe I just want a different `default` depending on the error `response`?

## Solution

Change `performRequest` to do the bare minimal: check with `NetworkHandler` for connection and perform the request. Handle possible network exceptions.

Simplify `rawRequest` and add an option for it to take a different  `onResponseError` lambda, which allows us to intercept the request on error as well. By default, it goes with the default behaviour of analysing the HTTP Code and mapping to it to a `Failure`.

Replace `default` argument in `request` for a lambda that enables us to inspect the result before returning anything.