### PR TITLE
fix: missing sonatype repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
     }
 }
 
@@ -10,6 +11,7 @@ allprojects {
         google()
         mavenCentral()
         maven { url = java.net.URI("https://jitpack.io") }
+        maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the project is not building with the following error

```kotlin
Could not determine the dependencies of task ':app:processDevDebugResources'.
> Could not resolve all task dependencies for configuration ':app:devDebugRuntimeClasspath'.
   > Could not find app.cash.sqldelight:android-driver:2.0.0-SNAPSHOT.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/app/cash/sqldelight/android-driver/2.0.0-SNAPSHOT/maven-metadata.xml
       - https://dl.google.com/dl/android/maven2/app/cash/sqldelight/android-driver/2.0.0-SNAPSHOT/android-driver-2.0.0-SNAPSHOT.pom
       - https://repo.maven.apache.org/maven2/app/cash/sqldelight/android-driver/2.0.0-SNAPSHOT/maven-metadata.xml
       - https://repo.maven.apache.org/maven2/app/cash/sqldelight/android-driver/2.0.0-SNAPSHOT/android-driver-2.0.0-SNAPSHOT.pom
       - https://jitpack.io/app/cash/sqldelight/android-driver/2.0.0-SNAPSHOT/maven-metadata.xml
       - https://jitpack.io/app/cash/sqldelight/android-driver/2.0.0-SNAPSHOT/android-driver-2.0.0-SNAPSHOT.pom
```

### Solutions

add the misisng repo to build.gradle.kts

### Testing

the project is building now

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
