### PR TITLE
refactor: extract email login into separate package [AR-1159]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
@@ -1,98 +1,41 @@
 package com.wire.android.ui.authentication.login
 
-import android.content.Context
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
-import com.wire.android.ui.common.WireDialog
-import com.wire.android.ui.common.WireDialogButtonProperties
-import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.authentication.login.email.LoginEmail
 import com.wire.android.ui.common.appBarElevation
-import com.wire.android.ui.common.button.WireButtonState
-import com.wire.android.ui.common.textfield.WirePasswordTextField
-import com.wire.android.ui.common.textfield.WirePrimaryButton
-import com.wire.android.ui.common.textfield.WireTextField
-import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.WireTheme
-import com.wire.android.ui.theme.wireDimensions
-import com.wire.android.ui.theme.wireTypography
-import com.wire.android.util.CustomTabsHelper
-import com.wire.android.util.DialogErrorStrings
-import com.wire.android.util.dialogErrorStrings
 import com.wire.kalium.logic.configuration.ServerConfig
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 @ExperimentalMaterialApi
 @Composable
 fun LoginScreen(serverConfig: ServerConfig) {
-    val scope = rememberCoroutineScope()
     val loginViewModel: LoginViewModel = hiltViewModel()
-    val loginState: LoginState = loginViewModel.loginState
     LoginContent(
-        loginState = loginState,
-        onUserIdentifierChange = { loginViewModel.onUserIdentifierChange(it) },
         onBackPressed = { loginViewModel.navigateBack() },
-        onPasswordChange = { loginViewModel.onPasswordChange(it) },
-        onDialogDismiss = { loginViewModel.onDialogDismiss() },
-        onRemoveDeviceOpen = { loginViewModel.onTooManyDevicesError() },
-        onLoginButtonClick = suspend { loginViewModel.login(serverConfig) },
-        accountsBaseUrl = serverConfig.accountsBaseUrl,
         //todo: temporary to show the remoteConfig
         serverTitle = serverConfig.title,
-        scope = scope
+        serverConfig = serverConfig
     )
 }
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterial3Api::class)
 @Composable
 private fun LoginContent(
-    loginState: LoginState,
-    onUserIdentifierChange: (TextFieldValue) -> Unit,
     onBackPressed: () -> Unit,
-    onPasswordChange: (TextFieldValue) -> Unit,
-    onDialogDismiss: () -> Unit,
-    onRemoveDeviceOpen: () -> Unit,
-    onLoginButtonClick: suspend () -> Unit,
-    accountsBaseUrl: String,
     serverTitle: String,
-    scope: CoroutineScope
+    serverConfig: ServerConfig
 ) {
     val scrollState = rememberScrollState()
     Scaffold(
@@ -102,170 +45,18 @@ private fun LoginContent(
                 title = "${stringResource(R.string.login_title)} $serverTitle",
                 onNavigationPressed = onBackPressed
             )
-        }
+        },
+        modifier = Modifier.fillMaxHeight(),
     ) {
-        Column(modifier = Modifier
-            .fillMaxHeight()
-            .verticalScroll(scrollState)
-            .padding(MaterialTheme.wireDimensions.spacing16x)
-        ) {
-            Spacer(modifier = Modifier.weight(1f))
-            UserIdentifierInput(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
-                userIdentifier = loginState.userIdentifier,
-                onUserIdentifierChange = onUserIdentifierChange,
-                error = when (loginState.loginError) {
-                    LoginError.TextFieldError.InvalidUserIdentifierError -> stringResource(R.string.login_error_invalid_user_identifier)
-                    else -> null
-                }
-            )
-            PasswordInput(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
-                password = loginState.password,
-                onPasswordChange = onPasswordChange
-            )
-            ForgotPasswordLabel(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
-                accountsBaseUrl = accountsBaseUrl
-            )
-            Spacer(modifier = Modifier.weight(1f))
-
-            LoginButton(
-                modifier = Modifier.fillMaxWidth(),
-                loading = loginState.loading,
-                enabled = loginState.loginEnabled
-            ) {
-                scope.launch {
-                    onLoginButtonClick()
-                }
-            }
-        }
-
-        if (loginState.loginError is LoginError.DialogError) {
-            val (title, message) = when (loginState.loginError) {
-                LoginError.DialogError.InvalidCredentialsError -> DialogErrorStrings(
-                    stringResource(id = R.string.login_error_invalid_credentials_title),
-                    stringResource(id = R.string.login_error_invalid_credentials_message)
-                )
-                // TODO: sync with design about the error message
-                LoginError.DialogError.UserAlreadyExists -> DialogErrorStrings("User Already LoggedIn", "UserAlreadyLoggedIn")
-                is LoginError.DialogError.GenericError -> {
-                    loginState.loginError.coreFailure.dialogErrorStrings(LocalContext.current.resources)
-                }
-            }
-            WireDialog(
-                title = title,
-                text = message,
-                onDismiss = onDialogDismiss,
-                optionButton1Properties = WireDialogButtonProperties(
-                    onClick = onDialogDismiss,
-                    text = stringResource(id = R.string.label_ok),
-                    type = WireDialogButtonType.Primary,
-                )
-            )
-        } else if (loginState.loginError is LoginError.TooManyDevicesError) {
-            onRemoveDeviceOpen()
-        }
-    }
-}
-
-@Composable
-private fun UserIdentifierInput(
-    modifier: Modifier,
-    userIdentifier: TextFieldValue,
-    error: String?,
-    onUserIdentifierChange: (TextFieldValue) -> Unit
-) {
-    WireTextField(
-        value = userIdentifier,
-        onValueChange = onUserIdentifierChange,
-        placeholderText = stringResource(R.string.login_user_identifier_placeholder),
-        labelText = stringResource(R.string.login_user_identifier_label),
-        state = if (error != null) WireTextFieldState.Error(error) else WireTextFieldState.Default,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
-        modifier = modifier.testTag("emailField")
-    )
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-@Composable
-private fun PasswordInput(modifier: Modifier, password: TextFieldValue, onPasswordChange: (TextFieldValue) -> Unit) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-    WirePasswordTextField(
-        value = password,
-        onValueChange = onPasswordChange,
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false, imeAction = ImeAction.Done),
-        keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
-        modifier = modifier.testTag("passwordField")
-    )
-}
-
-@Composable
-private fun ForgotPasswordLabel(modifier: Modifier, accountsBaseUrl: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
-        val context = LocalContext.current
-        Text(
-            text = stringResource(R.string.login_forgot_password),
-            style = MaterialTheme.wireTypography.body02.copy(
-                textDecoration = TextDecoration.Underline,
-                color = MaterialTheme.colorScheme.primary
-            ),
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = { openForgotPasswordPage(context, accountsBaseUrl) }
-                ).testTag("Forgot password?")
-        )
-    }
-}
-
-private fun openForgotPasswordPage(context: Context, accountsBaseUrl: String) {
-    val url = "https://${accountsBaseUrl}/forgot"
-    CustomTabsHelper.launchUrl(context, url)
-}
-
-@OptIn(ExperimentalAnimationApi::class)
-@Composable
-private fun LoginButton(modifier: Modifier, loading: Boolean, enabled: Boolean, onClick: () -> Unit) {
-    val interactionSource = remember { MutableInteractionSource() }
-    Column(modifier = modifier) {
-        val text = if (loading) stringResource(R.string.label_logging_in) else stringResource(R.string.label_login)
-        WirePrimaryButton(
-            text = text,
-            onClick = onClick,
-            state = if (enabled) WireButtonState.Default else WireButtonState.Disabled,
-            loading = loading,
-            interactionSource = interactionSource,
-            modifier = Modifier.fillMaxWidth().testTag("loginButton")
-        )
+        LoginEmail(serverConfig = serverConfig, scrollState = scrollState)
     }
 }
 
 @Preview
 @Composable
 private fun LoginScreenPreview() {
-    val scope = rememberCoroutineScope()
     WireTheme(isPreview = true) {
-        LoginContent(
-            loginState = LoginState(),
-            onUserIdentifierChange = { },
-            onBackPressed = { },
-            onPasswordChange = { },
-            onDialogDismiss = { },
-            onRemoveDeviceOpen = { },
-            onLoginButtonClick = suspend { },
-            accountsBaseUrl = "",
-            serverTitle = "",
-            scope = scope
-        )
+        LoginContent(onBackPressed = { }, serverTitle = "", serverConfig = ServerConfig.STAGING)
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -1,157 +1,20 @@
 package com.wire.android.ui.authentication.login
 
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.di.ClientScopeProvider
-import com.wire.android.navigation.BackStackMode
-import com.wire.android.navigation.NavigationCommand
-import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
-import com.wire.android.util.EMPTY
-import com.wire.kalium.logic.configuration.ServerConfig
-import com.wire.kalium.logic.feature.auth.AuthenticationResult
-import com.wire.kalium.logic.feature.auth.LoginUseCase
-import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
-import com.wire.kalium.logic.feature.client.RegisterClientResult
-import com.wire.kalium.logic.data.user.UserId
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ExperimentalMaterialApi
 @HiltViewModel
-class LoginViewModel @Inject constructor(
-    private val loginUseCase: LoginUseCase,
-    private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
-    private val clientScopeProviderFactory: ClientScopeProvider.Factory,
-    private val savedStateHandle: SavedStateHandle,
-    private val navigationManager: NavigationManager,
-) : ViewModel() {
-
-    var loginState by mutableStateOf(
-        LoginState(
-            userIdentifier = TextFieldValue(savedStateHandle.get(USER_IDENTIFIER_SAVED_STATE_KEY) ?: String.EMPTY),
-            password = TextFieldValue(String.EMPTY)
-        )
-    )
-        private set
-
-    fun login(serverConfig: ServerConfig) {
-        loginState = loginState.copy(loading = true, loginError = LoginError.None).updateLoginEnabled()
-        viewModelScope.launch {
-            val authSession = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true, serverConfig).let {
-                when (it) {
-                    is AuthenticationResult.Failure -> {
-                        updateLoginError(it.toLoginError())
-                        return@launch
-                    }
-                    is AuthenticationResult.Success -> it.userSession
-                }
-            }
-            val storedUserId = addAuthenticatedUser(authSession, false).let {
-                when (it) {
-                    is AddAuthenticatedUserUseCase.Result.Failure -> {
-                        updateLoginError(it.toLoginError())
-                        return@launch
-                    }
-                    is AddAuthenticatedUserUseCase.Result.Success -> it.userId
-                }
-            }
-            registerClient(storedUserId).let {
-                when (it) {
-                    is RegisterClientResult.Failure -> {
-                        updateLoginError(it.toLoginError())
-                        return@launch
-                    }
-                    is RegisterClientResult.Success -> navigateToConvScreen()
-                }
-            }
-        }
-    }
-
-    private suspend fun registerClient(userId: UserId): RegisterClientResult {
-        val clientScope = clientScopeProviderFactory.create(userId).clientScope
-        return clientScope.register(loginState.password.text, null)
-    }
-
-    fun onUserIdentifierChange(newText: TextFieldValue) {
-        // in case an error is showing e.g. inline error is should be cleared
-        if (loginState.loginError is LoginError.TextFieldError && newText != loginState.userIdentifier) {
-            clearLoginError()
-        }
-        loginState = loginState.copy(userIdentifier = newText).updateLoginEnabled()
-        savedStateHandle.set(USER_IDENTIFIER_SAVED_STATE_KEY, newText.text)
-    }
-
-    fun onPasswordChange(newText: TextFieldValue) {
-        loginState = loginState.copy(password = newText).updateLoginEnabled()
-    }
-
-    private fun updateLoginError(loginError: LoginError) {
-        loginState = if (loginError is LoginError.None) {
-            loginState.copy(loginError = loginError)
-        } else {
-            loginState.copy(loading = false, loginError = loginError).updateLoginEnabled()
-        }
-
-    }
-
-    fun onDialogDismiss() {
-        clearLoginError()
-    }
-
-    private fun clearLoginError() {
-        updateLoginError(LoginError.None)
-    }
-
-    fun onTooManyDevicesError() {
-        clearLoginError()
-        viewModelScope.launch {
-            navigateToRemoveDevicesScreen()
-        }
-    }
+class LoginViewModel @Inject constructor(private val navigationManager: NavigationManager) : ViewModel() {
 
     fun navigateBack() {
         viewModelScope.launch {
             navigationManager.navigateBack()
         }
     }
-
-    private fun LoginState.updateLoginEnabled() =
-        copy(loginEnabled = userIdentifier.text.isNotEmpty() && password.text.isNotEmpty() && !loading)
-
-
-    private suspend fun navigateToRemoveDevicesScreen() =
-        navigationManager.navigate(NavigationCommand(NavigationItem.RemoveDevices.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
-
-    private suspend fun navigateToConvScreen() =
-        navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
-
-    private companion object {
-        const val USER_IDENTIFIER_SAVED_STATE_KEY = "user_identifier"
-    }
-}
-
-// TODO: login error Mapper ?
-private fun AuthenticationResult.Failure.toLoginError() = when (this) {
-    is AuthenticationResult.Failure.Generic -> LoginError.DialogError.GenericError(this.genericFailure)
-    AuthenticationResult.Failure.InvalidCredentials -> LoginError.DialogError.InvalidCredentialsError
-    AuthenticationResult.Failure.InvalidUserIdentifier -> LoginError.TextFieldError.InvalidUserIdentifierError
-}
-
-private fun RegisterClientResult.Failure.toLoginError() = when (this) {
-    is RegisterClientResult.Failure.Generic -> LoginError.DialogError.GenericError(this.genericFailure)
-    RegisterClientResult.Failure.InvalidCredentials -> LoginError.DialogError.InvalidCredentialsError
-    RegisterClientResult.Failure.TooManyClients -> LoginError.TooManyDevicesError
-}
-
-private fun AddAuthenticatedUserUseCase.Result.Failure.toLoginError(): LoginError = when (this) {
-    is AddAuthenticatedUserUseCase.Result.Failure.Generic -> LoginError.DialogError.GenericError(this.genericFailure)
-    AddAuthenticatedUserUseCase.Result.Failure.UserAlreadyExists -> LoginError.DialogError.UserAlreadyExists
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmail.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmail.kt
@@ -1,0 +1,257 @@
+package com.wire.android.ui.authentication.login.email
+
+import android.content.Context
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.wire.android.R
+import com.wire.android.ui.authentication.login.LoginEmailError
+import com.wire.android.ui.authentication.login.LoginEmailState
+import com.wire.android.ui.common.WireDialog
+import com.wire.android.ui.common.WireDialogButtonProperties
+import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.textfield.WirePasswordTextField
+import com.wire.android.ui.common.textfield.WirePrimaryButton
+import com.wire.android.ui.common.textfield.WireTextField
+import com.wire.android.ui.common.textfield.WireTextFieldState
+import com.wire.android.ui.theme.WireTheme
+import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.DialogErrorStrings
+import com.wire.android.util.dialogErrorStrings
+import com.wire.kalium.logic.configuration.ServerConfig
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun LoginEmail(
+    serverConfig: ServerConfig,
+    scrollState: ScrollState = rememberScrollState()
+) {
+    val scope = rememberCoroutineScope()
+    val loginEmailViewModel: LoginEmailViewModel = hiltViewModel()
+    val loginEmailState: LoginEmailState = loginEmailViewModel.loginState
+    LoginEmailContent(
+        scrollState = scrollState,
+        loginEmailState = loginEmailState,
+        onUserIdentifierChange = { loginEmailViewModel.onUserIdentifierChange(it) },
+        onPasswordChange = { loginEmailViewModel.onPasswordChange(it) },
+        onDialogDismiss = { loginEmailViewModel.onDialogDismiss() },
+        onRemoveDeviceOpen = { loginEmailViewModel.onTooManyDevicesError() },
+        onLoginButtonClick = suspend { loginEmailViewModel.login(serverConfig) },
+        accountsBaseUrl = serverConfig.accountsBaseUrl,
+        scope = scope
+    )
+}
+
+@Composable
+private fun LoginEmailContent(
+    scrollState: ScrollState,
+    loginEmailState: LoginEmailState,
+    onUserIdentifierChange: (TextFieldValue) -> Unit,
+    onPasswordChange: (TextFieldValue) -> Unit,
+    onDialogDismiss: () -> Unit,
+    onRemoveDeviceOpen: () -> Unit,
+    onLoginButtonClick: suspend () -> Unit,
+    accountsBaseUrl: String,
+    scope: CoroutineScope
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .verticalScroll(scrollState)
+            .padding(MaterialTheme.wireDimensions.spacing16x)
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+        UserIdentifierInput(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
+            userIdentifier = loginEmailState.userIdentifier,
+            onUserIdentifierChange = onUserIdentifierChange,
+            error = when (loginEmailState.loginEmailError) {
+                LoginEmailError.TextFieldError.InvalidUserIdentifierError -> stringResource(R.string.login_error_invalid_user_identifier)
+                else -> null
+            }
+        )
+        PasswordInput(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
+            password = loginEmailState.password,
+            onPasswordChange = onPasswordChange
+        )
+        ForgotPasswordLabel(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
+            accountsBaseUrl = accountsBaseUrl
+        )
+        Spacer(modifier = Modifier.weight(1f))
+
+        LoginButton(
+            modifier = Modifier.fillMaxWidth(),
+            loading = loginEmailState.loading,
+            enabled = loginEmailState.loginEnabled
+        ) {
+            scope.launch {
+                onLoginButtonClick()
+            }
+        }
+    }
+
+    if (loginEmailState.loginEmailError is LoginEmailError.DialogError) {
+        val (title, message) = when (loginEmailState.loginEmailError) {
+            LoginEmailError.DialogError.InvalidCredentialsError -> DialogErrorStrings(
+                stringResource(id = R.string.login_error_invalid_credentials_title),
+                stringResource(id = R.string.login_error_invalid_credentials_message)
+            )
+            // TODO: sync with design about the error message
+            LoginEmailError.DialogError.UserAlreadyExists -> DialogErrorStrings("User Already LoggedIn", "UserAlreadyLoggedIn")
+            is LoginEmailError.DialogError.GenericError -> {
+                loginEmailState.loginEmailError.coreFailure.dialogErrorStrings(LocalContext.current.resources)
+            }
+        }
+        WireDialog(
+            title = title,
+            text = message,
+            onDismiss = onDialogDismiss,
+            optionButton1Properties = WireDialogButtonProperties(
+                onClick = onDialogDismiss,
+                text = stringResource(id = R.string.label_ok),
+                type = WireDialogButtonType.Primary,
+            )
+        )
+    } else if (loginEmailState.loginEmailError is LoginEmailError.TooManyDevicesError) {
+        onRemoveDeviceOpen()
+    }
+}
+
+@Composable
+private fun UserIdentifierInput(
+    modifier: Modifier,
+    userIdentifier: TextFieldValue,
+    error: String?,
+    onUserIdentifierChange: (TextFieldValue) -> Unit
+) {
+    WireTextField(
+        value = userIdentifier,
+        onValueChange = onUserIdentifierChange,
+        placeholderText = stringResource(R.string.login_user_identifier_placeholder),
+        labelText = stringResource(R.string.login_user_identifier_label),
+        state = if (error != null) WireTextFieldState.Error(error) else WireTextFieldState.Default,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
+        modifier = modifier.testTag("emailField")
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun PasswordInput(modifier: Modifier, password: TextFieldValue, onPasswordChange: (TextFieldValue) -> Unit) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    WirePasswordTextField(
+        value = password,
+        onValueChange = onPasswordChange,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, autoCorrect = false, imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+        modifier = modifier.testTag("passwordField")
+    )
+}
+
+@Composable
+private fun ForgotPasswordLabel(modifier: Modifier, accountsBaseUrl: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
+        val context = LocalContext.current
+        Text(
+            text = stringResource(R.string.login_forgot_password),
+            style = MaterialTheme.wireTypography.body02.copy(
+                textDecoration = TextDecoration.Underline,
+                color = MaterialTheme.colorScheme.primary
+            ),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = { openForgotPasswordPage(context, accountsBaseUrl) }
+                )
+                .testTag("Forgot password?")
+        )
+    }
+}
+
+private fun openForgotPasswordPage(context: Context, accountsBaseUrl: String) {
+    val url = "https://${accountsBaseUrl}/forgot"
+    CustomTabsHelper.launchUrl(context, url)
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+private fun LoginButton(modifier: Modifier, loading: Boolean, enabled: Boolean, onClick: () -> Unit) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Column(modifier = modifier) {
+        val text = if (loading) stringResource(R.string.label_logging_in) else stringResource(R.string.label_login)
+        WirePrimaryButton(
+            text = text,
+            onClick = onClick,
+            state = if (enabled) WireButtonState.Default else WireButtonState.Disabled,
+            loading = loading,
+            interactionSource = interactionSource,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("loginButton")
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LoginEmailScreenPreview() {
+    val scope = rememberCoroutineScope()
+    WireTheme(isPreview = true) {
+        LoginEmailContent(
+            scrollState = rememberScrollState(),
+            loginEmailState = LoginEmailState(),
+            onUserIdentifierChange = { },
+            onPasswordChange = { },
+            onDialogDismiss = { },
+            onRemoveDeviceOpen = { },
+            onLoginButtonClick = suspend { },
+            accountsBaseUrl = "",
+            scope = scope
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailState.kt
@@ -3,23 +3,23 @@ package com.wire.android.ui.authentication.login
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.kalium.logic.CoreFailure
 
-data class LoginState(
+data class LoginEmailState(
     val userIdentifier: TextFieldValue = TextFieldValue(""),
     val password: TextFieldValue = TextFieldValue(""),
     val loading: Boolean = false,
     val loginEnabled: Boolean = false,
-    val loginError: LoginError = LoginError.None
+    val loginEmailError: LoginEmailError = LoginEmailError.None
 )
 
-sealed class LoginError {
-    object None: LoginError()
-    sealed class TextFieldError: LoginError() {
+sealed class LoginEmailError {
+    object None: LoginEmailError()
+    sealed class TextFieldError: LoginEmailError() {
         object InvalidUserIdentifierError: TextFieldError()
     }
-    sealed class DialogError: LoginError() {
+    sealed class DialogError: LoginEmailError() {
         object InvalidCredentialsError: DialogError()
         object UserAlreadyExists: DialogError()
         data class GenericError(val coreFailure: CoreFailure): DialogError()
     }
-    object TooManyDevicesError: LoginError()
+    object TooManyDevicesError: LoginEmailError()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -1,0 +1,154 @@
+package com.wire.android.ui.authentication.login.email
+
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.android.di.ClientScopeProvider
+import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.NavigationCommand
+import com.wire.android.navigation.NavigationItem
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.authentication.login.LoginEmailError
+import com.wire.android.ui.authentication.login.LoginEmailState
+import com.wire.android.util.EMPTY
+import com.wire.kalium.logic.configuration.ServerConfig
+import com.wire.kalium.logic.feature.auth.AuthenticationResult
+import com.wire.kalium.logic.feature.auth.LoginUseCase
+import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
+import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.data.user.UserId
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@ExperimentalMaterialApi
+@HiltViewModel
+class LoginEmailViewModel @Inject constructor(
+    private val loginUseCase: LoginUseCase,
+    private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
+    private val clientScopeProviderFactory: ClientScopeProvider.Factory,
+    private val savedStateHandle: SavedStateHandle,
+    private val navigationManager: NavigationManager
+) : ViewModel() {
+
+    var loginState by mutableStateOf(
+        LoginEmailState(
+            userIdentifier = TextFieldValue(savedStateHandle.get(USER_IDENTIFIER_SAVED_STATE_KEY) ?: String.EMPTY),
+            password = TextFieldValue(String.EMPTY)
+        )
+    )
+        private set
+
+    fun login(serverConfig: ServerConfig) {
+        loginState = loginState.copy(loading = true, loginEmailError = LoginEmailError.None).updateLoginEnabled()
+        viewModelScope.launch {
+            val authSession = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true, serverConfig)
+                .let {
+                    when (it) {
+                        is AuthenticationResult.Failure -> {
+                            updateLoginError(it.toLoginError())
+                            return@launch
+                        }
+                        is AuthenticationResult.Success -> it.userSession
+                    }
+                }
+            val storedUserId = addAuthenticatedUser(authSession, false).let {
+                when (it) {
+                    is AddAuthenticatedUserUseCase.Result.Failure -> {
+                        updateLoginError(it.toLoginError())
+                        return@launch
+                    }
+                    is AddAuthenticatedUserUseCase.Result.Success -> it.userId
+                }
+            }
+            registerClient(storedUserId).let {
+                when (it) {
+                    is RegisterClientResult.Failure -> {
+                        updateLoginError(it.toLoginError())
+                        return@launch
+                    }
+                    is RegisterClientResult.Success -> navigateToConvScreen()
+                }
+            }
+        }
+    }
+
+    private suspend fun registerClient(userId: UserId): RegisterClientResult {
+        val clientScope = clientScopeProviderFactory.create(userId).clientScope
+        return clientScope.register(loginState.password.text, null)
+    }
+
+    fun onUserIdentifierChange(newText: TextFieldValue) {
+        // in case an error is showing e.g. inline error is should be cleared
+        if (loginState.loginEmailError is LoginEmailError.TextFieldError && newText != loginState.userIdentifier) {
+            clearLoginError()
+        }
+        loginState = loginState.copy(userIdentifier = newText).updateLoginEnabled()
+        savedStateHandle.set(USER_IDENTIFIER_SAVED_STATE_KEY, newText.text)
+    }
+
+    fun onPasswordChange(newText: TextFieldValue) {
+        loginState = loginState.copy(password = newText).updateLoginEnabled()
+    }
+
+    private fun updateLoginError(loginError: LoginEmailError) {
+        loginState = if (loginError is LoginEmailError.None) {
+            loginState.copy(loginEmailError = loginError)
+        } else {
+            loginState.copy(loading = false, loginEmailError = loginError).updateLoginEnabled()
+        }
+
+    }
+
+    fun onDialogDismiss() {
+        clearLoginError()
+    }
+
+    private fun clearLoginError() {
+        updateLoginError(LoginEmailError.None)
+    }
+
+    fun onTooManyDevicesError() {
+        clearLoginError()
+        viewModelScope.launch {
+            navigateToRemoveDevicesScreen()
+        }
+    }
+
+    private fun LoginEmailState.updateLoginEnabled() =
+        copy(loginEnabled = userIdentifier.text.isNotEmpty() && password.text.isNotEmpty() && !loading)
+
+
+    private suspend fun navigateToRemoveDevicesScreen() =
+        navigationManager.navigate(NavigationCommand(NavigationItem.RemoveDevices.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
+
+    private suspend fun navigateToConvScreen() =
+        navigationManager.navigate(NavigationCommand(NavigationItem.Home.getRouteWithArgs(), BackStackMode.CLEAR_WHOLE))
+
+    private companion object {
+        const val USER_IDENTIFIER_SAVED_STATE_KEY = "user_identifier"
+    }
+}
+
+// TODO: login error Mapper ?
+private fun AuthenticationResult.Failure.toLoginError() = when (this) {
+    is AuthenticationResult.Failure.Generic -> LoginEmailError.DialogError.GenericError(this.genericFailure)
+    AuthenticationResult.Failure.InvalidCredentials -> LoginEmailError.DialogError.InvalidCredentialsError
+    AuthenticationResult.Failure.InvalidUserIdentifier -> LoginEmailError.TextFieldError.InvalidUserIdentifierError
+}
+
+private fun RegisterClientResult.Failure.toLoginError() = when (this) {
+    is RegisterClientResult.Failure.Generic -> LoginEmailError.DialogError.GenericError(this.genericFailure)
+    RegisterClientResult.Failure.InvalidCredentials -> LoginEmailError.DialogError.InvalidCredentialsError
+    RegisterClientResult.Failure.TooManyClients -> LoginEmailError.TooManyDevicesError
+}
+
+private fun AddAuthenticatedUserUseCase.Result.Failure.toLoginError(): LoginEmailError = when (this) {
+    is AddAuthenticatedUserUseCase.Result.Failure.Generic -> LoginEmailError.DialogError.GenericError(this.genericFailure)
+    AddAuthenticatedUserUseCase.Result.Failure.UserAlreadyExists -> LoginEmailError.DialogError.UserAlreadyExists
+}

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireColorScheme.kt
@@ -61,6 +61,7 @@ data class WireColorScheme(
         background = background,                        onBackground = onBackground,
         surface = surface,                              onSurface = onSurface,
         surfaceVariant = divider,                       onSurfaceVariant = onSurface,
+        surfaceTint = primary,
         inverseSurface = onPrimaryButtonDisabled,       inverseOnSurface = Color.White,
         error = error,                                  onError = onError,
         errorContainer = errorOutline,                  onErrorContainer = error,

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/LoginViewModelTest.kt
@@ -1,0 +1,37 @@
+package com.wire.android.ui.authentication
+
+import androidx.compose.material.ExperimentalMaterialApi
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.authentication.login.LoginViewModel
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalMaterialApi::class, ExperimentalCoroutinesApi::class)
+@ExtendWith(CoroutineTestExtension::class)
+class LoginViewModelTest {
+
+    @MockK
+    private lateinit var navigationManager: NavigationManager
+
+    private lateinit var loginViewModel: LoginViewModel
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        loginViewModel = LoginViewModel(navigationManager)
+    }
+
+    @Test
+    fun `when navigateBack is called, execute navigationManager navigateBack`() {
+        coEvery { navigationManager.navigateBack() } returns Unit
+        loginViewModel.navigateBack()
+        coVerify(exactly = 1) { navigationManager.navigateBack() }
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -1,4 +1,4 @@
-package com.wire.android.ui.authentication.login
+package com.wire.android.ui.authentication.login.email
 
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.ui.text.input.TextFieldValue
@@ -9,6 +9,7 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItemDestinationsRoutes
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.authentication.login.LoginEmailError
 import com.wire.android.util.EMPTY
 import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.configuration.ServerConfig
@@ -42,7 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
-class LoginViewModelTest {
+class LoginEmailViewModelTest {
 
     @MockK
     private lateinit var loginUseCase: LoginUseCase
@@ -65,7 +66,7 @@ class LoginViewModelTest {
     @MockK
     private lateinit var client: Client
 
-    private lateinit var loginViewModel: LoginViewModel
+    private lateinit var loginViewModel: LoginEmailViewModel
 
     private val apiBaseUrl: String = "apiBaseUrl"
     private val userId: QualifiedID = QualifiedID("userId", "domain")
@@ -79,7 +80,7 @@ class LoginViewModelTest {
         every { clientScope.register } returns registerClientUseCase
         every { serverConfig.apiBaseUrl } returns apiBaseUrl
         every { authSession.userId } returns userId
-        loginViewModel = LoginViewModel(
+        loginViewModel = LoginEmailViewModel(
             loginUseCase,
             addAuthenticatedUserUseCase,
             clientScopeProviderFactory,
@@ -144,14 +145,14 @@ class LoginViewModelTest {
     fun `when button is clicked and login returns InvalidUserIdentifier error, InvalidUserIdentifierError is passed`() {
         coEvery { loginUseCase.invoke(any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidUserIdentifier
         runTest { loginViewModel.login(serverConfig) }
-        loginViewModel.loginState.loginError shouldBeInstanceOf LoginError.TextFieldError.InvalidUserIdentifierError::class
+        loginViewModel.loginState.loginEmailError shouldBeInstanceOf LoginEmailError.TextFieldError.InvalidUserIdentifierError::class
     }
 
     @Test
     fun `when button is clicked, with InvalidCredentials error, InvalidCredentialsError is passed`() {
         coEvery { loginUseCase.invoke(any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials
         runTest { loginViewModel.login(serverConfig) }
-        loginViewModel.loginState.loginError shouldBeInstanceOf LoginError.DialogError.InvalidCredentialsError::class
+        loginViewModel.loginState.loginEmailError shouldBeInstanceOf LoginEmailError.DialogError.InvalidCredentialsError::class
     }
 
     @Test
@@ -159,8 +160,8 @@ class LoginViewModelTest {
         coEvery { loginUseCase.invoke(any(), any(), any(), any()) } returns
                 AuthenticationResult.Failure.Generic(NetworkFailure.NoNetworkConnection)
         runTest { loginViewModel.login(serverConfig) }
-        loginViewModel.loginState.loginError shouldBeInstanceOf LoginError.DialogError.GenericError::class
-        (loginViewModel.loginState.loginError as LoginError.DialogError.GenericError).coreFailure shouldBe
+        loginViewModel.loginState.loginEmailError shouldBeInstanceOf LoginEmailError.DialogError.GenericError::class
+        (loginViewModel.loginState.loginEmailError as LoginEmailError.DialogError.GenericError).coreFailure shouldBe
                 NetworkFailure.NoNetworkConnection
     }
 
@@ -168,9 +169,9 @@ class LoginViewModelTest {
     fun `when login returns DialogError and dialog is dismissed, hide error`() {
         coEvery { loginUseCase.invoke(any(), any(), any(), any()) } returns AuthenticationResult.Failure.InvalidCredentials
         runTest { loginViewModel.login(serverConfig) }
-        loginViewModel.loginState.loginError shouldBeInstanceOf LoginError.DialogError.InvalidCredentialsError::class
+        loginViewModel.loginState.loginEmailError shouldBeInstanceOf LoginEmailError.DialogError.InvalidCredentialsError::class
         loginViewModel.onDialogDismiss()
-        loginViewModel.loginState.loginError shouldBe LoginError.None
+        loginViewModel.loginState.loginEmailError shouldBe LoginEmailError.None
     }
 
     @Test
@@ -178,7 +179,7 @@ class LoginViewModelTest {
         coEvery { loginUseCase.invoke(any(), any(), any(), any()) } returns AuthenticationResult.Success(authSession)
         coEvery { addAuthenticatedUserUseCase.invoke(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Failure.UserAlreadyExists
         runTest { loginViewModel.login(serverConfig) }
-        loginViewModel.loginState.loginError shouldBeInstanceOf LoginError.DialogError.UserAlreadyExists::class
+        loginViewModel.loginState.loginEmailError shouldBeInstanceOf LoginEmailError.DialogError.UserAlreadyExists::class
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -74,7 +74,7 @@ object Libraries {
         const val fragment = "1.2.5"
         const val compose = "1.2.0-alpha03"
         const val composeMaterial = compose
-        const val composeMaterial3 = "1.0.0-alpha05"
+        const val composeMaterial3 = "1.0.0-alpha08"
         const val composeActivity = "1.4.0"
         const val composeNavigation = "2.4.0-beta02"
         const val accompanist = "0.24.2-alpha"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is only a single type of login in the app which is the one using email/user handle. We need to add the second method - SSO login so it's necessary to first extract and separate email login with its viewmodel and composables into its own package.

### Solutions

All logic and views related to email login extracted to another package `com.wire.android.ui.authentication.login.email`. The main login screen now will be using `LoginEmail` screen from this package, and in the next PR it will have a tab row with both email and sso login.

### Testing

Added LoginEmailViewModelTest and modified LoginViewModelTest.

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Apart from automated tests, you can open login screen and check if anything changed from the UI and UX perspective (it shouldn't 😄 ).

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
