### PR TITLE
fix: add wireapp maven repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ allprojects {
         mavenCentral()
         maven { url = java.net.URI("https://jitpack.io") }
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
+        maven(url = "https://raw.githubusercontent.com/wireapp/wire-maven/main/releases")
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

```
Could not determine the dependencies of task ':app:processDevDebugResources'.
> Could not resolve all task dependencies for configuration ':app:devDebugRuntimeClasspath'.
   > Could not find com.wire:core-crypto-android:0.0.1.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/com/wire/core-crypto-android/0.0.1/core-crypto-android-0.0.1.pom
       - https://repo.maven.apache.org/maven2/com/wire/core-crypto-android/0.0.1/core-crypto-android-0.0.1.pom
       - https://jitpack.io/com/wire/core-crypto-android/0.0.1/core-crypto-android-0.0.1.pom
       - https://oss.sonatype.org/content/repositories/snapshots/com/wire/core-crypto-android/0.0.1/core-crypto-android-0.0.1.pom
     Required by:
         project :app > project :kalium:logic > project :kalium:cryptography

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
```

### Causes (Optional)

missing wireapp repo

### Solutions
add the missing maven repo

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
