### PR TITLE
fix: Gradle complaining about 2 google protobuf versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,10 @@ android {
     //configurations.implementation.configure {
     //    exclude(module = "protobuf-java")
     //}
+
+    packagingOptions {
+        resources.pickFirsts.add("google/protobuf/*.proto")
+    }
 }
 
 kapt {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Gradle complaining about 2 google protobuf versions

### Causes (Optional)

having 2 google protobuf versions

### Solutions

Pick one for Gradle because computers are indecisive creatures
