### PR TITLE
fix: updating login screen error state [AR-1100]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -41,11 +41,15 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             val loginResult = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true, serverConfig)
             loginState = loginState.copy(loading = false, loginError = loginResult.toLoginError()).updateLoginEnabled()
-            if(loginResult is AuthenticationResult.Success) navigateToConvScreen()
+            if (loginResult is AuthenticationResult.Success) navigateToConvScreen()
         }
     }
 
     fun onUserIdentifierChange(newText: TextFieldValue) {
+        // in case an error is showing e.g. inline error is should be cleared
+        if (loginState.loginError !is LoginError.None) {
+            clearLoginError()
+        }
         loginState = loginState.copy(userIdentifier = newText).updateLoginEnabled()
         savedStateHandle.set(USER_IDENTIFIER_SAVED_STATE_KEY, newText.text)
     }
@@ -63,7 +67,7 @@ class LoginViewModel @Inject constructor(
 
     // TODO: login error Mapper ?
     private fun AuthenticationResult.toLoginError() =
-        when(this) {
+        when (this) {
             is AuthenticationResult.Failure.Generic -> LoginError.DialogError.GenericError(this.genericFailure)
             AuthenticationResult.Failure.InvalidCredentials -> LoginError.DialogError.InvalidCredentialsError
             AuthenticationResult.Failure.InvalidUserIdentifier -> LoginError.TextFieldError.InvalidUserIdentifierError


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1100" title="AR-1100" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-1100</a>  Invalid Email inline error message should disappear as user types or change email text
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

[AR-1100]

### Solutions

clear the login error state after input change

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

manually 


----
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[AR-1100]: https://wearezeta.atlassian.net/browse/AR-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ