### PR TITLE
chore: update android tools build gradle to 7.0.4 to match kalium

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 private object Dependencies {
-    const val androidBuildTools = "com.android.tools.build:gradle:7.0.3"
+    const val androidBuildTools = "com.android.tools.build:gradle:7.0.4"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
     const val detektGradlePlugin = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.19.0"
     const val junit = "junit:junit:4.13"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Due to updating android tools build from `7.0.3` to `7.0.4` in Kalium, when running latest develop in Kalium and AR project it wouldn't build and would ask to bump the version.

### Solutions

Bumped android tools build gradle versiom from `7.0.3` to `7.0.4` to match Kalium when running latest develop

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
