### PR TITLE
chore: refactor login with the new flow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,13 +31,6 @@ android {
         versionName = "v${AndroidClient.versionName}(${versionCode})"
         testInstrumentationRunner = AndroidClient.testRunner
         setProperty("archivesBaseName", "${applicationId}-v${versionName}(${versionCode})")
-        /*
-        kapt {
-            arguments {
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
-        }
-         */
     }
 
     buildFeatures {
@@ -60,17 +53,9 @@ android {
     sourceSets["androidTest"].includeCommonTestSourceDir()
 
     // Remove protobuf-java as dependencies, so we can get protobuf-lite
-    configurations.implementation.configure {
-        exclude(module = "protobuf-java")
-    }
-
-    buildFeatures {
-        compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = Libraries.Versions.compose
-    }
+    //configurations.implementation.configure {
+    //    exclude(module = "protobuf-java")
+    //}
 }
 
 kapt {
@@ -89,8 +74,6 @@ dependencies {
     implementation(Libraries.material)
     implementation(Libraries.livedataKtx)
     implementation(Libraries.viewModelKtx)
-    //implementation(Libraries.Koin.androidCore)
-    //implementation(Libraries.Koin.viewModel)
     implementation(Libraries.Kotlin.coroutinesCore)
     implementation(Libraries.Kotlin.coroutinesAndroid)
     implementation(Libraries.viewPager2)
@@ -122,11 +105,13 @@ dependencies {
 
     // dagger/hilt
     implementation(Libraries.Hilt.android)
+    implementation(Libraries.Hilt.navigationCompose)
+    kapt(Libraries.Hilt.compiler)
+
+    // TODO: remove or move to Libraries
     implementation("androidx.appcompat:appcompat:1.4.0")
     implementation("com.google.android.material:material:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.2")
-    implementation(Libraries.Hilt.navigationCompose)
-    kapt(Libraries.Hilt.compiler)
 
     // Unit/Android tests dependencies
     testImplementation(TestLibraries.androidCore)
@@ -134,7 +119,6 @@ dependencies {
     testImplementation(TestLibraries.robolectric)
     testImplementation(TestLibraries.coroutinesTest)
     testImplementation(TestLibraries.testCore)
-    //testImplementation(TestLibraries.koinTest)
     testImplementation(TestLibraries.mockk)
     testImplementation(TestLibraries.kluent)
 
@@ -151,6 +135,6 @@ dependencies {
     androidTestImplementation(TestLibraries.kluentAndroid)
 
     // Development dependencies
-    debugImplementation(DevLibraries.fragmentTesting)
+    //debugImplementation(DevLibraries.fragmentTesting)
     debugImplementation(DevLibraries.leakCanary)
 }

--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -1,4 +1,4 @@
-package com.wire.android.hilt
+package com.wire.android.di
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import com.wire.android.navigation.NavigationManager

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -22,7 +22,7 @@ annotation class KaliumCoreLogic
 @InstallIn(SingletonComponent::class)
 class CoreLogicModule {
 
-    @com.wire.android.di.KaliumCoreLogic
+    @KaliumCoreLogic
     @Singleton
     @Provides
     fun coreLogicProvider(@ApplicationContext context: Context): CoreLogic {
@@ -37,5 +37,5 @@ class CoreLogicModule {
 class UseCaseModule {
     @ViewModelScoped
     @Provides
-    fun loginUseCaseProvider(@com.wire.android.di.KaliumCoreLogic coreLogic: CoreLogic) = coreLogic.getAuthenticationScope().loginUsingEmail
+    fun loginUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic) = coreLogic.getAuthenticationScope().login
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/Auth.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/Auth.kt
@@ -8,16 +8,16 @@ import androidx.navigation.compose.rememberNavController
 import com.wire.android.ui.authentication.login.LoginScreen
 import com.wire.android.ui.authentication.welcome.WelcomeScreen
 import com.wire.android.ui.common.UnderConstructionScreen
+import com.wire.kalium.logic.configuration.ServerConfig
 
 @Composable
 fun AuthScreen() {
     val navController = rememberNavController()
     NavHost(navController = navController, startDestination = AuthDestination.start) {
         composable(AuthDestination.welcomeScreen) { WelcomeScreen(navController) }
-        composable(AuthDestination.loginScreen) { LoginScreen() }
+        composable(AuthDestination.loginScreen) { LoginScreen(ServerConfig.STAGING) }
         composable(AuthDestination.createEnterpriseAccount) { UnderConstructionScreen(AuthDestination.createEnterpriseAccount) }
         composable(AuthDestination.createPrivateAccountScreen) { UnderConstructionScreen(AuthDestination.createPrivateAccountScreen) }
-
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
@@ -59,10 +59,10 @@ import com.wire.android.util.DialogErrorStrings
 import com.wire.android.util.dialogErrorStrings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-
+import com.wire.kalium.logic.configuration.ServerConfig
 
 @Composable
-fun LoginScreen() {
+fun LoginScreen(serverConfig: ServerConfig) {
     val scope = rememberCoroutineScope()
     val loginViewModel: LoginViewModel = hiltViewModel()
     val loginState: LoginState = loginViewModel.loginState
@@ -71,7 +71,7 @@ fun LoginScreen() {
         onUserIdentifierChange = { loginViewModel.onUserIdentifierChange(it) },
         onPasswordChange = { loginViewModel.onPasswordChange(it) },
         onDialogDismiss = { loginViewModel.onDialogDismissed() },
-        onLoginButtonClick = suspend { loginViewModel.login() },
+        onLoginButtonClick = suspend { loginViewModel.login(serverConfig) },
         scope = scope
     )
 }
@@ -193,14 +193,20 @@ private fun ForgotPasswordLabel(modifier: Modifier) {
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                    onClick = { openForgotPasswordPage(context, backgroundColor.toArgb()) }
+                    onClick = {
+                        // TODO: refactor this to open the browser
+                        openForgotPasswordPage(context, backgroundColor.toArgb())
+                    }
                 )
         )
     }
 }
 
 private fun openForgotPasswordPage(context: Context, @ColorInt color: Int) {
+    // TODO: get the link from the serverConfig
     val url = "${BuildConfig.ACCOUNTS_URL}/forgot"
+
+    // TODO: extract the custom tab code to it's own destination
     val builder = CustomTabsIntent.Builder()
     val colors = CustomTabColorSchemeParams.Builder()
         .setNavigationBarColor(color)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -35,6 +35,8 @@ class LoginViewModel @Inject constructor(
         private set
 
     fun login(serverConfig: ServerConfig) {
+        viewModelScope.launch { navigateToConvScreen() }
+        return
         loginState = loginState.copy(loading = true, loginError = LoginError.None).updateLoginEnabled()
         viewModelScope.launch {
             val loginResult = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true, serverConfig)
@@ -59,6 +61,7 @@ class LoginViewModel @Inject constructor(
     private fun LoginState.updateLoginEnabled() =
         copy(loginEnabled = userIdentifier.text.isNotEmpty() && password.text.isNotEmpty() && !loading)
 
+    // TODO: login error Mapper ?
     private fun AuthenticationResult.toLoginError() =
         when(this) {
             is AuthenticationResult.Failure.Generic -> LoginError.DialogError.GenericError(this.genericFailure)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -17,6 +17,7 @@ import com.wire.kalium.logic.feature.auth.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import com.wire.kalium.logic.configuration.ServerConfig
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
@@ -33,10 +34,10 @@ class LoginViewModel @Inject constructor(
     )
         private set
 
-    fun login() {
+    fun login(serverConfig: ServerConfig) {
         loginState = loginState.copy(loading = true, loginError = LoginError.None).updateLoginEnabled()
         viewModelScope.launch {
-            val loginResult = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true)
+            val loginResult = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true, serverConfig)
             loginState = loginState.copy(loading = false, loginError = loginResult.toLoginError()).updateLoginEnabled()
             if(loginResult is AuthenticationResult.Success) navigateToConvScreen()
         }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -35,8 +35,10 @@ class LoginViewModel @Inject constructor(
         private set
 
     fun login(serverConfig: ServerConfig) {
+        // TODO: remove the temporary trick to ignore login once the minify issue is solved
         viewModelScope.launch { navigateToConvScreen() }
         return
+        // -----
         loginState = loginState.copy(loading = true, loginError = LoginError.None).updateLoginEnabled()
         viewModelScope.launch {
             val loginResult = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true, serverConfig)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
the login flow is changed in kalium, and playtest was not possible because of missing classes while building with minify,
this PR 


### Solutions

refactor `loginViewModel` and `LoginScreen` to pass `serverConfig` (for now it's only staging) and disable the login flow until the minify issue is solved

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
