### PR TITLE
chore: remove 💩Jcenter💩

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter() //TODO Remove
     }
 }
 
@@ -10,7 +9,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter() //TODO Remove
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@ private object Dependencies {
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
     const val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
     const val junit = "junit:junit:4.13"
-    const val kluent = "org.amshove.kluent:kluent:1.60"
+    const val kluent = "org.amshove.kluent:kluent:1.68"
 }
 
 plugins {
@@ -12,8 +12,8 @@ plugins {
 }
 
 repositories {
-    jcenter()
     google()
+    mavenCentral()
 }
 dependencies {
     implementation(Dependencies.androidBuildTools)

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -147,7 +147,7 @@ object TestLibraries {
         const val androidCore = "1.4.0"
         const val junit4 = "4.13"
         const val mockk = "1.12.0"
-        const val kluent = "1.64"
+        const val kluent = "1.68"
         const val robolectric = "4.5.1"
         const val testRunner = "1.4.0"
         const val espresso = "3.4.0"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

JCenter is being just a big pain in the ass, going down all the time. It was supposed to be "read-only" for an undetermined amount of time, but it is very unreliable.

### Causes (Optional)

It turns out not only we still have it, but it had a higher order than Google's repo. 

### Solutions

Replaced JCenter with MavenCentral for the `buildSrc`, and just remove JCenter overall for the rest of the project.

### Testing

If it build, it works. N/A

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
