### PR TITLE
ci: update docker agent file to use jdk11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -322,6 +322,7 @@ pipeline {
       }
     }
   }
+
   environment {
     propertiesFile = 'local.properties'
     flavor = defineFlavor()
@@ -332,6 +333,7 @@ pipeline {
     runAcceptanceTests = true
     runUnitTests = true
     runStaticCodeAnalysis = true
+    ENABLE_SIGNING = true
   }
 
   post {

--- a/docker-agent/AndroidAgent
+++ b/docker-agent/AndroidAgent
@@ -1,4 +1,4 @@
-FROM openjdk:8
+FROM openjdk:11
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
@@ -39,10 +39,24 @@ RUN mkdir /home/${USER}/android-ndk-tmp && \
     cd ${ANDROID_NDK_HOME} && \
     rm -rf /home/${USER}/android-ndk-tmp
 
+# Download latest cmdline-tools to fix the sdkmanager jdk11 incompatibilities
+RUN mkdir /home/${USER}/cmdline-tools-tmp && \
+    cd /home/${USER}/cmdline-tools-tmp && \
+    wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip && \
+# uncompress
+    unzip commandlinetools-linux-7583922_latest.zip && \
+# hackytrick as google is stupid
+    mkdir /home/${USER}/android-sdk/cmdline-tools/ && \
+# now copy the cmdlone-tools folder as the actual tools folder
+    mv cmdline-tools /home/${USER}/android-sdk/cmdline-tools/tools && \
+# remove the temp folder
+    cd /home/${USER} && \
+    rm -rf /home/${USER}/cmdline-tools-tmp
+
 # Set environment variable
 ENV ANDROID_HOME /home/${USER}/android-sdk
 ENV ANDROID_SDK=${ANDROID_HOME}
-ENV PATH ${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${ANDROID_HOME}/tools/bin:$ANDROID_NDK_HOME:$PATH
+ENV PATH ${ANDROID_HOME}/cmdline-tools/tools:${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/emulator:${ANDROID_HOME}/cmdline-tools/tools/bin:$ANDROID_NDK_HOME:$PATH
 
 #define the values to install/setup via the sdk manager
 ARG BUILD_TOOLS_VERSION=30.0.2
@@ -50,7 +64,10 @@ ARG PLATFORMS_VERSION=android-29
 ARG ARCHITECTURE=x86
 
 # Make license agreement
-RUN yes | $ANDROID_HOME/tools/bin/sdkmanager --licenses
+RUN yes | $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager --licenses
 
 # Update and install using sdkmanager
-RUN $ANDROID_HOME/tools/bin/sdkmanager "tools" "platform-tools" "build-tools;${BUILD_TOOLS_VERSION}" "platforms;${PLATFORMS_VERSION}" "system-images;${PLATFORMS_VERSION};default;${ARCHITECTURE}" "extras;android;m2repository" "extras;google;m2repository"
+RUN $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager "tools" "platform-tools" "build-tools;${BUILD_TOOLS_VERSION}" "platforms;${PLATFORMS_VERSION}" "system-images;${PLATFORMS_VERSION};default;${ARCHITECTURE}" "extras;android;m2repository" "extras;google;m2repository"
+
+# uncomment if you need to run the docker image standalone for testing purpose
+#CMD tail -f /dev/null


### PR DESCRIPTION
update the docker agent for wire android reloaded to use jdk11 container instead of jdk8