### PR TITLE
Add a way to fetch PreKeys of users without qualified id

### DIFF
--- a/app/src/main/kotlin/com/wire/android/shared/prekey/data/QualifiedUserPreKeyInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/prekey/data/QualifiedUserPreKeyInfo.kt
@@ -1,0 +1,14 @@
+package com.wire.android.shared.prekey.data
+
+import com.wire.android.core.crypto.model.PreKey
+import com.wire.android.shared.user.QualifiedId
+
+data class QualifiedUserPreKeyInfo(val userId: QualifiedId, val clientsInfo: List<ClientPreKeyInfo>)
+
+@Deprecated(
+        "This data structure does not consider domain, needed for Federation",
+        ReplaceWith("QualifiedUserPreKeyInfo")
+)
+data class UserPreKeyInfo(val userId: String, val clientsInfo: List<ClientPreKeyInfo>)
+
+data class ClientPreKeyInfo(val clientId: String, val preKey: PreKey)

--- a/app/src/main/kotlin/com/wire/android/shared/prekey/data/UserPreKeyInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/prekey/data/UserPreKeyInfo.kt
@@ -1,8 +1,0 @@
-package com.wire.android.shared.prekey.data
-
-import com.wire.android.core.crypto.model.PreKey
-import com.wire.android.shared.user.QualifiedId
-
-data class UserPreKeyInfo(val userId: QualifiedId, val clientsInfo: List<ClientPreKeyInfo>)
-
-data class ClientPreKeyInfo(val clientId: String, val preKey: PreKey)

--- a/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/PreKeyAPI.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/PreKeyAPI.kt
@@ -5,10 +5,18 @@ import retrofit2.http.POST
 
 interface PreKeyAPI {
 
-    @POST(LIST_PRE_KEYS_ENDPOINT)
-    suspend fun preKeysByClientsOfUsers(preKeyListParameter: Map<String, Map<String, List<String>>>): Response<PreKeyListResponse>
+    @POST(LIST_PRE_KEYS_QUALIFIED_ENDPOINT)
+    suspend fun preKeysByClientsOfQualifiedUsers(preKeyListParameter: Map<String, Map<String, List<String>>>): Response<QualifiedPreKeyListResponse>
 
-    companion object{
-        const val LIST_PRE_KEYS_ENDPOINT = "/users/list-prekeys"
+    @Deprecated(
+        "This endpoint does not consider domain, needed for Federation",
+        ReplaceWith("preKeysByClientsOfQualifiedUsers")
+    )
+    @POST(LIST_PRE_KEYS_ENDPOINT)
+    suspend fun preKeysByClientsOfUsers(preKeyListParameter: Map<String, List<String>>): Response<PreKeyListResponse>
+
+    companion object {
+        const val LIST_PRE_KEYS_QUALIFIED_ENDPOINT = "/users/list-prekeys"
+        const val LIST_PRE_KEYS_ENDPOINT = "/users/prekeys"
     }
 }

--- a/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/PreKeyRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/PreKeyRemoteDataSource.kt
@@ -5,22 +5,32 @@ import com.wire.android.core.functional.Either
 import com.wire.android.core.functional.map
 import com.wire.android.core.network.ApiService
 import com.wire.android.core.network.NetworkHandler
+import com.wire.android.shared.prekey.data.QualifiedUserPreKeyInfo
 import com.wire.android.shared.prekey.data.UserPreKeyInfo
 import com.wire.android.shared.user.QualifiedId
 
 class PreKeyRemoteDataSource(
-    override val networkHandler: NetworkHandler,
-    private val preKeyAPI: PreKeyAPI,
-    private val remotePreKeyListMapper: RemotePreKeyListMapper
+        override val networkHandler: NetworkHandler,
+        private val preKeyAPI: PreKeyAPI,
+        private val remotePreKeyListMapper: RemotePreKeyListMapper
 ) : ApiService() {
 
-    suspend fun preKeysForMultipleUsers(qualifiedIdMap: Map<QualifiedId, List<String>>): Either<Failure, List<UserPreKeyInfo>> =
-        request {
-            val mapOfIds = qualifiedIdMap
-                .mapValues { entry -> mapOf(entry.key.id to entry.value) }
-                .mapKeys { entry -> entry.key.domain }
+    suspend fun preKeysForMultipleQualifiedUsers(qualifiedIdMap: Map<QualifiedId, List<String>>): Either<Failure, List<QualifiedUserPreKeyInfo>> =
+            request {
+                val mapOfIds = qualifiedIdMap
+                        .mapValues { entry -> mapOf(entry.key.id to entry.value) }
+                        .mapKeys { entry -> entry.key.domain }
 
-            preKeyAPI.preKeysByClientsOfUsers(mapOfIds)
-        }.map(remotePreKeyListMapper::fromRemotePreKeyInfoMap)
+                preKeyAPI.preKeysByClientsOfQualifiedUsers(mapOfIds)
+            }.map(remotePreKeyListMapper::fromRemoteQualifiedPreKeyInfoMap)
+
+    @Deprecated(
+            "This function does not consider domain, needed for Federation",
+            ReplaceWith("preKeysForMultipleQualifiedUsers")
+    )
+    suspend fun preKeysForMultipleUsers(idMap: Map<String, List<String>>): Either<Failure, List<UserPreKeyInfo>> =
+            request {
+                preKeyAPI.preKeysByClientsOfUsers(idMap)
+            }.map(remotePreKeyListMapper::fromRemotePreKeyInfoMap)
 
 }

--- a/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/PreKeyResponse.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/PreKeyResponse.kt
@@ -2,7 +2,13 @@ package com.wire.android.shared.prekey.data.remote
 
 import com.google.gson.annotations.SerializedName
 
-typealias PreKeyListResponse = Map<String, Map<String, Map<String, PreKeyResponse>>>
+typealias QualifiedPreKeyListResponse = Map<String, Map<String, Map<String, PreKeyResponse>>>
+
+@Deprecated(
+        "This data structure does not consider domain, needed for Federation",
+        ReplaceWith("QualifiedPreKeyListResponse")
+)
+typealias PreKeyListResponse = Map<String, Map<String, PreKeyResponse>>
 
 data class PreKeyResponse(
     @SerializedName("key")

--- a/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/RemotePreKeyListMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/shared/prekey/data/remote/RemotePreKeyListMapper.kt
@@ -1,23 +1,32 @@
 package com.wire.android.shared.prekey.data.remote
 
 import com.wire.android.shared.prekey.data.ClientPreKeyInfo
+import com.wire.android.shared.prekey.data.QualifiedUserPreKeyInfo
 import com.wire.android.shared.prekey.data.UserPreKeyInfo
 import com.wire.android.shared.user.QualifiedId
 
 class RemotePreKeyListMapper(private val remotePreKeyMapper: RemotePreKeyMapper) {
 
-    fun fromRemotePreKeyInfoMap(preKeyListResponse: PreKeyListResponse): List<UserPreKeyInfo> {
-        return preKeyListResponse.entries.flatMap { domainEntry ->
-            domainEntry.value.mapKeys { userEntry ->
-                QualifiedId(domainEntry.key, userEntry.key)
-            }.mapValues { userEntry ->
-                userEntry.value.mapValues { clientEntry ->
-                    remotePreKeyMapper.fromRemoteResponse(clientEntry.value)
+    fun fromRemoteQualifiedPreKeyInfoMap(qualifiedPreKeyListResponse: QualifiedPreKeyListResponse): List<QualifiedUserPreKeyInfo> =
+            qualifiedPreKeyListResponse.entries.flatMap { domainEntry ->
+                domainEntry.value.mapKeys { userEntry ->
+                    QualifiedId(domainEntry.key, userEntry.key)
+                }.mapValues { userEntry ->
+                    userEntry.value.mapValues { clientEntry ->
+                        remotePreKeyMapper.fromRemoteResponse(clientEntry.value)
+                    }
+                }.map { entry ->
+                    val clientsInfo = entry.value.map { clientEntry -> ClientPreKeyInfo(clientEntry.key, clientEntry.value) }
+                    QualifiedUserPreKeyInfo(entry.key, clientsInfo)
                 }
-            }.map { entry ->
-                val clientsInfo = entry.value.map { clientEntry -> ClientPreKeyInfo(clientEntry.key, clientEntry.value) }
-                UserPreKeyInfo(entry.key, clientsInfo)
             }
-        }
-    }
+
+    fun fromRemotePreKeyInfoMap(preKeyListResponse: PreKeyListResponse): List<UserPreKeyInfo> =
+            preKeyListResponse.entries.map { userEntry ->
+                val clientsInfo = userEntry.value.entries.map { clientEntry ->
+                    val preKey = remotePreKeyMapper.fromRemoteResponse(clientEntry.value)
+                    ClientPreKeyInfo(clientEntry.key, preKey)
+                }
+                UserPreKeyInfo(userEntry.key, clientsInfo)
+            }
 }

--- a/app/src/test/kotlin/com/wire/android/shared/prekey/data/remote/RemotePrekeyListMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/shared/prekey/data/remote/RemotePrekeyListMapperTest.kt
@@ -25,36 +25,147 @@ class RemotePrekeyListMapperTest : UnitTest() {
     }
 
     @Test
-    fun `given a PreKeyMap, when mapping to a list of UserPreKeyInfo, the users IDs should be converted correctly`() {
+    fun `given a PreKeyMap, when mapping to a list of QualifiedUserPreKeyInfo, the users IDs should be converted correctly`() {
         val preKeyResponse = mapOf(
-            "domA" to mapOf(
-                "userA" to mapOf("clientA" to PreKeyResponse("keyA", 1)),
-                "userB" to mapOf("clientB" to PreKeyResponse("key", 32))
-            ),
-            "domB" to mapOf(
-                "userB" to mapOf("clientB" to PreKeyResponse("keyC", 18))
-            )
+                "domA" to mapOf(
+                        "userA" to mapOf("clientA" to PreKeyResponse("keyA", 1)),
+                        "userB" to mapOf("clientB" to PreKeyResponse("key", 32))
+                ),
+                "domB" to mapOf(
+                        "userB" to mapOf("clientB" to PreKeyResponse("keyC", 18))
+                )
         )
 
-        val result = subject.fromRemotePreKeyInfoMap(preKeyResponse)
+        val result = subject.fromRemoteQualifiedPreKeyInfoMap(preKeyResponse)
 
         result.size shouldBeEqualTo 3
         result.map { it.userId } shouldContainSame listOf(
-            QualifiedId("domA", "userA"),
-            QualifiedId("domA", "userB"),
-            QualifiedId("domB", "userB")
+                QualifiedId("domA", "userA"),
+                QualifiedId("domA", "userB"),
+                QualifiedId("domB", "userB")
         )
     }
 
     @Test
-    fun `given a PreKeyMap, when mapping to a list of UserPreKeyInfo, the PreKeyMapper should be used`() {
+    fun `given a PreKeyMap, when mapping to a list of QualifiedUserPreKeyInfo, the PreKeyMapper should be used`() {
         val preKeyResponse = mapOf(
-            "domA" to mapOf(
-                "userA" to mapOf(
-                    "clientA" to PreKeyResponse("keyA", 1),
-                    "clientB" to PreKeyResponse("keyB", 1)
+                "domA" to mapOf(
+                        "userA" to mapOf(
+                                "clientA" to PreKeyResponse("keyA", 1),
+                                "clientB" to PreKeyResponse("keyB", 1)
+                        )
                 )
-            )
+        )
+        every { prekeyMapper.fromRemoteResponse(any()) } returns PreKey(2, "2")
+
+        subject.fromRemoteQualifiedPreKeyInfoMap(preKeyResponse)
+
+        verify(exactly = 2) { prekeyMapper.fromRemoteResponse(any()) }
+    }
+
+    @Test
+    fun `given a PreKeyMap, when mapping to a list of QualifiedUserPreKeyInfo, the PreKeyMapper should receive the correct arguments`() {
+        val firstKey = PreKeyResponse("keyA", 1)
+        val secondKey = PreKeyResponse("keyB", 4)
+        val preKeyResponse = mapOf(
+                "domA" to mapOf(
+                        "userA" to mapOf(
+                                "clientA" to firstKey,
+                                "clientB" to secondKey
+                        )
+                )
+        )
+        every { prekeyMapper.fromRemoteResponse(any()) } returns PreKey(2, "2")
+
+        subject.fromRemoteQualifiedPreKeyInfoMap(preKeyResponse)
+
+        verify(exactly = 1) { prekeyMapper.fromRemoteResponse(firstKey) }
+        verify(exactly = 1) { prekeyMapper.fromRemoteResponse(secondKey) }
+    }
+
+
+    @Test
+    fun `given a PreKeyMap, when mapping to a list of QualifiedUserPreKeyInfo, the clients should be returned in the right users`() {
+        val preKeyResponse = mapOf(
+                "domA" to mapOf(
+                        "userA" to mapOf(
+                                "clientA" to PreKeyResponse("keyA", 1),
+                                "clientB" to PreKeyResponse("keyA", 1)
+                        ),
+                        "userB" to mapOf("clientC" to PreKeyResponse("keyA", 1))
+                )
+        )
+
+        val result = subject.fromRemoteQualifiedPreKeyInfoMap(preKeyResponse)
+
+        val clientsA = result.first().clientsInfo.map { it.clientId }
+        clientsA.size shouldBeEqualTo 2
+        clientsA shouldContainSame listOf("clientA", "clientB")
+
+        val clientsB = result.second().clientsInfo.map { it.clientId }
+        clientsB.size shouldBeEqualTo 1
+        clientsB shouldContainSame listOf("clientC")
+    }
+
+    @Test
+    fun `given a PreKeyMap, when mapping to a list of QualifiedUserPreKeyInfo, the keys should be returned in the right clients`() {
+        class KeyMappingTestSet(val clientId: String, val response: PreKeyResponse, val mapped: PreKey)
+
+        val firstKeySet = KeyMappingTestSet("a", PreKeyResponse("keyA", 1), PreKey(1, "keyA"))
+        val secondKeySet = KeyMappingTestSet("b", PreKeyResponse("keyB", 4), PreKey(4, "keyB"))
+        val thirdKeySet = KeyMappingTestSet("c", PreKeyResponse("keyC", 4), PreKey(4, "keyC"))
+
+        val preKeyResponse = mapOf(
+                "domA" to mapOf(
+                        "userA" to mapOf(
+                                firstKeySet.clientId to firstKeySet.response,
+                                secondKeySet.clientId to secondKeySet.response
+                        ),
+                        "userB" to mapOf(thirdKeySet.clientId to thirdKeySet.response)
+                )
+        )
+
+        every { prekeyMapper.fromRemoteResponse(firstKeySet.response) } returns firstKeySet.mapped
+        every { prekeyMapper.fromRemoteResponse(secondKeySet.response) } returns secondKeySet.mapped
+        every { prekeyMapper.fromRemoteResponse(thirdKeySet.response) } returns thirdKeySet.mapped
+
+        val result = subject.fromRemoteQualifiedPreKeyInfoMap(preKeyResponse)
+
+        val userAInfo = result.first().clientsInfo
+        val firstClient = userAInfo.first()
+        firstClient.clientId shouldBeEqualTo firstKeySet.clientId
+        firstClient.preKey shouldBeEqualTo firstKeySet.mapped
+
+        val secondClient = userAInfo.second()
+
+        secondClient.clientId shouldBeEqualTo secondKeySet.clientId
+        secondClient.preKey shouldBeEqualTo secondKeySet.mapped
+
+        val thirdClient = result.second().clientsInfo.first()
+        thirdClient.clientId shouldBeEqualTo thirdKeySet.clientId
+        thirdClient.preKey shouldBeEqualTo thirdKeySet.mapped
+    }
+
+
+    @Test
+    fun `given an unqualified PreKeyMap, when mapping to a list of UserPreKeyInfo, the users IDs should be converted correctly`() {
+        val preKeyResponse = mapOf(
+                "userA" to mapOf("clientA" to PreKeyResponse("keyA", 1)),
+                "userB" to mapOf("clientB" to PreKeyResponse("key", 32))
+        )
+
+        val result = subject.fromRemotePreKeyInfoMap(preKeyResponse)
+
+        result.size shouldBeEqualTo 2
+        result.map { it.userId } shouldContainSame listOf("userA", "userB")
+    }
+
+    @Test
+    fun `given an unqualified PreKeyMap, when mapping to a list of UserPreKeyInfo, the PreKeyMapper should be used`() {
+        val preKeyResponse = mapOf(
+                "userA" to mapOf(
+                        "clientA" to PreKeyResponse("keyA", 1),
+                        "clientB" to PreKeyResponse("keyB", 1))
         )
         every { prekeyMapper.fromRemoteResponse(any()) } returns PreKey(2, "2")
 
@@ -64,16 +175,14 @@ class RemotePrekeyListMapperTest : UnitTest() {
     }
 
     @Test
-    fun `given a PreKeyMap, when mapping to a list of UserPreKeyInfo, the PreKeyMapper should receive the correct arguments`() {
+    fun `given an unqualified PreKeyMap, when mapping to a list of UserPreKeyInfo, the PreKeyMapper should receive the correct arguments`() {
         val firstKey = PreKeyResponse("keyA", 1)
         val secondKey = PreKeyResponse("keyB", 4)
         val preKeyResponse = mapOf(
-            "domA" to mapOf(
                 "userA" to mapOf(
-                    "clientA" to firstKey,
-                    "clientB" to secondKey
+                        "clientA" to firstKey,
+                        "clientB" to secondKey
                 )
-            )
         )
         every { prekeyMapper.fromRemoteResponse(any()) } returns PreKey(2, "2")
 
@@ -84,37 +193,13 @@ class RemotePrekeyListMapperTest : UnitTest() {
     }
 
     @Test
-    fun `given a PreKeyMap, when mapping to a list of UserPreKeyInfo, the user IDs should be converted correctly`() {
+    fun `given an unqualified PreKeyMap, when mapping to a list of UserPreKeyInfo, the clients should be returned in the right users`() {
         val preKeyResponse = mapOf(
-            "domA" to mapOf(
-                "userA" to mapOf("clientA" to PreKeyResponse("keyA", 1)),
-                "userB" to mapOf("clientB" to PreKeyResponse("key", 32))
-            ),
-            "domB" to mapOf(
-                "userB" to mapOf("clientB" to PreKeyResponse("keyC", 18))
-            )
-        )
-
-        val result = subject.fromRemotePreKeyInfoMap(preKeyResponse)
-
-        result.size shouldBeEqualTo 3
-        result.map { it.userId } shouldContainSame listOf(
-            QualifiedId("domA", "userA"),
-            QualifiedId("domA", "userB"),
-            QualifiedId("domB", "userB")
-        )
-    }
-
-    @Test
-    fun `given a PreKeyMap, when mapping to a list of UserPreKeyInfo, the clients should be returned in the right users`() {
-        val preKeyResponse = mapOf(
-            "domA" to mapOf(
                 "userA" to mapOf(
-                    "clientA" to PreKeyResponse("keyA", 1),
-                    "clientB" to PreKeyResponse("keyA", 1)
+                        "clientA" to PreKeyResponse("keyA", 1),
+                        "clientB" to PreKeyResponse("keyA", 1)
                 ),
                 "userB" to mapOf("clientC" to PreKeyResponse("keyA", 1))
-            )
         )
 
         val result = subject.fromRemotePreKeyInfoMap(preKeyResponse)
@@ -129,7 +214,7 @@ class RemotePrekeyListMapperTest : UnitTest() {
     }
 
     @Test
-    fun `given a PreKeyMap, when mapping to a list of UserPreKeyInfo, the keys should be returned in the right clients`() {
+    fun `given an unqualified PreKeyMap, when mapping to a list of UserPreKeyInfo, the keys should be returned in the right clients`() {
         class KeyMappingTestSet(val clientId: String, val response: PreKeyResponse, val mapped: PreKey)
 
         val firstKeySet = KeyMappingTestSet("a", PreKeyResponse("keyA", 1), PreKey(1, "keyA"))
@@ -137,13 +222,11 @@ class RemotePrekeyListMapperTest : UnitTest() {
         val thirdKeySet = KeyMappingTestSet("c", PreKeyResponse("keyC", 4), PreKey(4, "keyC"))
 
         val preKeyResponse = mapOf(
-            "domA" to mapOf(
                 "userA" to mapOf(
-                    firstKeySet.clientId to firstKeySet.response,
-                    secondKeySet.clientId to secondKeySet.response
+                        firstKeySet.clientId to firstKeySet.response,
+                        secondKeySet.clientId to secondKeySet.response
                 ),
                 "userB" to mapOf(thirdKeySet.clientId to thirdKeySet.response)
-            )
         )
 
         every { prekeyMapper.fromRemoteResponse(firstKeySet.response) } returns firstKeySet.mapped


### PR DESCRIPTION
In order to avoid refactoring a lot of the core of the aplication and put the exchanging of messages to proof, I'm adding support to fetching PreKeys without qualified ID.

By using the deprecated endpoints that don't understand the concept of domain, we maintain compatibility to what's currently implemented.

The federation-ready implementation was done in #240, and as it will be useful in the future I left it in.

