### PR TITLE
chore: make `internal` the default track for publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def defineTrackName() {
         return overwrite
     }
 
-    return 'production'
+    return 'internal'
 }
 
 pipeline {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When publishing the app, we should fallback to `internal` as a safety measure. If we mistype anything in the script and we can't figure out the correct track, it shouldn't publish the app to production.

### Causes (Optional)

`defineTrackName()` in Jenkinsfile was returning `production` by default.

### Solutions

Now it returns `internal` by default

### Testing

N/A


----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
