### PR TITLE
chore: add SendTextMessageUseCase to ConversationViewModel (AR-912)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -7,6 +7,7 @@ import com.wire.kalium.logic.feature.user.UploadUserAvatarUseCase
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -118,4 +119,13 @@ class UseCaseModule {
         @CurrentSession currentSession: AuthSession
     ): GetSelfUserUseCase =
         coreLogic.getSessionScope(currentSession).users.getSelfUser
+
+    @ViewModelScoped
+    @Provides
+    fun providesSendTextMessageUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentSession currentSession: AuthSession
+    ): SendTextMessageUseCase =
+        coreLogic.getSessionScope(currentSession).messages.sendTextMessage
+
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -19,6 +19,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.feature.conversation.GetConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.GetRecentMessagesUseCase
+import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -29,7 +30,8 @@ class ConversationViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val navigationManager: NavigationManager,
     private val getMessages: GetRecentMessagesUseCase,
-    private val getConversationDetails: GetConversationDetailsUseCase
+    private val getConversationDetails: GetConversationDetailsUseCase,
+    private val sendTextMessageUseCase: SendTextMessageUseCase
 ) : ViewModel() {
 
     var conversationViewState by mutableStateOf(ConversationViewState())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-912" title="AR-912" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-912</a>  Send text messages
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

> Sometimes you just gotta lick the stamp and send it 👅📮

### Issues

We need the UseCase to be defined and accessible to the ViewModel in order to send messages.

### Solutions

Add `SendTextMessageUseCase` to `ConversationViewModel` in order to enable sending of messages.

### Testing

N/A

### Notes (Optional)

Integrating the usecase with the input will be handled in another PR.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
