### PR TITLE
fix: coalesce to empty string name & handle in profile

### DIFF
--- a/.github/workflows/gradle-run-tests.yml
+++ b/.github/workflows/gradle-run-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   gradle-run-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileViewModel.kt
@@ -44,12 +44,12 @@ class UserProfileViewModel @Inject constructor(
             getSelf().collect {
                 userProfileState = SelfUserProfileState(
                     status = UserStatus.AVAILABLE,
-                    fullName = it.name!!,
-                    userName = it.handle!!,
+                    fullName = it.name.orEmpty(),
+                    userName = it.handle.orEmpty(),
                     teamName = it.team,
                     // Add some mocked team
                     otherAccounts = listOf(
-                        OtherAccount("someId", "", it.name!!, "Wire Swiss GmbH"),
+                        OtherAccount("someId", "", it.name.orEmpty(), "Wire Swiss GmbH"),
                         OtherAccount("someId", "", "B. A. Baracus", "The A-Team"),
                     )
                 )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When name or handle are not set, the app crashes.

### Solutions

Coalesce to empty string `name` and `handle`

### Testing

Register an account on web and close the application before setting a username.
Login into the app. The app doesn't crash when accessing the profile screen.

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
