### PR TITLE
feat: "create personal account" - "email" and "details" UI [AR-1069]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountNavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountNavigationItem.kt
@@ -2,7 +2,6 @@ package com.wire.android.ui.authentication.create.personalaccount
 
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavController
-import com.wire.android.ui.common.UnderConstructionScreen
 import com.wire.kalium.logic.configuration.ServerConfig
 
 enum class CreatePersonalAccountNavigationItem(
@@ -15,13 +14,18 @@ enum class CreatePersonalAccountNavigationItem(
     ),
     Email(
         route = CreatePersonalAccountDestinationsRoutes.EMAIL,
-        content = { UnderConstructionScreen(CreatePersonalAccountDestinationsRoutes.EMAIL) }
+        content = { EmailScreen(it.viewModel, it.serverConfig) }
+    ),
+    Details(
+        route = CreatePersonalAccountDestinationsRoutes.DETAILS,
+        content = { DetailsScreen(it.viewModel) }
     )
 }
 
 object CreatePersonalAccountDestinationsRoutes {
     const val OVERVIEW = "create_personal_account_overview_screen"
     const val EMAIL = "create_personal_account_email_screen"
+    const val DETAILS = "create_personal_accounts_details_screen"
 }
 
 data class ContentParams(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
@@ -1,10 +1,17 @@
 package com.wire.android.ui.authentication.create.personalaccount
 
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -14,11 +21,66 @@ import javax.inject.Inject
 class CreatePersonalAccountViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
 ) : ViewModel() {
-
     var moveToStep = MutableSharedFlow<CreatePersonalAccountNavigationItem>()
     var moveBack = MutableSharedFlow<Unit>()
+    var state by mutableStateOf(CreatePersonalAccountViewState())
+        private set
 
+    // Navigation
     fun goToStep(item: CreatePersonalAccountNavigationItem) { viewModelScope.launch { moveToStep.emit(item) } }
     fun goBackToPreviousStep() { viewModelScope.launch { moveBack.emit(Unit) } }
     fun closeForm() { viewModelScope.launch { navigationManager.navigateBack() } }
+    fun openLogin() { viewModelScope.launch { navigationManager.navigate(NavigationCommand(NavigationItem.Login.getRouteWithArgs())) } }
+
+    // Email
+    fun onEmailChange(newText: TextFieldValue) {
+        state = state.copy(email = state.email.copy(
+                email = newText,
+                error = CreatePersonalAccountViewState.EmailError.None,
+                continueEnabled = newText.text.isNotEmpty() && !state.email.loading
+        ))
+    }
+    fun onEmailContinue() {
+        state = state.copy(email = state.email.copy(loading = true, continueEnabled = false))
+        viewModelScope.launch {
+            delay(1000) //TODO replace with proper logic
+            state = state.copy(email = state.email.copy(loading = false, continueEnabled = true, termsDialogVisible = true))
+        }
+    }
+    fun onTermsDialogDismiss() { state = state.copy(email = state.email.copy(termsDialogVisible = false)) }
+    fun onTermsAccepted() { goToStep(CreatePersonalAccountNavigationItem.Details) }
+
+    // Details
+    fun onDetailsChange(newText: TextFieldValue, fieldType: DetailsFieldType) {
+        state = state.copy(details = when(fieldType) {
+            DetailsFieldType.FirstName -> state.details.copy(firstName = newText)
+                DetailsFieldType.LastName -> state.details.copy(lastName = newText)
+                DetailsFieldType.Password -> state.details.copy(password = newText)
+                DetailsFieldType.ConfirmPassword -> state.details.copy(confirmPassword = newText)
+        }.let { it.copy(
+                error = CreatePersonalAccountViewState.DetailsError.None,
+                continueEnabled = it.fieldsNotEmpty() && !it.loading
+            )
+        })
+    }
+    fun onDetailsContinue() {
+        state = state.copy(details = state.details.copy(loading = true, continueEnabled = false))
+        viewModelScope.launch {
+            delay(1000) //TODO replace with proper logic
+            state = state.copy(details = state.details.copy(
+                loading = false,
+                continueEnabled = true,
+                error = when {
+                    state.details.password.text != state.details.confirmPassword.text ->
+                        CreatePersonalAccountViewState.DetailsError.PasswordsNotMatchingError
+                    state.details.password.text.length < 8 -> CreatePersonalAccountViewState.DetailsError.InvalidPasswordError
+                    else -> CreatePersonalAccountViewState.DetailsError.None
+                }
+            ))
+        }
+    }
+}
+
+enum class DetailsFieldType {
+    FirstName, LastName, Password, ConfirmPassword
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@Suppress("MagicNumber")
 @OptIn(ExperimentalMaterialApi::class)
 @HiltViewModel
 class CreatePersonalAccountViewModel @Inject constructor(
@@ -42,8 +43,7 @@ class CreatePersonalAccountViewModel @Inject constructor(
     }
     fun onEmailContinue() {
         state = state.copy(email = state.email.copy(loading = true, continueEnabled = false))
-        viewModelScope.launch {
-            delay(1000) //TODO replace with proper logic
+        viewModelScope.launch { //TODO replace with proper logic
             state = state.copy(email = state.email.copy(loading = false, continueEnabled = true, termsDialogVisible = true))
         }
     }
@@ -65,19 +65,23 @@ class CreatePersonalAccountViewModel @Inject constructor(
     }
     fun onDetailsContinue() {
         state = state.copy(details = state.details.copy(loading = true, continueEnabled = false))
-        viewModelScope.launch {
-            delay(1000) //TODO replace with proper logic
+        viewModelScope.launch { //TODO replace with proper logic
             state = state.copy(details = state.details.copy(
                 loading = false,
                 continueEnabled = true,
                 error = when {
                     state.details.password.text != state.details.confirmPassword.text ->
                         CreatePersonalAccountViewState.DetailsError.PasswordsNotMatchingError
-                    state.details.password.text.length < 8 -> CreatePersonalAccountViewState.DetailsError.InvalidPasswordError
+                    state.details.password.text.length < MIN_PASSWORD_LENGTH ->
+                        CreatePersonalAccountViewState.DetailsError.InvalidPasswordError
                     else -> CreatePersonalAccountViewState.DetailsError.None
                 }
             ))
         }
+    }
+
+    companion object {
+        private const val MIN_PASSWORD_LENGTH = 8
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewState.kt
@@ -1,0 +1,39 @@
+package com.wire.android.ui.authentication.create.personalaccount
+
+import androidx.compose.ui.text.input.TextFieldValue
+
+data class CreatePersonalAccountViewState(
+    val email: Email = Email(),
+    val details: Details = Details(),
+) {
+    data class Email(
+        val email: TextFieldValue = TextFieldValue(""),
+        val termsDialogVisible: Boolean = false,
+        val continueEnabled: Boolean = false,
+        val loading: Boolean = false,
+        val error: EmailError = EmailError.None
+    )
+    sealed class EmailError {
+        object None : EmailError()
+        object InvalidEmailError: EmailError()
+    }
+
+    data class Details(
+        val firstName: TextFieldValue = TextFieldValue(""),
+        val lastName: TextFieldValue = TextFieldValue(""),
+        val password: TextFieldValue = TextFieldValue(""),
+        val confirmPassword: TextFieldValue = TextFieldValue(""),
+        val continueEnabled: Boolean = false,
+        val loading: Boolean = false,
+        val error: DetailsError = DetailsError.None
+    ) {
+        fun fieldsNotEmpty(): Boolean =
+            firstName.text.isNotEmpty() && lastName.text.isNotEmpty() && password.text.isNotEmpty() && confirmPassword.text.isNotEmpty()
+    }
+    sealed class DetailsError {
+        object None : DetailsError()
+        object InvalidPasswordError: DetailsError()
+        object PasswordsNotMatchingError: DetailsError()
+    }
+}
+

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/EmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/EmailScreen.kt
@@ -1,0 +1,221 @@
+package com.wire.android.ui.authentication.create.personalaccount
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.ClickableText
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.ui.common.textfield.WirePrimaryButton
+import com.wire.android.ui.common.textfield.WireTextField
+import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.CustomTabsHelper
+import com.wire.kalium.logic.configuration.ServerConfig
+
+@Composable
+fun EmailScreen(viewModel: CreatePersonalAccountViewModel, serverConfig: ServerConfig) {
+    EmailContent(
+        state = viewModel.state.email,
+        onEmailChange = viewModel::onEmailChange,
+        onBackPressed = viewModel::goBackToPreviousStep,
+        onContinuePressed = viewModel::onEmailContinue,
+        onLoginPressed = viewModel::openLogin,
+        onTermsDialogDismiss = viewModel::onTermsDialogDismiss,
+        onTermsAccepted = viewModel::onTermsAccepted,
+        websiteBaseUrl = serverConfig.websiteUrl,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+private fun EmailContent(
+    state: CreatePersonalAccountViewState.Email,
+    onEmailChange: (TextFieldValue) -> Unit,
+    onBackPressed: () -> Unit,
+    onContinuePressed: () -> Unit,
+    onLoginPressed: () -> Unit,
+    onTermsDialogDismiss: () -> Unit,
+    onTermsAccepted: () -> Unit,
+    websiteBaseUrl: String
+) {
+    Scaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = 0.dp,
+                title = stringResource(R.string.create_personal_account_title),
+                onNavigationPressed = onBackPressed
+            )
+        },
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Top) {
+            val keyboardController = LocalSoftwareKeyboardController.current
+            Text(
+                text = stringResource(R.string.create_personal_account_email_text),
+                style = MaterialTheme.wireTypography.body01,
+                modifier = Modifier.fillMaxWidth()
+                    .padding(
+                        horizontal = MaterialTheme.wireDimensions.spacing16x,
+                        vertical = MaterialTheme.wireDimensions.spacing24x
+                    )
+            )
+            WireTextField(
+                value = state.email,
+                onValueChange = onEmailChange,
+                placeholderText = stringResource(R.string.create_personal_account_email_placeholder),
+                labelText = stringResource(R.string.create_personal_account_email_label),
+                state = if(state.error is CreatePersonalAccountViewState.EmailError.None) WireTextFieldState.Default
+                    else WireTextFieldState.Error(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+                modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
+            )
+            if(state.error is CreatePersonalAccountViewState.EmailError.InvalidEmailError) EmailErrorText()
+            Spacer(modifier = Modifier.weight(1f))
+            EmailFooter(state = state, onLoginPressed = onLoginPressed, onContinuePressed = onContinuePressed)
+        }
+    }
+    if (state.termsDialogVisible) {
+        val context = LocalContext.current
+        TermsConditionsDialog(
+            onDialogDismiss = onTermsDialogDismiss,
+            onContinuePressed = onTermsAccepted,
+            onViewPolicyPressed = { CustomTabsHelper.launchUrl(context, "https://${websiteBaseUrl}/legal") }
+        )
+    }
+}
+
+@Composable
+private fun EmailErrorText() {
+    val learnMoreTag = "learn_more"
+    val context = LocalContext.current
+    val learnMoreUrl = "https://support.wire.com/hc/en-us/articles/115004082129" //TODO should we keep it in a different way?
+    val learnMoreText = stringResource(id = R.string.label_learn_more)
+    val annotatedText = buildAnnotatedString {
+        append("${stringResource(R.string.create_personal_account_email_error)} ")
+        pushStringAnnotation(tag = learnMoreTag, annotation = learnMoreUrl)
+        withStyle(style = SpanStyle(
+                color = MaterialTheme.wireColorScheme.onTertiaryButtonSelected,
+                fontWeight = MaterialTheme.wireTypography.label05.fontWeight,
+                fontSize = MaterialTheme.wireTypography.label05.fontSize,
+                textDecoration = TextDecoration.Underline
+            )
+        ) { append(learnMoreText) }
+        pop()
+    }
+    ClickableText(
+        modifier = Modifier.fillMaxWidth().padding(
+            vertical = MaterialTheme.wireDimensions.spacing8x,
+            horizontal = MaterialTheme.wireDimensions.spacing16x
+        ),
+        style = MaterialTheme.wireTypography.label04.copy(color = MaterialTheme.wireColorScheme.error, textAlign = TextAlign.Start),
+        text = annotatedText,
+        onClick = { offset ->
+            annotatedText.getStringAnnotations(tag = learnMoreTag, start = offset, end = offset).firstOrNull()?.let {
+                CustomTabsHelper.launchUrl(context, learnMoreUrl)
+            }
+        }
+    )
+}
+
+@Composable
+private fun EmailFooter(state: CreatePersonalAccountViewState.Email, onLoginPressed: () -> Unit, onContinuePressed: () -> Unit) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x)
+    ) {
+        Text(
+            text = "${stringResource(R.string.create_personal_account_email_footer_text)} ",
+            style = MaterialTheme.wireTypography.body02,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = stringResource(R.string.label_login),
+            style = MaterialTheme.wireTypography.body02.copy(textDecoration = TextDecoration.Underline),
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onLoginPressed
+                )
+        )
+    }
+    WirePrimaryButton(
+        text = stringResource(R.string.label_continue),
+        onClick = onContinuePressed,
+        fillMaxWidth = true,
+        loading = state.loading,
+        state = if (state.continueEnabled) WireButtonState.Default else WireButtonState.Disabled,
+        modifier = Modifier.fillMaxWidth().padding(MaterialTheme.wireDimensions.spacing16x),
+    )
+}
+
+@Composable
+private fun TermsConditionsDialog(onDialogDismiss: () -> Unit, onContinuePressed: () -> Unit, onViewPolicyPressed: () -> Unit) {
+    WireDialog(
+        title = stringResource(R.string.create_personal_account_email_terms_dialog_title),
+        text = stringResource(R.string.create_personal_account_email_terms_dialog_text),
+        onDismiss = onDialogDismiss,
+        confirmButtonProperties = WireDialogButtonProperties(
+            onClick = onContinuePressed,
+            text = stringResource(id = R.string.label_continue),
+            type = WireDialogButtonType.Primary,
+        )
+    ) {
+        Column {
+            WireSecondaryButton(
+                text = stringResource(R.string.label_cancel),
+                onClick = onDialogDismiss,
+                fillMaxWidth = true,
+                modifier = Modifier.fillMaxWidth().padding(bottom = MaterialTheme.wireDimensions.spacing8x),
+            )
+            WireSecondaryButton(
+                text = stringResource(R.string.create_personal_account_email_terms_dialog_view_policy),
+                onClick = onViewPolicyPressed,
+                fillMaxWidth = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun EmailScreenPreview() { EmailContent(CreatePersonalAccountViewState.Email(), {}, {}, {}, {}, {}, {}, "") }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/OverviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/OverviewScreen.kt
@@ -99,7 +99,7 @@ private fun OverviewTexts(modifier: Modifier, onLearnMoreClick: () -> Unit) {
             modifier = Modifier.fillMaxWidth()
         )
         Text(
-            text = stringResource(R.string.create_personal_account_link),
+            text = stringResource(R.string.label_learn_more),
             style = MaterialTheme.wireTypography.body02.copy(
                 textDecoration = TextDecoration.Underline,
                 color = MaterialTheme.colorScheme.primary

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/PersonalDetailsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/PersonalDetailsScreen.kt
@@ -1,0 +1,190 @@
+package com.wire.android.ui.authentication.create.personalaccount
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.relocation.BringIntoViewRequester
+import androidx.compose.foundation.relocation.bringIntoViewRequester
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.R
+import com.wire.android.ui.common.appBarElevation
+import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.textfield.WirePasswordTextField
+import com.wire.android.ui.common.textfield.WirePrimaryButton
+import com.wire.android.ui.common.textfield.WireTextField
+import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun DetailsScreen(viewModel: CreatePersonalAccountViewModel) {
+    DetailsContent(
+        state = viewModel.state.details,
+        onFirstNameChange = { viewModel.onDetailsChange(it, DetailsFieldType.FirstName) },
+        onLastNameChange = { viewModel.onDetailsChange(it, DetailsFieldType.LastName) },
+        onPasswordChange = { viewModel.onDetailsChange(it, DetailsFieldType.Password) },
+        onConfirmPasswordChange = { viewModel.onDetailsChange(it, DetailsFieldType.ConfirmPassword) },
+        onBackPressed = viewModel::goBackToPreviousStep,
+        onContinuePressed = viewModel::onDetailsContinue,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+private fun DetailsContent(
+    state: CreatePersonalAccountViewState.Details,
+    onFirstNameChange: (TextFieldValue) -> Unit,
+    onLastNameChange: (TextFieldValue) -> Unit,
+    onPasswordChange: (TextFieldValue) -> Unit,
+    onConfirmPasswordChange: (TextFieldValue) -> Unit,
+    onBackPressed: () -> Unit,
+    onContinuePressed: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+    val coroutineScope = rememberCoroutineScope()
+    Scaffold(
+        topBar = {
+            WireCenterAlignedTopAppBar(
+                elevation = scrollState.appBarElevation(),
+                title = stringResource(R.string.create_personal_account_title),
+                onNavigationPressed = onBackPressed
+            )
+        },
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top,
+            modifier = Modifier.fillMaxHeight().verticalScroll(scrollState)
+        ) {
+            Text(
+                text = stringResource(R.string.create_personal_account_details_text),
+                style = MaterialTheme.wireTypography.body01,
+                modifier = Modifier.fillMaxWidth().padding(
+                        horizontal = MaterialTheme.wireDimensions.spacing16x,
+                        vertical = MaterialTheme.wireDimensions.spacing24x
+                )
+            )
+            NameTextFields(state, onFirstNameChange, onLastNameChange, coroutineScope)
+            PasswordTextFields(state, onPasswordChange, onConfirmPasswordChange, coroutineScope)
+            Spacer(modifier = Modifier.weight(1f))
+            WirePrimaryButton(
+                text = stringResource(R.string.label_continue),
+                onClick = onContinuePressed,
+                fillMaxWidth = true,
+                loading = state.loading,
+                state = if (state.continueEnabled) WireButtonState.Default else WireButtonState.Disabled,
+                modifier = Modifier.fillMaxWidth().padding(MaterialTheme.wireDimensions.spacing16x),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun NameTextFields(
+    state: CreatePersonalAccountViewState.Details,
+    onFirstNameChange: (TextFieldValue) -> Unit,
+    onLastNameChange: (TextFieldValue) -> Unit,
+    coroutineScope: CoroutineScope
+) {
+    WireTextField(
+        value = state.firstName,
+        onValueChange = onFirstNameChange,
+        placeholderText = stringResource(R.string.create_personal_account_details_first_name_placeholder),
+        labelText = stringResource(R.string.create_personal_account_details_first_name_label),
+        labelMandatoryIcon = true,
+        state = WireTextFieldState.Default,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Next),
+        modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x).bringIntoViewOnFocus(coroutineScope)
+    )
+    WireTextField(
+        value = state.lastName,
+        onValueChange = onLastNameChange,
+        placeholderText = stringResource(R.string.create_personal_account_details_last_name_placeholder),
+        labelText = stringResource(R.string.create_personal_account_details_last_name_label),
+        labelMandatoryIcon = true,
+        state = WireTextFieldState.Default,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Next),
+        modifier = Modifier.padding(
+                horizontal = MaterialTheme.wireDimensions.spacing16x,
+                vertical = MaterialTheme.wireDimensions.spacing16x
+            ).bringIntoViewOnFocus(coroutineScope)
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
+@Composable
+private fun PasswordTextFields(
+    state: CreatePersonalAccountViewState.Details,
+    onPasswordChange: (TextFieldValue) -> Unit,
+    onConfirmPasswordChange: (TextFieldValue) -> Unit,
+    coroutineScope: CoroutineScope
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    WirePasswordTextField(
+        value = state.password,
+        onValueChange = onPasswordChange,
+        descriptionText = stringResource(R.string.create_personal_account_details_password_description),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false, imeAction = ImeAction.Next),
+        modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing16x).bringIntoViewOnFocus(coroutineScope),
+        state = if(state.error is CreatePersonalAccountViewState.DetailsError.None) WireTextFieldState.Default
+                else WireTextFieldState.Error()
+    )
+    WirePasswordTextField(
+        value = state.confirmPassword,
+        onValueChange = onConfirmPasswordChange,
+        labelText = stringResource(R.string.create_personal_account_details_confirm_password_label),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false, imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+        modifier = Modifier.padding(
+                horizontal = MaterialTheme.wireDimensions.spacing16x,
+                vertical = MaterialTheme.wireDimensions.spacing16x
+            ).bringIntoViewOnFocus(coroutineScope),
+        state = when(state.error) {
+            CreatePersonalAccountViewState.DetailsError.None ->  WireTextFieldState.Default
+            CreatePersonalAccountViewState.DetailsError.PasswordsNotMatchingError ->
+                WireTextFieldState.Error(stringResource(id = R.string.create_personal_account_details_password_not_matching_error))
+            CreatePersonalAccountViewState.DetailsError.InvalidPasswordError ->
+                WireTextFieldState.Error(stringResource(id = R.string.create_personal_account_details_password_error))
+        }
+    )
+}
+
+@Composable
+@OptIn(ExperimentalFoundationApi::class)
+private fun Modifier.bringIntoViewOnFocus(coroutineScope: CoroutineScope): Modifier {
+    val bringIntoViewRequester = remember { BringIntoViewRequester() }
+    return this.bringIntoViewRequester(bringIntoViewRequester)
+        .onFocusEvent { if(it.isFocused) coroutineScope.launch { bringIntoViewRequester.bringIntoView() } }
+}
+
+@Composable
+@Preview
+private fun DetailsScreenPreview() { DetailsContent(CreatePersonalAccountViewState.Details(), {}, {}, {}, {}, {}, {},) }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/RemoveDevice.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/RemoveDevice.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.authentication.devices
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -9,6 +10,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,6 +38,7 @@ import com.wire.android.ui.common.appBarElevation
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.textfield.WirePasswordTextField
 import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.dialogErrorStrings
 import com.wire.android.util.formatMediumDateTime
 import kotlinx.coroutines.android.awaitFrame
@@ -176,7 +179,7 @@ private fun RemoveDeviceDialog(
                 },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false, imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
-                modifier = Modifier.focusRequester(focusRequester)
+                modifier = Modifier.focusRequester(focusRequester).padding(bottom = MaterialTheme.wireDimensions.spacing8x)
             )
             SideEffect {
                 if (state.keyboardVisible) {

--- a/app/src/main/kotlin/com/wire/android/ui/common/Extensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/Extensions.kt
@@ -1,5 +1,6 @@
 package com.wire.android.ui.common
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.selection.selectable
@@ -49,6 +50,11 @@ internal fun dimensions() = MaterialTheme.wireDimensions
 fun LazyListState.appBarElevation(): Dp = MaterialTheme.wireDimensions.topBarShadowElevation.let {  maxElevation ->
     if (firstVisibleItemIndex == 0) minOf(firstVisibleItemScrollOffset.toFloat().dp, maxElevation)
     else maxElevation
+}
+
+@Composable
+fun ScrollState.appBarElevation(): Dp = MaterialTheme.wireDimensions.topBarShadowElevation.let { maxElevation ->
+    minOf(value.dp, maxElevation)
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -101,7 +101,7 @@ private fun WireDialogContent(
                 modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.dialogTextsSpacing)
             )
             content?.let {
-                Box(modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.dialogButtonsSpacing)) {
+                Box {
                     it.invoke()
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -33,9 +34,11 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -98,7 +101,7 @@ internal fun WireTextField(
             },
         )
         val bottomText = when {
-            state is WireTextFieldState.Error -> state.errorText
+            state is WireTextFieldState.Error && state.errorText != null -> state.errorText
             !descriptionText.isNullOrEmpty() -> descriptionText
             else -> String.EMPTY
         }
@@ -106,6 +109,7 @@ internal fun WireTextField(
             Text(
                 text = bottomText,
                 style = MaterialTheme.wireTypography.label04,
+                textAlign = TextAlign.Start,
                 color = colors.descriptionColor(state).value,
                 modifier = Modifier.padding(top = 4.dp)
             )
@@ -266,7 +270,7 @@ private fun WireTextFieldSuccessPreview() {
 
 sealed class WireTextFieldState {
     object Default : WireTextFieldState()
-    data class Error(val errorText: String) : WireTextFieldState()
+    data class Error(val errorText: String? = null) : WireTextFieldState()
     object Success : WireTextFieldState()
     object Disabled : WireTextFieldState()
 

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireTypography.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireTypography.kt
@@ -15,7 +15,7 @@ data class WireTypography(
     val title01: TextStyle,  val title02: TextStyle,  val title03: TextStyle,  val title04: TextStyle,
     val body01: TextStyle,   val body02: TextStyle,   val body03: TextStyle,   val body04: TextStyle,
     val button01: TextStyle, val button02: TextStyle, val button03: TextStyle, val button04: TextStyle, val button05: TextStyle,
-    val label01: TextStyle,  val label02: TextStyle,  val label03: TextStyle,  val label04: TextStyle,
+    val label01: TextStyle,  val label02: TextStyle,  val label03: TextStyle,  val label04: TextStyle, val label05: TextStyle,
     val badge01: TextStyle,
     val subline01: TextStyle,
 ) {
@@ -44,6 +44,7 @@ private val DefaultWireTypography = WireTypography(
     label02 = WireTypographyBase.Label02,
     label03 = WireTypographyBase.Label03,
     label04 = WireTypographyBase.Label04,
+    label05 = WireTypographyBase.Label05,
     badge01 = WireTypographyBase.Badge01,
     subline01 = WireTypographyBase.SubLine01,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireTypographyBase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireTypographyBase.kt
@@ -105,6 +105,9 @@ object WireTypographyBase {
         lineHeight = 16.sp,
         textAlign = TextAlign.Center
     )
+    val Label05 = Label04.copy(
+        fontWeight = FontWeight.W700
+    )
     val Badge01 = TextStyle(
         fontWeight = FontWeight.W700,
         fontSize = 10.sp,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
@@ -74,7 +74,7 @@ class UserProfileViewModel @Inject constructor(
 
     fun addAccount() {
         viewModelScope.launch {
-            navigationManager.navigate(NavigationCommand(NavigationItem.CreatePrivateAccount.getRouteWithArgs()))
+            navigationManager.navigate(NavigationCommand(NavigationItem.CreatePersonalAccount.getRouteWithArgs()))
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="label_cancel">Cancel</string>
     <string name="label_continue">Continue</string>
     <string name="label_remove">Remove</string>
+    <string name="label_learn_more">Learn more</string>
     <string name="label_removing">Removing...</string>
     <string name="label_logging_in">Logging in...</string>
     <string name="label_membership_guest">Guest</string>
@@ -76,7 +77,24 @@
     <!-- Create Personal Account -->
     <string name="create_personal_account_title">Create a Personal Account</string>
     <string name="create_personal_account_text">Securely chat with friends and family using Wire\'s public cloud server.</string>
-    <string name="create_personal_account_link">Learn more</string>
+    <string name="create_personal_account_email_text">Enter your email to start using the most secure collaboration platform.</string>
+    <string name="create_personal_account_email_placeholder">jane@example.com</string>
+    <string name="create_personal_account_email_label">EMAIL</string>
+    <string name="create_personal_account_email_footer_text">Already have an account? </string>
+    <string name="create_personal_account_email_terms_dialog_title">Terms &amp; Conditions</string>
+    <string name="create_personal_account_email_terms_dialog_text">By clicking continue you are agreeing to our Terms &amp; Conditions and Privacy Policy.</string>
+    <string name="create_personal_account_email_terms_dialog_view_policy">View ToC and Privacy Policy</string>
+    <string name="create_personal_account_email_error">The email address you provided has already.</string>
+    <string name="create_personal_account_details_text">Enter your personal details:</string>
+    <string name="create_personal_account_details_first_name_placeholder">Jane</string>
+    <string name="create_personal_account_details_first_name_label">FIRST NAME</string>
+    <string name="create_personal_account_details_last_name_placeholder">Doe</string>
+    <string name="create_personal_account_details_last_name_label">LAST NAME</string>
+    <string name="create_personal_account_details_password_description">Use at least 8 characters, with one lowercase letter, one capital letter, a number, and a special character.</string>
+    <string name="create_personal_account_details_password_error">Invalid password</string>
+    <string name="create_personal_account_details_password_not_matching_error">Passwords do not match</string>
+    <string name="create_personal_account_details_confirm_password_label">CONFIRM PASSWORD</string>
+
 
     <!-- Home -->
     <string name="home_open_drawer_description">Open drawer</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1069" title="AR-1069" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-1069</a>  implement the registration personal flow UI
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

User needs to be able to fill out a personal account creation flow.

### Solutions

- implemented "enter email" screen UI with error handling
- implemented "enter details" screen UI with error handling

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

https://user-images.githubusercontent.com/30429749/156128296-cc3a1d43-e29d-4dfd-b879-d6eebc8d5046.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
