### PR TITLE
fix: add missing navigation to create account under construction for user profile 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
@@ -73,7 +73,9 @@ class UserProfileViewModel @Inject constructor(
     }
 
     fun addAccount() {
-        // TODO
+        viewModelScope.launch {
+            navigationManager.navigate(NavigationCommand(NavigationItem.CreatePrivateAccount.getRouteWithArgs()))
+        }
     }
 
     fun editProfile() {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Add a missing navigation case to under construction, for the button  on user profile to create a new account or team

### Attachments (Optional)
![add-navtonewaccount](https://user-images.githubusercontent.com/5806454/155718098-88432aaa-55e1-444f-baf2-c3ae8ac3052d.gif)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
