### PR TITLE
feat(conversation): display 1:1 conversation title (AR-1178)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -151,8 +151,8 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun getConversationDetailsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
-        coreLogic.getSessionScope(currentAccount).conversations.getConversationDetails
+    fun observeConversationDetailsUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).conversations.observeConversationDetails
 
     @ViewModelScoped
     @Provides

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -4,15 +4,26 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.navigation.NavigationManager
+import com.wire.kalium.logic.data.conversation.Conversation
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.LegalHoldStatus
+import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.feature.asset.SendImageMessageUseCase
-import com.wire.kalium.logic.feature.conversation.GetConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.GetRecentMessagesUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import io.mockk.MockKAnnotations
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.internal.assertEquals
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,8 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 class ConversationsViewModelTest {
-    private lateinit var conversationsViewModel: ConversationViewModel
-
     @MockK
     private lateinit var savedStateHandle: SavedStateHandle
 
@@ -42,7 +51,7 @@ class ConversationsViewModelTest {
     lateinit var deleteMessage: DeleteMessageUseCase
 
     @MockK
-    lateinit var getConversationDetails: GetConversationDetailsUseCase
+    lateinit var observeConversationDetails: ObserveConversationDetailsUseCase
 
     @BeforeEach
     fun setUp() {
@@ -50,19 +59,24 @@ class ConversationsViewModelTest {
         every { savedStateHandle.getLiveData<String>(any()) } returns MutableLiveData("")
         every { savedStateHandle.set(any(), any<String>()) } returns Unit
 
-        conversationsViewModel = ConversationViewModel(
-            savedStateHandle = savedStateHandle,
-            navigationManager = navigationManager,
-            getMessages = getMessages,
-            getConversationDetails = getConversationDetails,
-            sendTextMessage = sendTextMessage,
-            sendImageMessage = sendImageMessage,
-            deleteMessage = deleteMessage
-        )
+        // Default empty values
+        coEvery { getMessages(any()) } returns flowOf(listOf())
+        coEvery { observeConversationDetails(any()) } returns flowOf()
     }
+
+    private fun createTestSubject() = ConversationViewModel(
+        savedStateHandle = savedStateHandle,
+        navigationManager = navigationManager,
+        getMessages = getMessages,
+        observeConversationDetails = observeConversationDetails,
+        sendTextMessage = sendTextMessage,
+        sendImageMessage = sendImageMessage,
+        deleteMessage = deleteMessage
+    )
 
     @Test
     fun `validate deleteMessageDialogsState states when deleteMessageDialog is visible`() {
+        val conversationsViewModel = createTestSubject()
         conversationsViewModel.showDeleteMessageDialog("")
         conversationsViewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
             forYourself = DeleteMessageDialogActiveState.Hidden,
@@ -72,6 +86,7 @@ class ConversationsViewModelTest {
 
     @Test
     fun `validate deleteMessageDialogsState states when deleteMessageForYourselfDialog is visible`() {
+        val conversationsViewModel = createTestSubject()
         conversationsViewModel.showDeleteMessageForYourselfDialog("")
         conversationsViewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
             forYourself = DeleteMessageDialogActiveState.Visible("", conversationsViewModel.conversationId!!),
@@ -79,13 +94,70 @@ class ConversationsViewModelTest {
         )
     }
 
-
     @Test
     fun `validate deleteMessageDialogsState states when dialogs are dismissed`() {
+        val conversationsViewModel = createTestSubject()
         conversationsViewModel.onDialogDismissed()
         conversationsViewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
             forYourself = DeleteMessageDialogActiveState.Hidden,
             forEveryone = DeleteMessageDialogActiveState.Hidden
+        )
+    }
+
+    @Test
+    fun `given a 1 on 1 conversation, when solving the conversation name, then the name of the other user is used`() = runTest {
+        val conversationDetails = CONVERSATION_DETAILS_ONE_ON_ONE
+        val otherUserName = conversationDetails.otherUser.name
+        coEvery { observeConversationDetails(any()) } returns flowOf(conversationDetails)
+
+        val conversationsViewModel = createTestSubject()
+
+        assertEquals(otherUserName, conversationsViewModel.conversationViewState.conversationName)
+    }
+
+    @Test
+    fun `given a group conversation, when solving the conversation name, then the name of the conversation is used`() = runTest {
+        val conversationDetails = testConversationDetailsGroup("Conversation Name Goes Here")
+        val conversationName = conversationDetails.conversation.name
+        coEvery { observeConversationDetails(any()) } returns flowOf(conversationDetails)
+
+        val conversationsViewModel = createTestSubject()
+
+        assertEquals(conversationName, conversationsViewModel.conversationViewState.conversationName)
+    }
+
+    @Test
+    fun `given the conversation name is updated, when solving the conversation name, then the state is updated accordingly`() = runTest {
+        val firstConversationDetails = testConversationDetailsGroup("Conversation Name Goes Here")
+        val secondConversationDetails = testConversationDetailsGroup("Conversation Name Was Updated")
+        val conversationDetailsChannel = Channel<ConversationDetails>(capacity = Channel.UNLIMITED)
+        firstConversationDetails.conversation.name
+
+        coEvery { observeConversationDetails(any()) } returns conversationDetailsChannel.consumeAsFlow()
+
+        val conversationsViewModel = createTestSubject()
+
+        conversationDetailsChannel.send(firstConversationDetails)
+        assertEquals(firstConversationDetails.conversation.name, conversationsViewModel.conversationViewState.conversationName)
+
+        conversationDetailsChannel.send(secondConversationDetails)
+        assertEquals(secondConversationDetails.conversation.name, conversationsViewModel.conversationViewState.conversationName)
+    }
+
+    private companion object {
+        val CONVERSATION_DETAILS_ONE_ON_ONE = ConversationDetails.OneOne(
+            mockk(),
+            mockk<OtherUser>().apply {
+                every { name } returns "Other User Name Goes Here"
+            },
+            ConversationDetails.OneOne.ConnectionState.OUTGOING,
+            LegalHoldStatus.DISABLED
+        )
+
+        fun testConversationDetailsGroup(conversationName: String) = ConversationDetails.Group(
+            mockk<Conversation>().apply {
+                every { name } returns conversationName
+            }
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1178" title="AR-1178" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-1178</a>  Display user metadata in conversation view
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?


### Issues

Correctly display the conversation title in the `ConversationScreen`.

### Solutions

Use the new `ObserveConversationDetailsUseCase` from Kalium.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Just open any (real) conversation from the conversation list.

### Attachments

Where it says "Gonzalo" it used to say "Some Name":

![Screenshot_1649225087](https://user-images.githubusercontent.com/9389043/161906289-a041b51e-c998-4f94-890d-c280a7806560.png)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
