### PR TITLE
ci(jenkins): abort ongoing runs upon new commits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,8 +66,9 @@ pipeline {
       label 'android-reloaded-builder'
       image 'android-reloaded-agent:latest'
     }
-
   }
+
+  options { disableConcurrentBuilds() }
 
   stages {
     stage('Precondition Checks') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ pipeline {
     }
   }
 
-  options { disableConcurrentBuilds() }
+  options { disableConcurrentBuilds(abortPrevious: true) }
 
   stages {
     stage('Precondition Checks') {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Jenkins can be a bit overloaded when we have too many recent builds ordered.

### Causes

At the moment we can have up to 4 jobs running in Jenkins.
Each commit already triggers two builds on our Jenkins runners:
One that checks the branch integrity by itself without any relationship to any PR, and another one that checks if the PR is good to merge against the target branch.

If we send a couple of commits to one branch, Jenkins gets overloaded and new builds are queued up for the future. (See attachments)

### Solutions

Initialy. Abort ongoing builds of the same branch/PR when a new commit is made.

### Testing

Two runs on this PR to see what gives :)
If it works, it works.

### Notes

We could see about disabling builds for branches (other than `main`, of course). And only building PRs.

### Attachments

Current issue. Builds staying 20mins in the queue before starting to build. Screenshot from last Friday (1st of April).
![grafik](https://user-images.githubusercontent.com/9389043/161503836-6a84726c-2173-4b23-9bd9-0dd201e5b303.png)


With these changes, new commits are triggering new builds (number 4) for the branch `ci/disable-concurrent-jenkins-build` and this PR are aborting previous runs (number 3):
![grafik](https://user-images.githubusercontent.com/9389043/161505647-53c19d1c-9821-4c6d-985e-ef1d13d35aab.png)



----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
