### PR TITLE
fix: show mocked data for Other Teams section on User Profile [AR-1139]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
@@ -46,7 +46,12 @@ class UserProfileViewModel @Inject constructor(
                     status = UserStatus.AVAILABLE,
                     fullName = it.name!!,
                     userName = it.handle!!,
-                    teamName = it.team
+                    teamName = it.team,
+                    // Add some mocked team
+                    otherAccounts = listOf(
+                        OtherAccount("someId", "", "Tommaso", "Wire Swiss GmbH"),
+                        OtherAccount("someId", "", "B. A. Baracus", "The A-Team"),
+                    )
                 )
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
@@ -49,7 +49,7 @@ class UserProfileViewModel @Inject constructor(
                     teamName = it.team,
                     // Add some mocked team
                     otherAccounts = listOf(
-                        OtherAccount("someId", "", "Tommaso", "Wire Swiss GmbH"),
+                        OtherAccount("someId", "", it.name!!, "Wire Swiss GmbH"),
                         OtherAccount("someId", "", "B. A. Baracus", "The A-Team"),
                     )
                 )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1139" title="AR-1139" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-1139</a>  Self profile displays incorrectly on Pixel3
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

Adds a couple of mocked teams on the User Profile

### Screenshots
<img width="408" alt="Captura de pantalla 2022-02-25 a las 13 06 00" src="https://user-images.githubusercontent.com/2468164/155712437-7d901bab-67d8-44ae-9ab4-2e2b460a9ed0.png">

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
