### PR TITLE
ci: fix UI tests job and disable them on Jenkins

### DIFF
--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          script: ./gradlew connectedCheck
+          script: ./gradlew runAcceptanceTests
             
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.

--- a/.github/workflows/gradle-run-ui-tests.yml
+++ b/.github/workflows/gradle-run-ui-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Android Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: {{ matrix.api-level }}
+          api-level: ${{ matrix.api-level }}
           script: ./gradlew connectedCheck
             
       - name: Cleanup Gradle Cache

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -361,7 +361,7 @@ pipeline {
     adbPort = '5555'
     emulatorPrefix = "${BRANCH_NAME.replaceAll('/','_')}"
     trackName = defineTrackName()
-    runAcceptanceTests = true
+    runAcceptanceTests = false
     runUnitTests = true
     runStaticCodeAnalysis = true
     ENABLE_SIGNING = "TRUE"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

* CI is failing to start UI tests.
![grafik](https://user-images.githubusercontent.com/9389043/161780305-306d569b-94cf-45f1-85ef-7540cd885b6e.png)

* UI tests are unstable. We should stop running them on Jenkins temporarily as they aren't solid yet.

### Causes

* Malformed YML file when getting the `api-level` from the matrix value.

### Solutions

`$` for the YML.
Replace `connectedCheck` with `runAcceptanceTests`, which is a home-made task that we can customise deeper if we want to. Also, runs tests only once instead of once per flavour.

### Testing

`ui-tests` job should run successfully on this PR.
Jenkins should not run `runAcceptanceTests`.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
