### PR TITLE
Chore: Display version code in version name

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,7 +22,7 @@ android {
         minSdkVersion(AndroidSdk.min)
         targetSdkVersion(AndroidSdk.target)
         versionCode = AndroidClient.versionCode
-        versionName = AndroidClient.versionName
+        versionName = "v${AndroidClient.versionName}(${versionCode})"
         testInstrumentationRunner = AndroidClient.testRunner
         setProperty("archivesBaseName", "${applicationId}-v${versionName}(${versionCode})")
 


### PR DESCRIPTION
We are now displaying the version code in the version name so we can distinguish between different builds