### PR TITLE
fix: drawer scrim size accordingly to design specs (AR-994)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeDrawer.kt
@@ -12,8 +12,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DrawerState
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material3.DrawerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -5,9 +5,9 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalDrawer
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.RectangleShape
@@ -41,9 +41,9 @@ fun HomeScreen(startScreen: String?, viewModel: HomeViewModel) {
             )
         }
 
-        NavigationDrawer(
-            drawerContainerColor = MaterialTheme.colorScheme.surface,
-            drawerTonalElevation = 0.dp,
+        ModalDrawer(
+            drawerBackgroundColor = MaterialTheme.colorScheme.surface,
+            drawerElevation = 0.dp,
             drawerShape = RectangleShape,
             drawerState = drawerState,
             drawerContent = drawerContent,

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeState.kt
@@ -4,14 +4,14 @@ package com.wire.android.ui.home
 
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material.DrawerState
+import androidx.compose.material.DrawerValue
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.rememberDrawerState
 import androidx.compose.material.rememberModalBottomSheetState
-import androidx.compose.material3.DrawerState
-import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-994" title="AR-994" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />AR-994</a>  Increase navigation drawer closing area
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Design team requires, by its specs, that the `NavigationDrawer` have a scrim size of 56.dp. This is not possible using the latest compose material lib, see more at: https://issuetracker.google.com/issues/207957335

### Solutions

As this is a spec expected from design team (having a minimum scrim margin of 56.dp) I change the `NavigationDrawer` to a `ModalDrawer` that has this margin by default. 

### Attachments (Optional)

**Material 3 component lib :**
<img src="https://user-images.githubusercontent.com/5806454/162333170-0f890369-6f2b-4dc3-a11e-40c74c11bda4.png" width="300" />

**Material component lib:**
<img src="https://user-images.githubusercontent.com/5806454/162333083-7ccda47d-98b1-4285-b0e9-93f183fdbdd5.png" width="300" />


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
