### PR TITLE
fix: expand bottom sheet on show

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationState.kt
@@ -43,9 +43,8 @@ class ConversationState(
                 }
             }
         }
-        coroutineScope.launch { modalBottomSheetState.show() }
+        coroutineScope.launch { modalBottomSheetState.animateTo(ModalBottomSheetValue.Expanded) }
     }
-
 }
 
 @OptIn(ExperimentalMaterialApi::class)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This expands the `BottomSheet` modal to a "full" state, allowing to display all items consistently on all screens.

### Attachments (Optional)
<img src="https://user-images.githubusercontent.com/5806454/153652481-b683d893-aa8e-4a38-852f-1003f2f9e1aa.gif" width="350"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
