### PR TITLE
fix: increase CI emulator data partition size.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -125,7 +125,7 @@ pipeline {
           }
           steps {
             sh '''docker rm ${emulatorPrefix}_9 || true
-                  docker run --privileged --network build-machine -d -e DEVICE="Nexus 5" --name ${emulatorPrefix}-${BUILD_NUMBER}_9 budtmo/docker-android-x86-9.0'''
+                  docker run --privileged --network build-machine -d -e DEVICE="Nexus 5" -e DATAPARTITION="2g" --name ${emulatorPrefix}-${BUILD_NUMBER}_9 budtmo/docker-android-x86-9.0'''
           }
         }
 
@@ -135,7 +135,7 @@ pipeline {
           }
           steps {
             sh '''docker rm ${emulatorPrefix}_10 || true
-                  docker run --privileged --network build-machine -d -e DEVICE="Nexus 5" --name ${emulatorPrefix}-${BUILD_NUMBER}_10 budtmo/docker-android-x86-10.0'''
+                  docker run --privileged --network build-machine -d -e DEVICE="Nexus 5" -e DATAPARTITION="2g" --name ${emulatorPrefix}-${BUILD_NUMBER}_10 budtmo/docker-android-x86-10.0'''
           }
         }
       }


### PR DESCRIPTION
CI for the previous commit was failing due to an error regarding insufficient
disk space in the emulator when installing the application for running emulator
tests.

Some spelunking in the docker-android git repository (from which the emulator
containers are built) suggests that we can set a DATAPARTITION environment
variable on the docker command line, which will tell the containerised emulator
to create an appropriately sized data partition.

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Jenkins builds are failing. ❌

### Causes

Lack of disk space on Emulators when installing the APK. 🦣

### Solutions

Increase emulator data partition size! 💿→📀

### Testing

↓ CI Checks ↓ ✅ 

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
