### PR TITLE
fix: signing not enabled when publishing builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -337,7 +337,7 @@ pipeline {
     runAcceptanceTests = true
     runUnitTests = true
     runStaticCodeAnalysis = true
-    ENABLE_SIGNING = true
+    ENABLE_SIGNING = "TRUE"
   }
 
   post {

--- a/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
+++ b/buildSrc/src/main/kotlin/scripts/variants.gradle.kts
@@ -25,7 +25,7 @@ object Default {
 }
 
 android {
-    val enableSigning = System.getenv("ENABLE_SIGNING") == "TRUE"
+    val enableSigning = System.getenv("ENABLE_SIGNING").equals("TRUE", true)
     if (enableSigning) {
         signingConfigs {
             maybeCreate(BuildTypes.RELEASE).apply {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When building APK's or App Bundles in our Jenkins machine, the artifacts are not signed.

### Causes (Optional)

Probably casing. Not 100% sure yet. The environment variable is defined as a boolean, and we are reading it and comparing with "TRUE".

### Solutions

Make it a bit more flexible

### Testing

N/A?

#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
