### PR TITLE
feat: add custom text field with proper styling [AR-863]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     implementation(Libraries.composeUi)
     implementation(Libraries.composeMaterial)
     implementation(Libraries.composeTooling)
+    implementation(Libraries.composeIcons)
     implementation(Libraries.composeActivity)
     implementation(Libraries.composeNavigation)
     implementation(Libraries.accompanistPager)

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -48,19 +48,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.wire.android.R
 
-sealed class WireTextFieldState {
-    object Default : WireTextFieldState()
-    data class Error(val errorText: String) : WireTextFieldState()
-    object Success : WireTextFieldState()
-    object Disabled : WireTextFieldState()
-
-    fun icon(): ImageVector? = when (this) {
-        is Error -> Icons.Filled.ErrorOutline
-        is Success -> Icons.Filled.Check
-        else -> null
-    }
-}
-
 @Composable
 internal fun WireTextField(
     value: TextFieldValue,
@@ -284,4 +271,17 @@ fun WireTextFieldSuccessPreview() {
         state = WireTextFieldState.Success,
         modifier = Modifier.padding(16.dp)
     )
+}
+
+sealed class WireTextFieldState {
+    object Default : WireTextFieldState()
+    data class Error(val errorText: String) : WireTextFieldState()
+    object Success : WireTextFieldState()
+    object Disabled : WireTextFieldState()
+
+    fun icon(): ImageVector? = when (this) {
+        is Error -> Icons.Filled.ErrorOutline
+        is Success -> Icons.Filled.Check
+        else -> null
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -1,0 +1,287 @@
+package com.wire.android.ui.common.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.wire.android.R
+
+sealed class WireTextFieldState {
+    object Default : WireTextFieldState()
+    data class Error(val errorText: String) : WireTextFieldState()
+    object Success : WireTextFieldState()
+    object Disabled : WireTextFieldState()
+
+    fun icon(): ImageVector? = when (this) {
+        is Error -> Icons.Filled.ErrorOutline
+        is Success -> Icons.Filled.Check
+        else -> null
+    }
+}
+
+@Composable
+internal fun WireTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    readOnly: Boolean = false,
+    singleLine: Boolean = true,
+    maxLines: Int = 1,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions(),
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    placeholderText: String? = null,
+    labelText: String? = null,
+    labelMandatoryIcon: Boolean = false,
+    descriptionText: String? = null,
+    state: WireTextFieldState = WireTextFieldState.Default,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    textStyle: TextStyle = LocalTextStyle.current.copy(fontSize = 14.sp, textAlign = TextAlign.Start),
+    inputMinHeight: Dp = 48.dp,
+    shape: Shape = RoundedCornerShape(16.dp),
+    colors: WireTextFieldColors = wireTextFieldColors(),
+    modifier: Modifier = Modifier
+) {
+    val enabled = state !is WireTextFieldState.Disabled
+
+    Column(modifier = modifier) {
+        if (labelText != null)
+            Label(labelText, labelMandatoryIcon, state, interactionSource, colors)
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = textStyle,
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            maxLines = maxLines,
+            readOnly = readOnly,
+            enabled = enabled,
+            cursorBrush = SolidColor(MaterialTheme.colors.primary),
+            visualTransformation = visualTransformation,
+            interactionSource = interactionSource,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = colors.backgroundColor(state).value, shape = shape)
+                .border(width = 1.dp, color = colors.borderColor(state, interactionSource).value, shape = shape),
+            decorationBox = { innerTextField ->
+                InnerText(innerTextField, value, leadingIcon, trailingIcon, placeholderText, state, textStyle, inputMinHeight)
+            },
+        )
+        val bottomText = when {
+            state is WireTextFieldState.Error -> state.errorText
+            !descriptionText.isNullOrEmpty() -> descriptionText
+            else -> null
+        }
+        if (bottomText != null)
+            Text(
+                text = bottomText,
+                fontSize = MaterialTheme.typography.caption.fontSize,
+                color = colors.descriptionColor(state).value,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+    }
+}
+
+@Composable
+private fun Label(
+    labelText: String,
+    labelMandatoryIcon: Boolean,
+    state: WireTextFieldState,
+    interactionSource: InteractionSource,
+    colors: WireTextFieldColors
+) {
+    Row {
+        Text(
+            text = labelText,
+            style = MaterialTheme.typography.caption,
+            color = colors.labelColor(state, interactionSource).value,
+            modifier = Modifier.padding(bottom = 4.dp, end = 4.dp)
+        )
+        if (labelMandatoryIcon)
+            Icon(
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_input_mandatory),
+                tint = colors.labelMandatoryColor(state).value,
+                contentDescription = "",
+                modifier = Modifier.padding(top = 2.dp)
+            )
+    }
+}
+
+@Composable
+private fun InnerText(
+    innerTextField: @Composable () -> Unit,
+    value: TextFieldValue,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    placeholderText: String? = null,
+    state: WireTextFieldState = WireTextFieldState.Default,
+    textStyle: TextStyle = LocalTextStyle.current.copy(fontSize = 14.sp, textAlign = TextAlign.Start),
+    inputMinHeight: Dp = 48.dp,
+    colors: WireTextFieldColors = wireTextFieldColors()
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.heightIn(min = inputMinHeight)
+    ) {
+
+        val trailingOrStateIcon: @Composable (() -> Unit)? = when {
+            trailingIcon != null -> trailingIcon
+            else -> state.icon()?.Icon()
+        }
+        if (leadingIcon != null)
+            Box(contentAlignment = Alignment.Center) {
+                Tint(contentColor = colors.iconColor(state).value, content = leadingIcon)
+            }
+        Box(Modifier.weight(1f)) {
+            val padding = Modifier.padding(
+                start = if(leadingIcon == null) 16.dp else 0.dp,
+                end = if(trailingOrStateIcon == null) 16.dp else 0.dp,
+                top = 2.dp, bottom = 2.dp
+            )
+            if (value.text.isEmpty() && placeholderText != null)
+                Text(
+                    text = placeholderText,
+                    fontSize = textStyle.fontSize,
+                    textAlign = textStyle.textAlign,
+                    color = colors.placeholderColor(state).value,
+                    modifier = Modifier.fillMaxWidth().then(padding)
+                )
+            Box(
+                modifier = Modifier.fillMaxWidth().then(padding),
+                propagateMinConstraints = true
+            ) {
+                innerTextField()
+            }
+        }
+        if (trailingOrStateIcon != null)
+            Box(contentAlignment = Alignment.Center) {
+                Tint(contentColor = colors.iconColor(state).value, content = trailingOrStateIcon)
+            }
+    }
+}
+
+@Composable
+private fun ImageVector.Icon(): @Composable (() -> Unit) =
+    { Icon(imageVector = this, contentDescription = "", modifier = Modifier.padding(horizontal = 16.dp)) }
+
+@Composable
+private fun Tint(contentColor: Color, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalContentColor provides contentColor) {
+        CompositionLocalProvider(LocalContentAlpha provides contentColor.alpha, content = content)
+    }
+}
+
+@Preview(name = "Default WireTextField")
+@Composable
+fun WireTextFieldPreview() {
+    WireTextField(
+        value = TextFieldValue("text"),
+        onValueChange = {},
+        modifier = Modifier.padding(16.dp)
+    )
+}
+
+@Preview(name = "Default WireTextField with labels")
+@Composable
+fun WireTextFieldLabelsPreview() {
+    WireTextField(
+        value = TextFieldValue("text"),
+        labelText = "label",
+        labelMandatoryIcon = true,
+        descriptionText = "description",
+        onValueChange = {},
+        modifier = Modifier.padding(16.dp)
+    )
+}
+
+@Preview(name = "Dense Search WireTextField")
+@Composable
+fun WireTextFieldDenseSearchPreview() {
+    WireTextField(
+        value = TextFieldValue(""),
+        placeholderText = "Search",
+        leadingIcon = { IconButton(modifier = Modifier.height(40.dp), onClick = {}) { Icon(Icons.Filled.Search,"") } },
+        trailingIcon = { IconButton(modifier = Modifier.height(40.dp), onClick = {}) { Icon(Icons.Filled.Close,"") } },
+        onValueChange = {},
+        inputMinHeight = 40.dp,
+        textStyle = LocalTextStyle.current.copy(fontSize = 14.sp, textAlign = TextAlign.Center),
+        modifier = Modifier.padding(16.dp)
+    )
+}
+
+@Preview(name = "Disabled WireTextField")
+@Composable
+fun WireTextFieldDisabledPreview() {
+    WireTextField(
+        value = TextFieldValue("text"),
+        onValueChange = {},
+        state = WireTextFieldState.Disabled,
+        modifier = Modifier.padding(16.dp)
+    )
+}
+
+@Preview(name = "Error WireTextField")
+@Composable
+fun WireTextFieldErrorPreview() {
+    WireTextField(
+        value = TextFieldValue("text"),
+        onValueChange = {},
+        state = WireTextFieldState.Error("error"),
+        modifier = Modifier.padding(16.dp)
+    )
+}
+
+@Preview(name = "Success WireTextField")
+@Composable
+fun WireTextFieldSuccessPreview() {
+    WireTextField(
+        value = TextFieldValue("text"),
+        onValueChange = {},
+        state = WireTextFieldState.Success,
+        modifier = Modifier.padding(16.dp)
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextFieldDefaults.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextFieldDefaults.kt
@@ -1,0 +1,128 @@
+package com.wire.android.ui.common.textfield
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun wireTextFieldColors(
+    focusColor: Color = MaterialTheme.colors.primary,
+    errorColor: Color = MaterialTheme.colors.error,
+    successColor: Color = Color.Green, //TODO
+    borderColor: Color = MaterialTheme.colors.onSurface.copy(ContentAlpha.disabled),
+    placeholderColor: Color = MaterialTheme.colors.onSurface.copy(ContentAlpha.medium),
+    textColor: Color = LocalContentColor.current.copy(LocalContentAlpha.current),
+    disabledTextColor: Color = textColor.copy(ContentAlpha.disabled),
+    backgroundColor: Color = Color.White,
+    disabledBackgroundColor: Color = Color.LightGray,
+    labelColor: Color = MaterialTheme.colors.onSurface.copy(ContentAlpha.medium),
+    descriptionColor: Color = MaterialTheme.colors.onSurface.copy(ContentAlpha.medium),
+): WireTextFieldColors {
+    return object : WireTextFieldColors {
+
+        @Composable
+        override fun textColor(state: WireTextFieldState): State<Color> =
+            rememberUpdatedState(if (state is WireTextFieldState.Disabled) disabledTextColor else textColor)
+
+        @Composable
+        override fun backgroundColor(state: WireTextFieldState): State<Color> =
+            rememberUpdatedState(if (state is WireTextFieldState.Disabled) disabledBackgroundColor else backgroundColor)
+
+        @Composable
+        override fun placeholderColor(state: WireTextFieldState): State<Color> = rememberUpdatedState(placeholderColor)
+
+        @Composable
+        override fun labelMandatoryColor(state: WireTextFieldState): State<Color> = rememberUpdatedState(errorColor)
+
+        @Composable
+        override fun descriptionColor(state: WireTextFieldState): State<Color> = rememberUpdatedState(
+            when (state) {
+                is WireTextFieldState.Error -> errorColor
+                else -> descriptionColor
+            }
+        )
+
+        @Composable
+        override fun iconColor(state: WireTextFieldState): State<Color> = rememberUpdatedState(
+            when (state) {
+                WireTextFieldState.Disabled -> disabledTextColor
+                is WireTextFieldState.Error -> errorColor
+                WireTextFieldState.Success -> successColor
+                else -> textColor
+            }
+        )
+
+        @Composable
+        override fun labelColor(state: WireTextFieldState, interactionSource: InteractionSource): State<Color> {
+            val focused by interactionSource.collectIsFocusedAsState()
+            return rememberUpdatedState(
+                when {
+                    state is WireTextFieldState.Error -> errorColor
+                    state is WireTextFieldState.Success -> successColor
+                    focused -> focusColor
+                    else -> labelColor
+                }
+            )
+        }
+
+        @Composable
+        override fun borderColor(state: WireTextFieldState, interactionSource: InteractionSource): State<Color> {
+            val focused by interactionSource.collectIsFocusedAsState()
+            val targetValue = when {
+                state is WireTextFieldState.Error -> errorColor
+                state is WireTextFieldState.Success -> successColor
+                focused -> focusColor
+                else -> borderColor
+            }
+            return if (state !is WireTextFieldState.Disabled) animateColorAsState(targetValue, tween(AnimationDuration))
+            else rememberUpdatedState(targetValue)
+        }
+
+        @Composable
+        override fun cursorColor(state: WireTextFieldState): State<Color> =
+            rememberUpdatedState(if (state is WireTextFieldState.Error) errorColor else focusColor)
+    }
+}
+
+@Stable
+interface WireTextFieldColors {
+    @Composable
+    fun textColor(state: WireTextFieldState): State<Color>
+
+    @Composable
+    fun backgroundColor(state: WireTextFieldState): State<Color>
+
+    @Composable
+    fun placeholderColor(state: WireTextFieldState): State<Color>
+
+    @Composable
+    fun labelColor(state: WireTextFieldState, interactionSource: InteractionSource): State<Color>
+
+    @Composable
+    fun labelMandatoryColor(state: WireTextFieldState): State<Color>
+
+    @Composable
+    fun descriptionColor(state: WireTextFieldState): State<Color>
+
+    @Composable
+    fun iconColor(state: WireTextFieldState): State<Color>
+
+    @Composable
+    fun borderColor(state: WireTextFieldState, interactionSource: InteractionSource): State<Color>
+
+    @Composable
+    fun cursorColor(state: WireTextFieldState): State<Color>
+}
+
+private const val AnimationDuration = 150

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextFieldDefaults.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextFieldDefaults.kt
@@ -85,7 +85,7 @@ fun wireTextFieldColors(
                 focused -> focusColor
                 else -> borderColor
             }
-            return if (state !is WireTextFieldState.Disabled) animateColorAsState(targetValue, tween(AnimationDuration))
+            return if (state !is WireTextFieldState.Disabled) animateColorAsState(targetValue, tween(ANIMATION_DURATION))
             else rememberUpdatedState(targetValue)
         }
 
@@ -125,4 +125,4 @@ interface WireTextFieldColors {
     fun cursorColor(state: WireTextFieldState): State<Color>
 }
 
-private const val AnimationDuration = 150
+private const val ANIMATION_DURATION = 150

--- a/app/src/main/res/drawable/ic_input_mandatory.xml
+++ b/app/src/main/res/drawable/ic_input_mandatory.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="8dp"
+        android:height="8dp"
+        android:viewportWidth="8"
+        android:viewportHeight="8">
+    <path
+            android:pathData="M3.43774,3.02884L3.24877,0H4.74619L4.55721,3.02884L7.08127,1.35048L7.82998,2.64952L5.11694,4L7.82998,5.35048L7.08127,6.64952L4.55721,4.97116L4.74619,8H3.24877L3.43774,4.97116L0.91369,6.64952L0.16498,5.35048L2.87801,4L0.16498,2.64952L0.91369,1.35048L3.43774,3.02884Z"
+            android:fillColor="#C20013"
+            android:fillType="evenOdd"/>
+</vector>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -96,6 +96,7 @@ object Libraries {
     const val composeUi           =  "androidx.compose.ui:ui:${Versions.compose}"
     const val composeMaterial     =  "androidx.compose.material:material:${Versions.compose}"
     const val composeTooling      =  "androidx.compose.ui:ui-tooling:${Versions.compose}"
+    const val composeIcons        = "androidx.compose.material:material-icons-extended:${Versions.compose}"
     const val composeActivity     =  "androidx.activity:activity-compose:${Versions.composeActivity}"
     const val composeNavigation   =  "androidx.navigation:navigation-compose:${Versions.composeNavigation}"
     const val accompanistPager    = "com.google.accompanist:accompanist-pager:${Versions.accompanist}"

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -81,13 +81,14 @@ complexity:
   LongMethod:
     active: true
     threshold: 60
+    ignoreAnnotated: ['Composable']
   LongParameterList:
     active: true
     functionThreshold: 6
     constructorThreshold: 7
     ignoreDefaultParameters: false
     ignoreDataClasses: true
-    ignoreAnnotated: []
+    ignoreAnnotated: ['Composable']
   MethodOverloading:
     active: false
     threshold: 6


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-863" title="AR-863" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-863</a>  Inputs
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Material TextField has a min height bigger than we want (56dp) and the official "dense" version of it isn't yet available so we need a custom one which allows to set a lower height (40dp) and has a border width that matches the design.

### Attachments (Optional)

![device-2022-01-19-192029](https://user-images.githubusercontent.com/30429749/150191787-8c39ea2b-2a66-480f-b0b2-30bc730c6f29.png)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.