### PR TITLE
fix: display type a message hint 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -34,7 +33,6 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
@@ -118,6 +116,72 @@ internal fun WireTextField(
 }
 
 @Composable
+internal fun WireTextFieldTest(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    readOnly: Boolean = false,
+    singleLine: Boolean = true,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions(),
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    placeholderText: String? = null,
+    labelText: String? = null,
+    labelMandatoryIcon: Boolean = false,
+    descriptionText: String? = null,
+    state: WireTextFieldState = WireTextFieldState.Default,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    textStyle: TextStyle = MaterialTheme.wireTypography.body01,
+    placeholderTextStyle: TextStyle = MaterialTheme.wireTypography.body01,
+    inputMinHeight: Dp = MaterialTheme.wireDimensions.textFieldMinHeight,
+    shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.textFieldCornerSize),
+    colors: WireTextFieldColors = wireTextFieldColors(),
+    modifier: Modifier = Modifier
+) {
+    val enabled = state !is WireTextFieldState.Disabled
+
+    Column(modifier = modifier) {
+        if (labelText != null)
+            Label(labelText, labelMandatoryIcon, state, interactionSource, colors)
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            textStyle = textStyle.copy(color = colors.textColor(state = state).value),
+            keyboardOptions = keyboardOptions,
+            keyboardActions = keyboardActions,
+            singleLine = singleLine,
+            readOnly = readOnly,
+            enabled = enabled,
+            cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+            visualTransformation = visualTransformation,
+            interactionSource = interactionSource,
+//            modifier = Modifier
+//                .fillMaxWidth()
+//                .background(color = colors.backgroundColor(state).value, shape = shape)
+//                .border(width = 1.dp, color = colors.borderColor(state, interactionSource).value, shape = shape),
+            decorationBox = { innerTextField ->
+                InnerText(innerTextField, value, leadingIcon, trailingIcon, placeholderText, state, placeholderTextStyle, inputMinHeight)
+            },
+        )
+        val bottomText = when {
+            state is WireTextFieldState.Error && state.errorText != null -> state.errorText
+            !descriptionText.isNullOrEmpty() -> descriptionText
+            else -> String.EMPTY
+        }
+        AnimatedVisibility(visible = bottomText.isNotEmpty()) {
+            Text(
+                text = bottomText,
+                style = MaterialTheme.wireTypography.label04,
+                textAlign = TextAlign.Start,
+                color = colors.descriptionColor(state).value,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@Composable
 private fun Label(
     labelText: String,
     labelMandatoryIcon: Boolean,
@@ -143,7 +207,7 @@ private fun Label(
 }
 
 @Composable
-private fun InnerText(
+ fun InnerText(
     innerTextField: @Composable () -> Unit,
     value: TextFieldValue,
     leadingIcon: @Composable (() -> Unit)? = null,

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -116,7 +116,7 @@ internal fun WireTextField(
 }
 
 @Composable
-internal fun WireTextFieldTest(
+internal fun BorderLessWireTextField(
     value: TextFieldValue,
     onValueChange: (TextFieldValue) -> Unit,
     readOnly: Boolean = false,
@@ -135,7 +135,6 @@ internal fun WireTextFieldTest(
     textStyle: TextStyle = MaterialTheme.wireTypography.body01,
     placeholderTextStyle: TextStyle = MaterialTheme.wireTypography.body01,
     inputMinHeight: Dp = MaterialTheme.wireDimensions.textFieldMinHeight,
-    shape: Shape = RoundedCornerShape(MaterialTheme.wireDimensions.textFieldCornerSize),
     colors: WireTextFieldColors = wireTextFieldColors(),
     modifier: Modifier = Modifier
 ) {
@@ -156,10 +155,6 @@ internal fun WireTextFieldTest(
             cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
             visualTransformation = visualTransformation,
             interactionSource = interactionSource,
-//            modifier = Modifier
-//                .fillMaxWidth()
-//                .background(color = colors.backgroundColor(state).value, shape = shape)
-//                .border(width = 1.dp, color = colors.borderColor(state, interactionSource).value, shape = shape),
             decorationBox = { innerTextField ->
                 InnerText(innerTextField, value, leadingIcon, trailingIcon, placeholderText, state, placeholderTextStyle, inputMinHeight)
             },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -14,25 +14,25 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
-import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
-import com.wire.android.ui.common.bottomsheet.MenuItemIcon
-import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
-import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
+import com.wire.android.ui.common.bottomsheet.MenuItemIcon
+import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.home.conversations.mock.mockMessages
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.Message
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.messagecomposer.MessageComposer
-import kotlinx.coroutines.launch
 import com.wire.android.util.dialogErrorStrings
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -114,7 +114,6 @@ private fun ConversationScreen(
     onSendAttachment: (AttachmentBundle?) -> Unit,
     onBackButtonClick: () -> Unit,
     onDeleteMessage: (String) -> Unit,
-
     ) {
     val conversationScreenState = rememberConversationScreenState()
     val scope = rememberCoroutineScope()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -51,7 +51,7 @@ import com.wire.android.R
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.common.textfield.WireTextFieldTest
+import com.wire.android.ui.common.textfield.BorderLessWireTextField
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.messagecomposer.attachment.AttachmentOptionsComponent
 import com.wire.android.ui.theme.wireColorScheme
@@ -332,11 +332,13 @@ private fun MessageComposerInput(
     onFocusChanged: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    WireTextFieldTest(
+    BorderLessWireTextField(
         value = messageText,
         onValueChange = onMessageTextChanged,
         singleLine = messageComposerInputState == MessageComposeInputState.Enabled,
         textStyle = MaterialTheme.wireTypography.body01,
+        // Add a extra space so that the a cursor is placed one space before "Type a message"
+        placeholderText = " " + stringResource(R.string.label_type_a_message),
         modifier = modifier.then(
             Modifier.onFocusChanged { focusState ->
                 if (focusState.isFocused) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Surface
@@ -52,6 +51,7 @@ import com.wire.android.R
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.textfield.WireTextFieldTest
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.messagecomposer.attachment.AttachmentOptionsComponent
 import com.wire.android.ui.theme.wireColorScheme
@@ -191,7 +191,6 @@ private fun MessageComposer(
                                 else
                                     Modifier
                             )
-
                     ) {
                         transition.AnimatedVisibility(
                             visible = { messageComposerState.messageComposeInputState == MessageComposeInputState.Enabled }
@@ -229,7 +228,6 @@ private fun MessageComposer(
                                                     max = MaterialTheme.wireDimensions.messageComposerActiveInputMaxHeight
                                                 )
                                                 .padding(
-                                                    bottom = MaterialTheme.wireDimensions.spacing16x,
                                                     end = dimensions().messageComposerPaddingEnd
                                                 )
                                         }
@@ -334,7 +332,7 @@ private fun MessageComposerInput(
     onFocusChanged: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    BasicTextField(
+    WireTextFieldTest(
         value = messageText,
         onValueChange = onMessageTextChanged,
         singleLine = messageComposerInputState == MessageComposeInputState.Enabled,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -251,5 +251,6 @@
     <string name="notification_receiver_name">You</string>
     <string name="content_description_copy">Copy</string>
     <string name="content_description_show_more_options">Show more options</string>
+    <string name="label_type_a_message">Type a message</string>
 
 </resources>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- There was no Type a message hint

## Solution 

- Use existing WireTextField create a new type BorderLessWireTextField and remove a border from the WireTextField
- Add a place holder text to BorderLessWireTextField 

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

![image](https://user-images.githubusercontent.com/15973138/161538772-85608525-7bf9-4792-9637-6a1e7586e850.png)
![image](https://user-images.githubusercontent.com/15973138/161538792-68e3a626-6963-4993-8853-de52419feed8.png)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
