### PR TITLE
fix: ui tests isolation and datastore management

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     // Application Specific plugins
     id(BuildPlugins.androidApplication)
     id(BuildPlugins.kotlinAndroid)
-    //id(BuildPlugins.kotlinAndroidExtensions)
+    // id(BuildPlugins.kotlinAndroidExtensions)
     id(BuildPlugins.kotlinKapt)
     id(BuildPlugins.kotlinParcelize)
     id(BuildPlugins.hilt)
@@ -31,9 +31,10 @@ android {
         minSdk = AndroidSdk.min
         targetSdk = AndroidSdk.target
         versionCode = AndroidClient.versionCode
-        versionName = "v${AndroidClient.versionName}(${versionCode})"
+        versionName = "v${AndroidClient.versionName}($versionCode)"
         testInstrumentationRunner = AndroidClient.testRunner
-        setProperty("archivesBaseName", "${applicationId}-v${versionName}(${versionCode})")
+        testInstrumentationRunnerArguments.putAll(mapOf("clearPackageData" to "true"))
+        setProperty("archivesBaseName", "$applicationId-v$versionName($versionCode)")
     }
 
     buildFeatures {
@@ -56,19 +57,19 @@ android {
     sourceSets["androidTest"].includeCommonTestSourceDir()
 
     // Remove protobuf-java as dependencies, so we can get protobuf-lite
-    //configurations.implementation.configure {
+    // configurations.implementation.configure {
     //    exclude(module = "protobuf-java")
-    //}
+    // }
 
     packagingOptions {
         resources.pickFirsts.add("google/protobuf/*.proto")
     }
 
     testOptions {
+        animationsDisabled = true
         unitTests.isReturnDefaultValues = true
         unitTests.isIncludeAndroidResources = true
     }
-
 }
 
 kapt {
@@ -121,7 +122,7 @@ dependencies {
     // Saved state module for ViewModel
     implementation(Libraries.Lifecycle.viewModelSavedState)
 
-    //Compose
+    // Compose
     implementation(Libraries.composeUi)
     implementation(Libraries.composeFoundation)
     implementation(Libraries.composeMaterial3)

--- a/app/src/main/kotlin/com/wire/android/datastore/UserDataStore.kt
+++ b/app/src/main/kotlin/com/wire/android/datastore/UserDataStore.kt
@@ -9,10 +9,10 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.wire.android.model.UserStatus
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 @Singleton
 class UserDataStore @Inject constructor(@ApplicationContext private val context: Context) {
@@ -20,15 +20,14 @@ class UserDataStore @Inject constructor(@ApplicationContext private val context:
     companion object {
         private const val PREFERENCES_NAME = "user_data"
 
-        //keys
+        // keys
         private val SHOW_STATUS_RATIONALE_AVAILABLE = booleanPreferencesKey("show_status_rationale_available")
         private val SHOW_STATUS_RATIONALE_BUSY = booleanPreferencesKey("show_status_rationale_busy")
         private val SHOW_STATUS_RATIONALE_AWAY = booleanPreferencesKey("show_status_rationale_away")
         private val SHOW_STATUS_RATIONALE_NONE = booleanPreferencesKey("show_status_rationale_none")
         private val USER_AVATAR_ASSET_ID = stringPreferencesKey("user_avatar_asset_id")
+        private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
     }
-
-    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = PREFERENCES_NAME)
 
     suspend fun dontShowStatusRationaleAgain(status: UserStatus) {
         context.dataStore.edit { preferences ->


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This new config, address the error from develop caused by multiple datastores. I added a configuration to clear the state of the app before running tests. Also, as suggested by the error, moved the datastore to the companion object for uniqueness 

### Attachments (Optional)

```
Starting 14 tests on Android SDK built for x86_64 - 9

com.wire.android.ui.ConversationScreenTest > userSearchesConversation[Android SDK built for x86_64 - 9] SKIPPED 
Starting 14 tests on Android SDK built for x86 - 10

com.wire.android.ui.ConversationScreenTest > userSearchesConversation[Android SDK built for x86 - 10] SKIPPED 

com.wire.android.ui.LoginScreenTest > login_success_case[Android SDK built for x86_64 - 9] FAILED 
	java.lang.AssertionError: Failed to perform isDisplayed check.
	Reason: Expected exactly '1' node but could not find any node that satisfies: (Text + EditableText contains 'Logging in...' (ignoreCase: false))

com.wire.android.ui.MainScreenTest > iTapCreateEnterpriseButton[Android SDK built for x86 - 10] FAILED 
	java.lang.IllegalStateException: There are multiple DataStores active for the same file: /data/user/0/com.wire.android.dev.debug/files/datastore/user_data.preferences_pb. You should either maintain your DataStore as a singleton or confirm that there is no two DataStore's active on the same file (by confirming that the scope is cancelled).
	at androidx.datastore.core.SingleProcessDataStore$file$2.invoke(SingleProcessDataStore.kt:168)
Tests on Android SDK built for x86 - 10 failed: Instrumentation run failed due to 'Process crashed.'

com.wire.android.ui.RemoveDeviceScreenTest > removeDevice_Successfully[Android SDK built for x86_64 - 9] SKIPPED 

com.wire.android.ui.RemoveDeviceScreenTest > removeDevice_cancel[Android SDK built for x86_64 - 9] SKIPPED 

com.wire.android.ui.RemoveDeviceScreenTest > removeDevice_error_wrongPassword[Android SDK built for x86_64 - 9] SKIPPED 

com.wire.android.ui.UserProfileScreenTest > userProfile_change_status[Android SDK built for x86_64 - 9] SKIPPED 

> Task :app:connectedDevDebugAndroidTest FAILED
```

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
