### PR TITLE
fix: new conversation search fix

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -10,16 +10,16 @@ import com.wire.android.ui.home.newconversation.newGroup.NewGroupScreen
 
 @Composable
 fun NewConversationRouter(newConversationViewModel: NewConversationViewModel = hiltViewModel()) {
-    val navController = rememberNavController()
-    val listNavController = rememberNavController()
+    val newConversationNavController = rememberNavController()
+    val searchNavController = rememberNavController()
 
-    NavHost(navController = navController, startDestination = Screen.SearchListNavHostScreens.route) {
+    NavHost(navController = newConversationNavController, startDestination = Screen.SearchListNavHostScreens.route) {
         composable(
             route = Screen.SearchListNavHostScreens.route,
             content = {
                 SearchListNavigationHost(
-                    navController = navController,
-                    listNavController = listNavController,
+                    newConversationNavController = newConversationNavController,
+                    searchNavController = searchNavController,
                     newConversationViewModel = newConversationViewModel
                 )
             })
@@ -27,7 +27,7 @@ fun NewConversationRouter(newConversationViewModel: NewConversationViewModel = h
         composable(
             route = Screen.NewGroupNameScreen.route,
             content = {
-                NewGroupScreen(onBackPressed = { navController.popBackStack() })
+                NewGroupScreen(onBackPressed = { newConversationNavController.popBackStack() })
             })
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -1,197 +1,33 @@
 package com.wire.android.ui.home.newconversation
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.wire.android.R
-import com.wire.android.ui.common.topappbar.NavigationIconType
-import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
-import com.wire.android.ui.common.topappbar.search.AppTopBarWithSearchBar
-import com.wire.android.ui.home.newconversation.contacts.ContactsScreen
+import com.wire.android.ui.home.newconversation.common.Screen
 import com.wire.android.ui.home.newconversation.newGroup.NewGroupScreen
-import com.wire.android.ui.home.newconversation.search.SearchPeopleScreen
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @Composable
 fun NewConversationRouter(newConversationViewModel: NewConversationViewModel = hiltViewModel()) {
-    val newConversationState = rememberNewConversationState()
-    val scope = rememberCoroutineScope()
+    val navController = rememberNavController()
+    val listNavController = rememberNavController()
 
-    LaunchedEffect(newConversationViewModel) {
-        newConversationViewModel.moveToStep.onEach { item ->
-            when (item) {
-                NewConversationNavigationCommand.KnownContacts -> newConversationState.navigateToKnownContacts()
-                NewConversationNavigationCommand.SearchContacts -> newConversationState.navigateToSearch()
-                NewConversationNavigationCommand.NewGroup -> newConversationState.navigateToNewGroup()
-            }
-        }.launchIn(scope)
-    }
+    NavHost(navController = navController, startDestination = Screen.SearchListNavHostScreens.route) {
+        composable(
+            route = Screen.SearchListNavHostScreens.route,
+            content = {
+                SearchListNavigationHost(
+                    navController = navController,
+                    listNavController = listNavController,
+                    newConversationViewModel = newConversationViewModel
+                )
+            })
 
-    with(newConversationViewModel.state) {
-        NavHost(
-            navController = newConversationState.navController,
-            startDestination = NewConversationStateScreen.KNOWN_CONTACTS
-        ) {
-            composable(
-                route = NewConversationStateScreen.KNOWN_CONTACTS,
-                content = {
-                    ScreenWithSearchTopBar(
-                        newConversationViewModel = newConversationViewModel,
-                        searchQuery = searchQuery,
-                        scrollPosition = newConversationState.scrollPosition,
-                        content = {
-                            ContactsScreen(
-                                onScrollPositionChanged = { newConversationState.updateScrollPosition(it) },
-                                allKnownContact = allKnownContacts,
-                                contactsAddedToGroup = contactsAddedToGroup,
-                                onAddToGroup = { contact ->
-                                    newConversationViewModel.addContactToGroup(contact)
-                                },
-                                onRemoveFromGroup = { contact ->
-                                    newConversationViewModel.removeContactFromGroup(contact)
-                                },
-                                onOpenUserProfile = { contact ->
-                                    newConversationViewModel.openUserProfile(contact, true)
-                                },
-                                onNewGroupClicked = { newConversationViewModel.openNewGroupScreen() }
-                            )
-                        }
-                    )
-
-                }
-            )
-            composable(
-                route = NewConversationStateScreen.SEARCH_PEOPLE,
-                content = {
-                    ScreenWithSearchTopBar(
-                        newConversationViewModel = newConversationViewModel,
-                        searchQuery = searchQuery,
-                        scrollPosition = newConversationState.scrollPosition,
-                        content = {
-                            SearchPeopleScreen(
-                                searchQuery = searchQuery,
-                                noneSearchSucceed = noneSearchSucceed,
-                                knownContactSearchResult = localContactSearchResult,
-                                publicContactSearchResult = publicContactsSearchResult,
-                                federatedBackendResultContact = federatedContactSearchResult,
-                                contactsAddedToGroup = contactsAddedToGroup,
-                                onAddToGroup = { contact -> newConversationViewModel.addContactToGroup(contact) },
-                                onRemoveFromGroup = { contact -> newConversationViewModel.removeContactFromGroup(contact) },
-                                onOpenUserProfile = { searchContact ->
-                                    newConversationViewModel.openUserProfile(
-                                        contact = searchContact.contact,
-                                        internal = searchContact.internal
-                                    )
-                                },
-                                onNewGroupClicked = { newConversationViewModel.openNewGroupScreen() }
-                            )
-
-                        }
-                    )
-                }
-            )
-            composable(
-                route = NewConversationStateScreen.NEW_GROUP,
-                content = {
-                    NewGroupScreen(onBackPressed = { newConversationState.navigateBack() })
-                }
-            )
-
-        }
-    }
-}
-
-@Composable
-fun ScreenWithSearchTopBar(
-    newConversationViewModel: NewConversationViewModel,
-    searchQuery: String,
-    scrollPosition: Int,
-    content: @Composable () -> Unit
-) {
-    AppTopBarWithSearchBar(
-        scrollPosition = scrollPosition,
-        searchBarHint = stringResource(R.string.label_search_people),
-        searchQuery = searchQuery,
-        onSearchQueryChanged = { searchTerm ->
-            // when the searchTerm changes, we want to propagate it
-            // to the ViewModel, only when the searchQuery inside the ViewModel
-            // is different than searchTerm coming from the TextInputField
-            if (searchTerm != searchQuery) {
-                newConversationViewModel.search(searchTerm)
-            }
-        },
-        onSearchClicked = { newConversationViewModel.openSearchContacts() },
-        onCloseSearchClicked = {
-            newConversationViewModel.openKnownContacts()
-        },
-        appTopBar = {
-            WireCenterAlignedTopAppBar(
-                elevation = 0.dp,
-                title = stringResource(R.string.label_new_conversation),
-                navigationIconType = NavigationIconType.Close,
-                onNavigationPressed = { newConversationViewModel.close() }
-            )
-        },
-        content = content
-    )
-
-}
-
-private class NewConversationStateScreen(
-    val navController: NavHostController
-) {
-
-    var scrollPosition by mutableStateOf(0)
-        private set
-
-    fun updateScrollPosition(newScrollPosition: Int) {
-        scrollPosition = newScrollPosition
-    }
-
-    fun navigateToSearch() {
-        navController.navigate(SEARCH_PEOPLE)
-    }
-
-    fun navigateToNewGroup() {
-        navController.navigate(NEW_GROUP)
-    }
-
-    fun navigateToKnownContacts() {
-        navController.navigate(KNOWN_CONTACTS)
-    }
-
-    fun navigateBack() {
-        navController.popBackStack()
-    }
-
-
-    companion object {
-        const val KNOWN_CONTACTS = "known_contacts"
-        const val SEARCH_PEOPLE = "search_people"
-        const val NEW_GROUP = "new_group"
-
-    }
-}
-
-@OptIn(ExperimentalAnimationApi::class)
-@Composable
-private fun rememberNewConversationState(
-    navController: NavHostController = rememberNavController()
-): NewConversationStateScreen {
-    return remember {
-        NewConversationStateScreen(navController)
+        composable(
+            route = Screen.NewGroupNameScreen.route,
+            content = {
+                NewGroupScreen(onBackPressed = { navController.popBackStack() })
+            })
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -23,7 +23,6 @@ import com.wire.kalium.logic.feature.publicuser.SearchUserDirectoryUseCase
 import com.wire.kalium.logic.functional.Either
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onStart
@@ -63,8 +62,6 @@ class NewConversationViewModel
 
     var groupNameState: NewGroupNameViewState by mutableStateOf(NewGroupNameViewState())
 
-    var moveToStep = MutableSharedFlow<NewConversationNavigationCommand>()
-
     private var innerSearchPeopleState: SearchPeopleState by mutableStateOf(SearchPeopleState())
 
     private var localContactSearchResult by mutableStateOf(
@@ -80,6 +77,13 @@ class NewConversationViewModel
     )
 
     private val searchQueryStateFlow = SearchQueryStateFlow()
+
+    var scrollPosition by mutableStateOf(0)
+        private set
+
+    fun updateScrollPosition(newScrollPosition: Int) {
+        scrollPosition = newScrollPosition
+    }
 
     init {
         viewModelScope.launch {
@@ -208,34 +212,9 @@ class NewConversationViewModel
         groupNameState = groupNameState.copy(animatedGroupNameError = false)
     }
 
-
-    fun openKnownContacts() {
-        innerSearchPeopleState = innerSearchPeopleState.copy(searchQuery = "")
-        goToStep(NewConversationNavigationCommand.KnownContacts)
-    }
-
-    fun openSearchContacts() {
-        goToStep(NewConversationNavigationCommand.SearchContacts)
-    }
-
     fun close() {
         viewModelScope.launch {
             navigationManager.navigateBack()
         }
     }
-
-    fun openNewGroupScreen() {
-        goToStep(NewConversationNavigationCommand.NewGroup)
-    }
-
-    private fun goToStep(item: NewConversationNavigationCommand) {
-        viewModelScope.launch { moveToStep.emit(item) }
-    }
-}
-
-sealed class NewConversationNavigationCommand {
-    object KnownContacts : NewConversationNavigationCommand()
-    object SearchContacts : NewConversationNavigationCommand()
-    object NewGroup : NewConversationNavigationCommand()
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchListNavigationHost.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchListNavigationHost.kt
@@ -1,0 +1,107 @@
+package com.wire.android.ui.home.newconversation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.wire.android.R
+import com.wire.android.ui.common.topappbar.NavigationIconType
+import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.common.topappbar.search.AppTopBarWithSearchBar
+import com.wire.android.ui.home.newconversation.common.Screen
+import com.wire.android.ui.home.newconversation.common.SearchListScreens
+import com.wire.android.ui.home.newconversation.contacts.ContactsScreen
+import com.wire.android.ui.home.newconversation.search.SearchPeopleScreen
+
+@Composable
+fun SearchListNavigationHost(
+    navController: NavController,
+    listNavController: NavController,
+    newConversationViewModel: NewConversationViewModel
+) {
+    with(newConversationViewModel.state) {
+        AppTopBarWithSearchBar(
+            scrollPosition = newConversationViewModel.scrollPosition,
+            searchBarHint = stringResource(R.string.label_search_people),
+            searchQuery = searchQuery,
+            onSearchQueryChanged = { searchTerm ->
+                // when the searchTerm changes, we want to propagate it
+                // to the ViewModel, only when the searchQuery inside the ViewModel
+                // is different than searchTerm coming from the TextInputField
+                if (searchTerm != searchQuery) {
+                    newConversationViewModel.search(searchTerm)
+                }
+            },
+            onSearchClicked = {
+                listNavController.navigate(SearchListScreens.SearchPeopleScreen.route)
+            },
+            onCloseSearchClicked = {
+                listNavController.navigate(SearchListScreens.KnownContactsScreen.route)
+            },
+            appTopBar = {
+                WireCenterAlignedTopAppBar(
+                    elevation = 0.dp,
+                    title = stringResource(R.string.label_new_conversation),
+                    navigationIconType = NavigationIconType.Close,
+                    onNavigationPressed = { newConversationViewModel.close() }
+                )
+            },
+            content = {
+                NavHost(
+                    navController = listNavController as NavHostController,
+                    startDestination = SearchListScreens.KnownContactsScreen.route
+                ) {
+                    composable(
+                        route = SearchListScreens.KnownContactsScreen.route,
+                        content = {
+                            ContactsScreen(
+                                onScrollPositionChanged = { newConversationViewModel.updateScrollPosition(it) },
+                                allKnownContact = allKnownContacts,
+                                contactsAddedToGroup = contactsAddedToGroup,
+                                onAddToGroup = { contact ->
+                                    newConversationViewModel.addContactToGroup(contact)
+                                },
+                                onRemoveFromGroup = { contact ->
+                                    newConversationViewModel.removeContactFromGroup(contact)
+                                },
+                                onOpenUserProfile = { contact ->
+                                    newConversationViewModel.openUserProfile(contact, true)
+                                },
+                                onNewGroupClicked = {
+                                    navController.navigate(Screen.NewGroupNameScreen.route)
+                                }
+                            )
+                        }
+                    )
+                    composable(
+                        route = SearchListScreens.SearchPeopleScreen.route,
+                        content = {
+                            SearchPeopleScreen(
+                                searchQuery = searchQuery,
+                                noneSearchSucceed = noneSearchSucceed,
+                                knownContactSearchResult = localContactSearchResult,
+                                publicContactSearchResult = publicContactsSearchResult,
+                                federatedBackendResultContact = federatedContactSearchResult,
+                                contactsAddedToGroup = contactsAddedToGroup,
+                                onAddToGroup = { contact -> newConversationViewModel.addContactToGroup(contact) },
+                                onRemoveFromGroup = { contact -> newConversationViewModel.removeContactFromGroup(contact) },
+                                onOpenUserProfile = { searchContact ->
+                                    newConversationViewModel.openUserProfile(
+                                        contact = searchContact.contact,
+                                        internal = searchContact.internal
+                                    )
+                                },
+                                onNewGroupClicked = {
+                                    navController.navigate(Screen.NewGroupNameScreen.route)
+                                }
+                            )
+                        }
+                    )
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchListNavigationHost.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchListNavigationHost.kt
@@ -18,8 +18,8 @@ import com.wire.android.ui.home.newconversation.search.SearchPeopleScreen
 
 @Composable
 fun SearchListNavigationHost(
-    navController: NavController,
-    listNavController: NavController,
+    newConversationNavController: NavController,
+    searchNavController: NavController,
     newConversationViewModel: NewConversationViewModel
 ) {
     with(newConversationViewModel.state) {
@@ -36,10 +36,10 @@ fun SearchListNavigationHost(
                 }
             },
             onSearchClicked = {
-                listNavController.navigate(SearchListScreens.SearchPeopleScreen.route)
+                searchNavController.navigate(SearchListScreens.SearchPeopleScreen.route)
             },
             onCloseSearchClicked = {
-                listNavController.navigate(SearchListScreens.KnownContactsScreen.route)
+                searchNavController.navigate(SearchListScreens.KnownContactsScreen.route)
             },
             appTopBar = {
                 WireCenterAlignedTopAppBar(
@@ -51,7 +51,7 @@ fun SearchListNavigationHost(
             },
             content = {
                 NavHost(
-                    navController = listNavController as NavHostController,
+                    navController = searchNavController as NavHostController,
                     startDestination = SearchListScreens.KnownContactsScreen.route
                 ) {
                     composable(
@@ -71,7 +71,7 @@ fun SearchListNavigationHost(
                                     newConversationViewModel.openUserProfile(contact, true)
                                 },
                                 onNewGroupClicked = {
-                                    navController.navigate(Screen.NewGroupNameScreen.route)
+                                    newConversationNavController.navigate(Screen.NewGroupNameScreen.route)
                                 }
                             )
                         }
@@ -95,7 +95,7 @@ fun SearchListNavigationHost(
                                     )
                                 },
                                 onNewGroupClicked = {
-                                    navController.navigate(Screen.NewGroupNameScreen.route)
+                                    newConversationNavController.navigate(Screen.NewGroupNameScreen.route)
                                 }
                             )
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/Screen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/Screen.kt
@@ -1,0 +1,12 @@
+package com.wire.android.ui.home.newconversation.common
+
+
+sealed class Screen(val route: String) {
+    object NewGroupNameScreen : Screen("new_group_name")
+    object SearchListNavHostScreens : Screen("search_list_nav_host")
+}
+
+sealed class SearchListScreens(val route: String) {
+    object KnownContactsScreen : SearchListScreens("known_contacts")
+    object SearchPeopleScreen : SearchListScreens("search_people")
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

after adding the new group name screen the search flow was not working properly


### Solutions

update the navigation flow by using nested navhosts


#### How to Test

go to the new conversation flow and try to search 



### Attachments (Optional)
## before
![Wire 2022-04-11 at 6_33 PM](https://user-images.githubusercontent.com/34056732/162942012-bc86392c-d811-42ee-bb75-2c80cb1500ac.gif)

## after 
![new convo flow](https://user-images.githubusercontent.com/34056732/162942272-894172a5-8b2e-46a8-a043-7368158a6137.gif)



----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
