### PR TITLE
chore: upload APK to internal lane on Google Play for commits on `develop` branch too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,9 @@ def defineFlavor() {
     def branchName = env.BRANCH_NAME
     if (branchName == "main") {
         return 'Internal'
-    } else if(branchName == "develop") {
+    } else if (branchName == "develop") {
         return 'Dev'
-    } else if(branchName == "release") {
+    } else if (branchName == "release") {
         return 'Public'
     }
     return 'Dev'
@@ -314,7 +314,7 @@ pipeline {
           }
           stage('Playstore') {
             when {
-              expression { env.trackName != 'None' && env.flavor != 'Dev' && env.CHANGE_ID == null }
+              expression { env.trackName != 'None' && env.CHANGE_ID == null }
             }
             steps {
               echo 'Checking folder before playstore upload'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ def defineFlavor() {
     if (branchName == "main") {
         return 'Internal'
     } else if (branchName == "develop") {
-        return 'Dev'
+        return 'Internal'
     } else if (branchName == "release") {
         return 'Public'
     }
@@ -314,7 +314,7 @@ pipeline {
           }
           stage('Playstore') {
             when {
-              expression { env.trackName != 'None' && env.CHANGE_ID == null }
+              expression { env.trackName != 'None' && env.flavor != 'Dev' && env.CHANGE_ID == null }
             }
             steps {
               echo 'Checking folder before playstore upload'


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Current builds were only uploading the Internal lane on Google Play for commits on `main` branch.


### Solutions

Since the Jenkinsfile trackName is hardcoded to `internal`, with this PR, every commit on `main`, `release` or `develop` branches will trigger an upload of the app's release APK to Google Play , so that it can be tested by design team at any time.

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
