### PR TITLE
feat(conversation): display message sender name (AR-1179)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -156,6 +156,11 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
+    fun observeConversationMembersUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).conversations.observeConversationMembers
+
+    @ViewModelScoped
+    @Provides
     fun getMessagesUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).messages.getRecentMessages
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
@@ -1,0 +1,17 @@
+package com.wire.android.ui.home.conversations
+
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.user.UserId
+
+fun List<MemberDetails>.findSender(senderId: UserId): MemberDetails? = firstOrNull { member ->
+    when (member) {
+        is MemberDetails.Other -> member.otherUser.id == senderId
+        is MemberDetails.Self -> member.selfUser.id == senderId
+    }
+}
+
+val MemberDetails.name
+    get() = when (this) {
+        is MemberDetails.Other -> this.otherUser.name
+        is MemberDetails.Self -> this.selfUser.name
+    }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -21,7 +21,6 @@ import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.User
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.extractImageParams
-import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.message.MessageContent.Text
 import com.wire.kalium.logic.data.conversation.MemberDetails
@@ -195,18 +194,6 @@ class ConversationViewModel @Inject constructor(
         onDialogDismissed()
     }
 
-    private fun List<MemberDetails>.findSender(senderId: UserId): MemberDetails? = firstOrNull { member ->
-        when (member) {
-            is MemberDetails.Other -> member.otherUser.id == senderId
-            is MemberDetails.Self -> member.selfUser.id == senderId
-        }
-    }
-
-    private val MemberDetails.name
-        get() = when (this) {
-            is MemberDetails.Other -> this.otherUser.name
-            is MemberDetails.Self -> this.selfUser.name
-        }
 
     private fun List<com.wire.kalium.logic.data.message.Message>.toUIMessages(members: List<MemberDetails>): List<Message> {
         return map { message ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -21,14 +21,18 @@ import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.User
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.extractImageParams
+import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.message.MessageContent.Text
+import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.feature.asset.SendImageMessageUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.GetRecentMessagesUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
@@ -41,6 +45,7 @@ class ConversationViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
     private val getMessages: GetRecentMessagesUseCase,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
+    private val observeMemberDetails: ObserveConversationMembersUseCase,
     private val sendImageMessage: SendImageMessageUseCase,
     private val sendTextMessage: SendTextMessageUseCase,
     private val deleteMessage: DeleteMessageUseCase
@@ -65,10 +70,11 @@ class ConversationViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getMessages(conversationId!!) // TODO what if null???
-                .collect { dbMessages ->
-                    conversationViewState = conversationViewState.copy(messages = dbMessages.toUIMessages())
-                }
+            getMessages(conversationId!!).combine(observeMemberDetails(conversationId)) { messages, members ->
+                messages.toUIMessages(members)
+            }.collect { uiMessages ->
+                conversationViewState = conversationViewState.copy(messages = uiMessages)
+            }
         }
 
         viewModelScope.launch {
@@ -189,8 +195,22 @@ class ConversationViewModel @Inject constructor(
         onDialogDismissed()
     }
 
-    private fun List<com.wire.kalium.logic.data.message.Message>.toUIMessages(): List<Message> {
+    private fun List<MemberDetails>.findSender(senderId: UserId): MemberDetails? = firstOrNull { member ->
+        when (member) {
+            is MemberDetails.Other -> member.otherUser.id == senderId
+            is MemberDetails.Self -> member.selfUser.id == senderId
+        }
+    }
+
+    private val MemberDetails.name
+        get() = when (this) {
+            is MemberDetails.Other -> this.otherUser.name
+            is MemberDetails.Self -> this.selfUser.name
+        }
+
+    private fun List<com.wire.kalium.logic.data.message.Message>.toUIMessages(members: List<MemberDetails>): List<Message> {
         return map { message ->
+            val sender = members.findSender(message.senderUserId)
             Message(
                 messageContent = TextMessage(
                     messageBody = MessageBody(
@@ -199,7 +219,8 @@ class ConversationViewModel @Inject constructor(
                 ),
                 messageSource = MessageSource.CurrentUser,
                 messageHeader = MessageHeader(
-                    "Cool User",
+                    // TODO: Designs for deleted users?
+                    sender?.name ?: "Deleted User",
                     Membership.None,
                     true,
                     message.date,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1179" title="AR-1179" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-1179</a>  User display name
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Display the message sender's name instead of the hard-coded `"Cool User"`.

### Solutions

Use the new `ObserveConversationMembersUseCase` from Kalium and combine this flow with the messages flow when mapping to UI state.

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution

#### How to Test

Just send/receive messages!

### Attachments

![Screenshot_1649234504](https://user-images.githubusercontent.com/9389043/161933872-ca1db9bb-6927-4e74-87ce-5940c3193653.png)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
