### PR TITLE
feat: "create personal account" - add "overview" screen and navigation [AR-954]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/Auth.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/Auth.kt
@@ -1,35 +1,49 @@
 package com.wire.android.ui.authentication
 
 
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.wire.android.ui.authentication.create.personalaccount.CreatePersonalAccountScreen
 import com.wire.android.ui.authentication.devices.RemoveDeviceScreen
 import com.wire.android.ui.authentication.login.LoginScreen
 import com.wire.android.ui.authentication.welcome.WelcomeScreen
 import com.wire.android.ui.common.UnderConstructionScreen
 import com.wire.kalium.logic.configuration.ServerConfig
 
-@ExperimentalMaterialApi
 @Composable
 fun AuthScreen() {
     val navController = rememberNavController()
-    NavHost(navController = navController, startDestination = AuthDestination.start) {
-        composable(AuthDestination.welcomeScreen) { WelcomeScreen(navController) }
-        composable(AuthDestination.loginScreen) { LoginScreen(navController, ServerConfig.STAGING) }
-        composable(AuthDestination.createEnterpriseAccountScreen) { UnderConstructionScreen(AuthDestination.createEnterpriseAccountScreen) }
-        composable(AuthDestination.createPrivateAccountScreen) { UnderConstructionScreen(AuthDestination.createPrivateAccountScreen) }
-        composable(AuthDestination.removeDeviceScreen) { RemoveDeviceScreen(navController = navController) }
+    val authNavigationManager = AuthNavigationManager(navController)
+    NavHost(navController = navController, startDestination = AuthDestination.Welcome.route) {
+        AuthDestination.values().forEach { destination ->
+            composable(route = destination.route) {
+                destination.content(authNavigationManager)
+            }
+        }
     }
 }
 
-object AuthDestination {
-    const val welcomeScreen: String = "welcome_screen"
-    const val loginScreen: String = "login_screen"
-    const val createEnterpriseAccountScreen: String = "create_enterprise_account_screen"
-    const val createPrivateAccountScreen: String = "create_private_account_screen"
-    const val removeDeviceScreen: String = "remove_device"
-    const val start = welcomeScreen
+class AuthNavigationManager(private val navController: NavController) {
+    fun navigate(authDestination: AuthDestination) = navController.navigate(authDestination.route)
+    fun navigateBack() = navController.popBackStack()
+}
+
+enum class AuthDestination(val route: String) {
+    Welcome(route = "welcome_screen"),
+    Login(route = "login_screen"),
+    RemoveDevice(route = "remove_device_screen"),
+    CreatePersonalAccount(route = "create_personal_account_screen"),
+    CreateTeam(route = "create_team_screen")
+}
+
+@Composable
+private fun AuthDestination.content(manager: AuthNavigationManager) = when(this) {
+    AuthDestination.Welcome -> WelcomeScreen(manager)
+    AuthDestination.Login ->  LoginScreen(manager, ServerConfig.STAGING)
+    AuthDestination.RemoveDevice -> RemoveDeviceScreen(manager)
+    AuthDestination.CreatePersonalAccount -> CreatePersonalAccountScreen(manager, ServerConfig.STAGING)
+    AuthDestination.CreateTeam -> UnderConstructionScreen("create_team_screen")
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountScreen.kt
@@ -1,0 +1,65 @@
+package com.wire.android.ui.authentication.create.personalaccount
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.navigation.NavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.wire.android.ui.authentication.AuthNavigationManager
+import com.wire.android.ui.common.UnderConstructionScreen
+import com.wire.kalium.logic.configuration.ServerConfig
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun CreatePersonalAccountScreen(
+    authNavigationManager: AuthNavigationManager,
+    serverConfig: ServerConfig
+) {
+    val viewModel: CreatePersonalAccountViewModel = hiltViewModel()
+    val navController = rememberNavController()
+    val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner was provided via LocalViewModelStoreOwner"
+    }
+    val navigationManager = CreatePersonalAccountNavigationManager(authNavigationManager, navController)
+    NavHost(navController = navController, startDestination = CreatePersonalAccountDestination.Overview.route) {
+        CreatePersonalAccountDestination.values().forEach { destination ->
+            composable(route = destination.route) {
+                    destination.content(ContentParams(navigationManager, viewModel, serverConfig))
+            }
+        }
+    }
+}
+
+class CreatePersonalAccountNavigationManager(
+    private val authNavigationManager: AuthNavigationManager,
+    private val navController: NavController
+) {
+    fun navigate(destination: CreatePersonalAccountDestination) {
+        navController.navigate(destination.route)
+    }
+
+    fun navigateBack() {
+        if (!navController.popBackStack()) authNavigationManager.navigateBack()
+    }
+}
+
+enum class CreatePersonalAccountDestination(val route: String) {
+    Overview(route = "create_personal_account_overview_screen"),
+    Email(route = "create_personal_account_email_screen")
+}
+
+private data class ContentParams(
+    val manager: CreatePersonalAccountNavigationManager,
+    val viewModel: CreatePersonalAccountViewModel,
+    val serverConfig: ServerConfig,
+)
+
+@Composable
+private fun CreatePersonalAccountDestination.content(params: ContentParams) = when(this) {
+    CreatePersonalAccountDestination.Overview ->
+        OverviewScreen(navigationManager = params.manager, serverConfig = params.serverConfig)
+    CreatePersonalAccountDestination.Email -> UnderConstructionScreen(CreatePersonalAccountDestination.Email.route)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
@@ -1,0 +1,12 @@
+package com.wire.android.ui.authentication.create.personalaccount
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@OptIn(ExperimentalMaterialApi::class)
+@HiltViewModel
+class CreatePersonalAccountViewModel @Inject constructor(
+) : ViewModel() {
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/OverviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/OverviewScreen.kt
@@ -1,0 +1,132 @@
+package com.wire.android.ui.authentication.create.personalaccount
+
+import android.content.Context
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.ui.common.textfield.WirePrimaryButton
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.CustomTabsHelper
+import com.wire.kalium.logic.configuration.ServerConfig
+
+@Composable
+fun OverviewScreen(
+    navigationManager: CreatePersonalAccountNavigationManager,
+    serverConfig: ServerConfig,
+) {
+    OverviewContent(
+        onBackPressed = { navigationManager.navigateBack() },
+        onContinuePressed = { navigationManager.navigate(CreatePersonalAccountDestination.Email) },
+        websiteBaseUrl = serverConfig.websiteUrl,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun OverviewContent(
+    onBackPressed: () -> Unit,
+    onContinuePressed: () -> Unit,
+    websiteBaseUrl: String,
+) {
+    Scaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = 0.dp,
+                title = stringResource(R.string.create_personal_account_title),
+                onNavigationPressed = onBackPressed
+            )
+        },
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            val context = LocalContext.current
+            Spacer(modifier = Modifier.weight(1f))
+            Image(
+                painter = painterResource(id = R.drawable.ic_create_personal_account),
+                contentDescription = "",
+                contentScale = ContentScale.Inside,
+                modifier = Modifier
+                    .padding(
+                        horizontal = MaterialTheme.wireDimensions.spacing64x,
+                        vertical = MaterialTheme.wireDimensions.spacing32x
+                    )
+            )
+            OverviewTexts(
+                modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing24x),
+                onLearnMoreClick = { openLearnMorePage(context, websiteBaseUrl) }
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            WirePrimaryButton(
+                text = stringResource(R.string.label_continue),
+                onClick = onContinuePressed,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(MaterialTheme.wireDimensions.spacing16x),
+            )
+        }
+    }
+}
+
+@Composable
+private fun OverviewTexts(modifier: Modifier, onLearnMoreClick: () -> Unit) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.create_personal_account_text),
+            style = MaterialTheme.wireTypography.body02,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Text(
+            text = stringResource(R.string.create_personal_account_link),
+            style = MaterialTheme.wireTypography.body02.copy(
+                textDecoration = TextDecoration.Underline,
+                color = MaterialTheme.colorScheme.primary
+            ),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onLearnMoreClick
+                )
+        )
+    }
+}
+
+private fun openLearnMorePage(context: Context, websiteBaseUrl: String) {
+    val url = "https://${websiteBaseUrl}/pricing"
+    CustomTabsHelper.launchUrl(context, url)
+}
+
+@Composable
+@Preview
+private fun OverviewScreenPreview() {
+    OverviewContent(
+        onBackPressed = { },
+        onContinuePressed = { },
+        websiteBaseUrl = ""
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/RemoveDevice.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/RemoveDevice.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.wire.android.R
+import com.wire.android.ui.authentication.AuthNavigationManager
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.android.ui.common.SurfaceBackgroundWrapper
 import com.wire.android.ui.common.WireDialog
@@ -43,11 +43,11 @@ import com.wire.android.util.formatMediumDateTime
 import kotlinx.coroutines.android.awaitFrame
 
 @Composable
-fun RemoveDeviceScreen(navController: NavController) {
+fun RemoveDeviceScreen(authNavigationManager: AuthNavigationManager) {
     val viewModel: RemoveDeviceViewModel = hiltViewModel()
     val state: RemoveDeviceState = viewModel.state
     RemoveDeviceContent(
-        navController = navController,
+        authNavigationManager = authNavigationManager,
         state = state,
         onItemClicked = viewModel::onItemClicked,
         onPasswordChange = viewModel::onPasswordChange,
@@ -60,7 +60,7 @@ fun RemoveDeviceScreen(navController: NavController) {
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 private fun RemoveDeviceContent(
-    navController: NavController,
+    authNavigationManager: AuthNavigationManager,
     state: RemoveDeviceState,
     onItemClicked: (Device) -> Unit,
     onPasswordChange: (TextFieldValue) -> Unit,
@@ -73,7 +73,7 @@ private fun RemoveDeviceContent(
         topBar = {
             RemoveDeviceTopBar(
                 elevation = lazyListState.appBarElevation(),
-                onBackNavigationPressed = { navController.popBackStack() }) //TODO logout?
+                onBackNavigationPressed = { authNavigationManager.navigateBack() }) //TODO logout?
         }
     ) {
         when(state) {
@@ -195,7 +195,7 @@ private fun RemoveDeviceDialog(
 @Composable
 private fun RemoveDeviceScreenPreview() {
     RemoveDeviceContent(
-        navController = rememberNavController(),
+        authNavigationManager = AuthNavigationManager(rememberNavController()),
         state = RemoveDeviceState.Success(List(10) { Device(name = "device") }, RemoveDeviceDialogState.Hidden),
         onItemClicked = {},
         onPasswordChange = {},

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.authentication.login
 
 import android.content.Context
+import android.net.Uri
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -34,10 +35,9 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavController
-import com.wire.android.BuildConfig
 import com.wire.android.R
 import com.wire.android.ui.authentication.AuthDestination
+import com.wire.android.ui.authentication.AuthNavigationManager
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
@@ -56,10 +56,9 @@ import com.wire.kalium.logic.configuration.ServerConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@ExperimentalMaterialApi
 @Composable
 fun LoginScreen(
-    navController: NavController,
+    authNavigationManager: AuthNavigationManager,
     serverConfig: ServerConfig
 ) {
     val scope = rememberCoroutineScope()
@@ -68,14 +67,15 @@ fun LoginScreen(
     LoginContent(
         loginState = loginState,
         onUserIdentifierChange = { loginViewModel.onUserIdentifierChange(it) },
-        onBackPressed = { navController.popBackStack() },
+        onBackPressed = { authNavigationManager.navigateBack() },
         onPasswordChange = { loginViewModel.onPasswordChange(it) },
         onDialogDismiss = { loginViewModel.clearLoginError() },
         onRemoveDeviceOpen = {
-            navController.navigate(AuthDestination.removeDeviceScreen)
+            authNavigationManager.navigate(AuthDestination.RemoveDevice)
             loginViewModel.clearLoginError()
         },
         onLoginButtonClick = suspend { loginViewModel.login(serverConfig) },
+        accountsBaseUrl = serverConfig.accountsBaseUrl,
         scope = scope
     )
 }
@@ -90,6 +90,7 @@ private fun LoginContent(
     onDialogDismiss: () -> Unit,
     onRemoveDeviceOpen: () -> Unit,
     onLoginButtonClick: suspend () -> Unit,
+    accountsBaseUrl: String,
     scope: CoroutineScope
 ) {
     Scaffold(
@@ -123,7 +124,7 @@ private fun LoginContent(
                     onPasswordChange = onPasswordChange
                 )
                 Spacer(modifier = Modifier.height(16.dp))
-                ForgotPasswordLabel(modifier = Modifier.fillMaxWidth())
+                ForgotPasswordLabel(modifier = Modifier.fillMaxWidth(), accountsBaseUrl)
             }
 
             LoginButton(
@@ -195,7 +196,7 @@ private fun PasswordInput(modifier: Modifier, password: TextFieldValue, onPasswo
 }
 
 @Composable
-private fun ForgotPasswordLabel(modifier: Modifier) {
+private fun ForgotPasswordLabel(modifier: Modifier, accountsBaseUrl: String) {
     Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
         val context = LocalContext.current
         Text(
@@ -209,19 +210,14 @@ private fun ForgotPasswordLabel(modifier: Modifier) {
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                    onClick = {
-                        // TODO: refactor this to open the browser
-                        openForgotPasswordPage(context)
-                    }
+                    onClick = { openForgotPasswordPage(context, accountsBaseUrl) }
                 )
         )
     }
 }
 
-private fun openForgotPasswordPage(context: Context) {
-    // TODO: get the link from the serverConfig
-    val url = "${BuildConfig.ACCOUNTS_URL}/forgot"
-
+private fun openForgotPasswordPage(context: Context, accountsBaseUrl: String) {
+    val url = "https://${accountsBaseUrl}/forgot"
     CustomTabsHelper.launchUrl(context, url)
 }
 
@@ -255,6 +251,7 @@ private fun LoginScreenPreview() {
             onDialogDismiss = { },
             onRemoveDeviceOpen = { },
             onLoginButtonClick = suspend { },
+            accountsBaseUrl = "",
             scope = scope
         )
     }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -24,7 +24,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@ExperimentalMaterialApi
+@OptIn(ExperimentalMaterialApi::class)
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/Welcome.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/welcome/Welcome.kt
@@ -45,6 +45,7 @@ import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
 import com.wire.android.R
 import com.wire.android.ui.authentication.AuthDestination
+import com.wire.android.ui.authentication.AuthNavigationManager
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.textfield.WirePrimaryButton
 import com.wire.android.ui.theme.WireTheme
@@ -59,13 +60,13 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
 
 @Composable
-fun WelcomeScreen(navController: NavController) {
-    WelcomeContent(navController)
+fun WelcomeScreen(authNavigationManager: AuthNavigationManager) {
+    WelcomeContent(authNavigationManager)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun WelcomeContent(navController: NavController) {
+private fun WelcomeContent(authNavigationManager: AuthNavigationManager) {
     Scaffold(modifier = Modifier.padding(vertical = MaterialTheme.wireDimensions.welcomeVerticalPadding)) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -89,17 +90,17 @@ private fun WelcomeContent(navController: NavController) {
                 horizontal = MaterialTheme.wireDimensions.welcomeButtonHorizontalPadding
             )) {
                 LoginButton {
-                    navController.navigate(AuthDestination.loginScreen)
+                    authNavigationManager.navigate(AuthDestination.Login)
                 }
-                CreateEnterpriseAccountButton {
-                    navController.navigate((AuthDestination.createEnterpriseAccountScreen))
+                CreateTeamButton {
+                    authNavigationManager.navigate(AuthDestination.CreateTeam)
                 }
             }
 
             WelcomeFooter(modifier = Modifier
                 .padding(horizontal = MaterialTheme.wireDimensions.welcomeTextHorizontalPadding),
                 onPrivateAccountClick = {
-                    navController.navigate(AuthDestination.createPrivateAccountScreen)
+                    authNavigationManager.navigate(AuthDestination.CreatePersonalAccount)
                 })
         }
     }
@@ -197,10 +198,10 @@ private fun LoginButton(onClick: () -> Unit) {
 }
 
 @Composable
-private fun CreateEnterpriseAccountButton(onClick: () -> Unit) {
+private fun CreateTeamButton(onClick: () -> Unit) {
     WireSecondaryButton(
         onClick = onClick,
-        text = stringResource(R.string.welcome_button_create_enterprise_account),
+        text = stringResource(R.string.welcome_button_create_team),
         modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.welcomeButtonVerticalPadding)
     )
 }
@@ -254,7 +255,7 @@ private fun shouldJumpToEnd(previousPage: Int, currentPage: Int, lastPage: Int):
 @Composable
 private fun WelcomeScreenPreview() {
     WireTheme(isPreview = true) {
-        WelcomeContent(rememberNavController())
+        WelcomeContent(AuthNavigationManager(rememberNavController()))
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -82,7 +82,7 @@ private val LightWireColorScheme = WireColorScheme(
     tertiaryButtonSelected = WireColorPalette.LightBlue50,         onTertiaryButtonSelected = WireColorPalette.LightBlue500,
     tertiaryButtonSelectedOutline = WireColorPalette.LightBlue300,
     tertiaryButtonRipple = Color.Black,
-    divider = WireColorPalette.Gray40,
+    divider = WireColorPalette.Gray30,
     secondaryText = WireColorPalette.Gray70,
     labelText = WireColorPalette.Gray80,
     badge = WireColorPalette.Gray90,                               onBadge = Color.White
@@ -116,7 +116,7 @@ private val DarkWireColorScheme = WireColorScheme(
     tertiaryButtonSelected = WireColorPalette.DarkBlue50,          onTertiaryButtonSelected = WireColorPalette.DarkBlue500,
     tertiaryButtonSelectedOutline = WireColorPalette.DarkBlue300,
     tertiaryButtonRipple = Color.White,
-    divider = WireColorPalette.Gray70,
+    divider = WireColorPalette.Gray80,
     secondaryText = WireColorPalette.Gray40,
     labelText = WireColorPalette.Gray30,
     badge = WireColorPalette.Gray10,                               onBadge = Color.Black

--- a/app/src/main/res/drawable/ic_create_personal_account.xml
+++ b/app/src/main/res/drawable/ic_create_personal_account.xml
@@ -1,0 +1,218 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="140dp"
+    android:height="198dp"
+    android:viewportWidth="140"
+    android:viewportHeight="198">
+  <path
+      android:pathData="M113.22,1.5H30.723C24.874,1.5 20.133,6.241 20.133,12.09V185.296C20.133,191.145 24.874,195.886 30.723,195.886H113.22C119.068,195.886 123.81,191.145 123.81,185.296V12.09C123.81,6.241 119.068,1.5 113.22,1.5Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M103.261,5.521C103.261,9.142 100.325,12.985 96.705,12.985H47.946C44.301,12.985 41.386,9.142 41.386,5.521H32.687C30.365,5.521 28.138,6.444 26.496,8.086C24.854,9.728 23.931,11.955 23.931,14.277V183.11C23.931,185.432 24.854,187.659 26.496,189.301C28.138,190.943 30.365,191.865 32.687,191.865H111.251C113.573,191.865 115.8,190.943 117.442,189.301C119.084,187.659 120.007,185.432 120.007,183.11V14.277C120.007,13.127 119.78,11.989 119.34,10.926C118.9,9.864 118.255,8.899 117.442,8.086C116.629,7.273 115.664,6.628 114.602,6.188C113.54,5.748 112.401,5.521 111.251,5.521H103.261Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M113.118,195.886H28.767C20.133,195.886 16.678,190.448 16.678,183.798V12.195C16.686,9.361 17.815,6.645 19.819,4.641C21.823,2.637 24.539,1.507 27.374,1.5H113.118C114.523,1.5 115.913,1.777 117.211,2.314C118.508,2.852 119.687,3.64 120.68,4.633C121.672,5.626 122.46,6.805 122.997,8.103C123.534,9.4 123.81,10.791 123.81,12.195V185.191C123.81,186.595 123.534,187.986 122.997,189.284C122.46,190.581 121.672,191.76 120.68,192.754C119.687,193.747 118.508,194.535 117.211,195.072C115.913,195.61 114.523,195.886 113.118,195.886Z"
+      android:fillColor="#6DB3FF"/>
+  <path
+      android:pathData="M106.456,6.902C104.792,6.902 102.455,7.072 101.872,8.636C100.892,11.268 99.155,14.386 96.417,14.386H45.589C42.852,14.386 40.79,11.483 39.806,8.85C39.223,7.287 37.781,6.902 36.117,6.902H32.687C27.851,6.902 21.858,9.442 21.858,14.277V183.11C21.858,187.945 26.952,190.504 31.788,190.504H108.688C113.523,190.504 119.322,187.945 119.322,183.11V14.277C119.322,9.442 114.71,6.902 109.874,6.902H106.456Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M113.045,1.5H27.442C21.498,1.5 16.678,6.319 16.678,12.264V185.122C16.678,191.067 21.498,195.886 27.442,195.886H113.045C118.99,195.886 123.81,191.067 123.81,185.122V12.264C123.81,6.319 118.99,1.5 113.045,1.5Z"
+      android:strokeWidth="2.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#0772DE"/>
+  <path
+      android:pathData="M104.172,6.882C103.649,6.88 103.14,7.05 102.724,7.367C102.308,7.685 102.008,8.131 101.872,8.636C101.107,11.588 98.511,14.237 95.425,14.237H45.78C42.694,14.237 40.11,11.588 39.332,8.636C39.197,8.132 38.899,7.687 38.484,7.37C38.07,7.053 37.562,6.881 37.04,6.882H30.245C25.32,6.882 21.336,10.746 21.336,15.512V181.875C21.336,186.641 25.329,190.505 30.245,190.505H110.243C115.167,190.505 119.152,186.641 119.152,181.875V15.512C119.152,10.746 115.159,6.882 110.243,6.882H104.172Z"
+      android:strokeWidth="2.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#0772DE"/>
+  <path
+      android:pathData="M111.385,68.154H29.087C28.554,68.154 28.123,68.586 28.123,69.118V93.036C28.123,93.568 28.554,94 29.087,94H111.385C111.917,94 112.349,93.568 112.349,93.036V69.118C112.349,68.586 111.917,68.154 111.385,68.154Z"
+      android:fillColor="#E6F1FC"/>
+  <path
+      android:pathData="M111.385,37.988H29.087C28.554,37.988 28.123,38.419 28.123,38.952V62.869C28.123,63.402 28.554,63.833 29.087,63.833H111.385C111.917,63.833 112.349,63.402 112.349,62.869V38.952C112.349,38.419 111.917,37.988 111.385,37.988Z"
+      android:fillColor="#E6F1FC"/>
+  <path
+      android:pathData="M42.37,51.644H98.106"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.92"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M42.37,58.164H95.344"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.92"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M53.276,45.124H81.421"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.92"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M74.29,41.965H66.19C64.926,41.965 63.902,42.989 63.902,44.253V52.352C63.902,53.616 64.926,54.64 66.19,54.64H74.29C75.553,54.64 76.578,53.616 76.578,52.352V44.253C76.578,42.989 75.553,41.965 74.29,41.965Z"
+      android:fillColor="#65A8EB"/>
+  <path
+      android:pathData="M111.385,148.821H29.087C28.554,148.821 28.123,149.252 28.123,149.785V173.702C28.123,174.235 28.554,174.666 29.087,174.666H111.385C111.917,174.666 112.349,174.235 112.349,173.702V149.785C112.349,149.252 111.917,148.821 111.385,148.821Z"
+      android:fillColor="#E6F1FC"/>
+  <path
+      android:pathData="M111.385,118.654H29.087C28.554,118.654 28.123,119.086 28.123,119.618V143.536C28.123,144.068 28.554,144.5 29.087,144.5H111.385C111.917,144.5 112.349,144.068 112.349,143.536V119.618C112.349,119.086 111.917,118.654 111.385,118.654Z"
+      android:fillColor="#E6F1FC"/>
+  <path
+      android:pathData="M53.276,75.525H81.421"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.92"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M49.279,131.792H92.21"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.92"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M42.37,138.312H81.421"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.92"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M53.276,155.673H79.412"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3.92"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M99.75,36.62H2.63C2.006,36.62 1.5,37.125 1.5,37.75V78.83C1.5,79.454 2.006,79.96 2.63,79.96H99.75C100.374,79.96 100.88,79.454 100.88,78.83V37.75C100.88,37.125 100.374,36.62 99.75,36.62Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#ffffff"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M22.295,47.545C22.295,43.723 19.197,40.624 15.374,40.624C11.552,40.624 8.453,43.723 8.453,47.545C8.453,51.367 11.552,54.466 15.374,54.466C19.197,54.466 22.295,51.367 22.295,47.545Z"
+      android:fillColor="#FF7D8B"/>
+  <path
+      android:pathData="M9.612,60.974H78.125"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M9.612,71.516H86.07"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M30.545,50.433H92.906"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M137.87,85.771H29.479C28.855,85.771 28.35,86.276 28.35,86.9V117.901C28.35,118.525 28.855,119.031 29.479,119.031H137.87C138.494,119.031 139,118.525 139,117.901V86.9C139,86.276 138.494,85.771 137.87,85.771Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#ffffff"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M49.141,96.697C49.141,92.874 46.042,89.776 42.22,89.776C38.397,89.776 35.299,92.874 35.299,96.697C35.299,100.519 38.397,103.618 42.22,103.618C46.042,103.618 49.141,100.519 49.141,96.697Z"
+      android:fillColor="#48A0FF"/>
+  <path
+      android:pathData="M36.461,110.125H120.444"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M57.39,100.398H131.026"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M106.408,127.345H8.101C7.381,127.345 6.797,127.929 6.797,128.649V158.677C6.797,159.398 7.381,159.981 8.101,159.981H106.408C107.128,159.981 107.712,159.398 107.712,158.677V128.649C107.712,127.929 107.128,127.345 106.408,127.345Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#ffffff"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M25.908,138.113C25.908,134.291 22.809,131.192 18.987,131.192C15.164,131.192 12.066,134.291 12.066,138.113C12.066,141.936 15.164,145.034 18.987,145.034C22.809,145.034 25.908,141.936 25.908,138.113Z"
+      android:fillColor="#5AE6FF"/>
+  <path
+      android:pathData="M13.86,151.809H101.82"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M39.766,143.661H91.473"
+      android:strokeLineJoin="round"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#B5D5F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M70.248,60.31V60.177L70.151,60.242L70.049,60.177V60.31C55.657,70.601 46.44,71.245 34.412,74.371C34.473,87.484 34.177,100.646 35.663,113.673C37.498,129.743 49.837,149.109 70.049,149.356H70.248C90.468,149.109 102.8,129.743 104.634,113.673C106.12,100.646 105.825,87.484 105.89,74.371C93.854,71.237 84.633,70.601 70.248,60.31Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M72.5,61.655L69.892,60.177C69.863,60.197 69.28,60.31 69.28,60.31C55.871,70.601 48.626,70.552 37.433,73.674C37.49,86.783 37.214,100.633 38.599,113.661C40.308,129.731 52.668,149.096 71.507,149.343H71.69C90.529,149.096 103.217,129.731 104.926,113.661C106.311,100.633 106.035,87.472 106.092,74.359C94.886,71.237 86.042,68.997 72.5,61.655Z"
+      android:fillColor="#FFD939"/>
+  <path
+      android:pathData="M69.385,60.8C66.299,63.039 53.891,71.378 34.404,74.37C34.465,87.483 34.169,100.645 35.655,113.673C37.49,129.742 49.829,149.108 70.041,149.355H70.248C90.468,149.108 102.8,129.742 104.634,113.673C106.12,100.645 105.825,87.483 105.89,74.37C90.626,72.345 74.707,63.003 70.965,60.739C70.725,60.591 70.447,60.517 70.166,60.528C69.884,60.539 69.613,60.633 69.385,60.8Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M83.487,99.394H56.799C56.298,99.394 55.892,99.8 55.892,100.301V121.477C55.892,121.978 56.298,122.384 56.799,122.384H83.487C83.988,122.384 84.394,121.978 84.394,121.477V100.301C84.394,99.8 83.988,99.394 83.487,99.394Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M83.535,99.394H59.626C59.151,99.394 58.767,99.778 58.767,100.253V121.526C58.767,122 59.151,122.384 59.626,122.384H83.535C84.009,122.384 84.394,122 84.394,121.526V100.253C84.394,99.778 84.009,99.394 83.535,99.394Z"
+      android:fillColor="#60ACFF"/>
+  <path
+      android:pathData="M62.112,99.017V91.586C62.112,89.456 62.958,87.413 64.464,85.907C65.97,84.401 68.013,83.555 70.143,83.555V83.555C71.197,83.555 72.241,83.763 73.215,84.167C74.189,84.57 75.074,85.162 75.82,85.908C76.565,86.653 77.156,87.539 77.559,88.513C77.963,89.487 78.17,90.531 78.169,91.586V99.017"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M83.487,99.394H56.799C56.298,99.394 55.892,99.8 55.892,100.301V121.477C55.892,121.978 56.298,122.384 56.799,122.384H83.487C83.988,122.384 84.394,121.978 84.394,121.477V100.301C84.394,99.8 83.988,99.394 83.487,99.394Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M75.699,104.986H84.394"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M78.173,109.595H84.394"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#0772DE"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="label_new">New</string>
     <string name="label_login">Login</string>
     <string name="label_ok">OK</string>
+    <string name="label_continue">Continue</string>
     <string name="label_cancel">Cancel</string>
     <string name="label_remove">Remove</string>
     <string name="label_removing">Removing...</string>
@@ -50,8 +51,9 @@
     <!-- Welcome -->
     <string name="welcome_screen_title">welcome</string>
     <string name="welcome_footer_text">Want to chat with friends and family?</string>
-    <string name="welcome_footer_link">Create a private account for free</string>
+    <string name="welcome_footer_link">Create a personal account for free</string>
     <string name="welcome_button_create_enterprise_account">Create Enterprise Account</string>
+    <string name="welcome_button_create_team">Create a Team</string>
 
     <!-- Login -->
     <string name="login_title">Login</string>
@@ -72,6 +74,11 @@ username</string>
     <string name="remove_device_id_and_time_label">ID: %1$s\nAdded: %2$s</string>
     <string name="remove_device_dialog_title">Remove the following device?</string>
     <string name="remove_device_invalid_password">Invalid password</string>
+
+    <!-- Create Personal Account -->
+    <string name="create_personal_account_title">Create a Personal Account</string>
+    <string name="create_personal_account_text">Securely chat with friends and family using Wire\'s public cloud server.</string>
+    <string name="create_personal_account_link">Learn more</string>
 
     <!-- Home -->
     <string name="home_open_drawer_description">Open drawer</string>

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -73,7 +73,7 @@ object Libraries {
         const val composeMaterial = compose
         const val composeMaterial3 = "1.0.0-alpha05"
         const val composeActivity = "1.4.0"
-        const val composeNavigation = "2.4.0-beta02"
+        const val composeNavigation = "2.4.1"
         const val accompanist = "0.24.2-alpha"
         const val composeConstraint = "1.0.0-rc02"
         const val hilt = "2.38.1"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User needs to be able to create a personal account. The creation flow has to be open by pressing the "Create a private account for free" on `WelcomeScreen`.

### Solutions

- implemented "Overview" screen (first one in personal account creation flow)
- refactored  "Auth" nested navigation
- implemented "Create personal account" nested navigation

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/155493387-3d311832-0726-4c35-9416-4d3455b36add.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
