### PR TITLE
fix: inject qualifiedID

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/ClientScopeProvider.kt
+++ b/app/src/main/kotlin/com/wire/android/di/ClientScopeProvider.kt
@@ -2,19 +2,20 @@ package com.wire.android.di
 
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.feature.client.ClientScope
+import com.wire.kalium.logic.data.user.UserId
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 
 class ClientScopeProvider @AssistedInject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
-    @Assisted private val userId: String
+    @Assisted private val userId: UserId
 ) {
     val clientScope: ClientScope
         get() = coreLogic.getSessionScope(userId).client
 
     @AssistedFactory
     interface Factory {
-        fun create(userId: String): ClientScopeProvider
+        fun create(userId: UserId): ClientScopeProvider
     }
 }

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -11,6 +11,7 @@ import com.wire.kalium.logic.feature.publicuser.SearchUserDirectoryUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UploadUserAvatarUseCase
+import com.wire.kalium.logic.data.user.UserId
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -58,7 +59,7 @@ class UseCaseModule {
     @ViewModelScoped
     @Provides
     // TODO: can be improved by caching the current session in kalium or changing the scope to ActivityRetainedScoped
-    fun currentSessionProvider(@KaliumCoreLogic coreLogic: CoreLogic): String {
+    fun currentSessionProvider(@KaliumCoreLogic coreLogic: CoreLogic): UserId {
         return runBlocking {
             return@runBlocking when (val result = coreLogic.getAuthenticationScope().session.currentSession.invoke()) {
                 is CurrentSessionResult.Success -> result.authSession.userId
@@ -76,7 +77,7 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun logoutUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String): LogoutUseCase =
+    fun logoutUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): LogoutUseCase =
         coreLogic.getSessionScope(currentAccount).logout
 
     @ViewModelScoped
@@ -111,12 +112,12 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun setUserHandleUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String) =
+    fun setUserHandleUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).users.setUserHandle
 
     @ViewModelScoped
     @Provides
-    fun getConversationsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String) =
+    fun getConversationsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).conversations.getConversations
 
     @ViewModelScoped
@@ -131,54 +132,54 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun selfClientsUseCase(@CurrentAccount currentAccount: String, clientScopeProviderFactory: ClientScopeProvider.Factory) =
+    fun selfClientsUseCase(@CurrentAccount currentAccount: UserId, clientScopeProviderFactory: ClientScopeProvider.Factory) =
         clientScopeProviderFactory.create(currentAccount).clientScope.selfClients
 
     @ViewModelScoped
     @Provides
-    fun getPublicAsset(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String): GetPublicAssetUseCase =
+    fun getPublicAsset(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): GetPublicAssetUseCase =
         coreLogic.getSessionScope(currentAccount).users.getPublicAsset
 
     @ViewModelScoped
     @Provides
-    fun uploadUserAvatar(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String): UploadUserAvatarUseCase =
+    fun uploadUserAvatar(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): UploadUserAvatarUseCase =
         coreLogic.getSessionScope(currentAccount).users.uploadUserAvatar
 
     @ViewModelScoped
     @Provides
-    fun getConversationDetailsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String) =
+    fun getConversationDetailsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).conversations.getConversationDetails
 
     @ViewModelScoped
     @Provides
-    fun getMessagesUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String) =
+    fun getMessagesUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).messages.getRecentMessages
 
     @ViewModelScoped
     @Provides
-    fun deleteClientUseCase(@CurrentAccount currentAccount: String, clientScopeProviderFactory: ClientScopeProvider.Factory) =
+    fun deleteClientUseCase(@CurrentAccount currentAccount: UserId, clientScopeProviderFactory: ClientScopeProvider.Factory) =
         clientScopeProviderFactory.create(currentAccount).clientScope.deleteClient
 
     @ViewModelScoped
     @Provides
-    fun registerClientUseCase(@CurrentAccount currentAccount: String, clientScopeProviderFactory: ClientScopeProvider.Factory) =
+    fun registerClientUseCase(@CurrentAccount currentAccount: UserId, clientScopeProviderFactory: ClientScopeProvider.Factory) =
         clientScopeProviderFactory.create(currentAccount).clientScope.register
 
     @ViewModelScoped
     @Provides
-    fun listenToEventsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String) =
+    fun listenToEventsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).listenToEvents
 
     @ViewModelScoped
     @Provides
-    fun providesGetSelfUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: String): GetSelfUserUseCase =
+    fun providesGetSelfUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): GetSelfUserUseCase =
         coreLogic.getSessionScope(currentAccount).users.getSelfUser
 
     @ViewModelScoped
     @Provides
     fun providesSendTextMessageUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
-        @CurrentAccount currentAccount: String
+        @CurrentAccount currentAccount: UserId
     ): SendTextMessageUseCase =
         coreLogic.getSessionScope(currentAccount).messages.sendTextMessage
 
@@ -186,7 +187,7 @@ class UseCaseModule {
     @Provides
     fun providesSearchKnownUsersUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
-        @CurrentAccount currentAccount: String
+        @CurrentAccount currentAccount: UserId
     ): SearchKnownUsersUseCase =
         coreLogic.getSessionScope(currentAccount).users.searchKnownUsers
 
@@ -194,7 +195,7 @@ class UseCaseModule {
     @Provides
     fun providesSearchPublicUserUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
-        @CurrentAccount currentAccount: String
+        @CurrentAccount currentAccount: UserId
     ): SearchUserDirectoryUseCase =
         coreLogic.getSessionScope(currentAccount).users.searchUserDirectory
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
after the kalium changes in [refactor: replace nonQualifiedID with qualifiedID #335 ](https://github.com/wireapp/kalium/pull/335) `getSessionScope` takes UserId 

### Solutions

replace the nonQualifiedID with qualifiedID

----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
