### PR TITLE
fix: adjust message item paddings

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -53,9 +53,8 @@ fun MessageItem(
         Row(
             Modifier
                 .padding(
-                    start = MaterialTheme.wireDimensions.spacing8x,
                     end = MaterialTheme.wireDimensions.spacing16x,
-                    bottom = MaterialTheme.wireDimensions.spacing8x
+                    bottom = MaterialTheme.wireDimensions.messageItemBottomPadding
                 )
                 .fillMaxWidth()
                 .combinedClickable(
@@ -64,13 +63,15 @@ fun MessageItem(
                     onLongClick = onLongClicked
                 )
         ) {
+            Spacer(Modifier.padding(start = 2.dp))
             UserProfileAvatar(
                 userAvatarAsset = message.user.avatarAsset,
                 status = message.user.availabilityStatus
             )
+            Spacer(Modifier.padding(start = 12.dp))
             Column {
                 MessageHeader(messageHeader)
-                Spacer(modifier = Modifier.height(6.dp))
+                Spacer(modifier = Modifier.height(dimensions().spacing6x))
                 if (!isDeleted) {
                     MessageContent(messageContent, onAssetMessageClicked)
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -204,7 +204,7 @@ private fun MessageComposer(
                                     onLongPress = { /* Called on Long Press */ },
                                     onTap = {  /* Called on Tap */ }
                                 )
-                            }
+                            }.background(color = MaterialTheme.wireColorScheme.backgroundVariant)
                             .weight(1f)) {
                         content()
                     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -209,7 +209,6 @@ private fun MessageComposer(
                         content()
                     }
                     // Column wrapping CollapseIconButton and MessageComposerInput
-
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -209,6 +209,7 @@ private fun MessageComposer(
                         content()
                     }
                     // Column wrapping CollapseIconButton and MessageComposerInput
+
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -132,7 +132,9 @@ data class WireDimensions(
     //calling
     val defaultCallingControlsSize: Dp,
     val defaultSheetPeekHeight: Dp,
-    val callingUserAvatarSize: Dp
+    val callingUserAvatarSize: Dp,
+    // Message item
+    val messageItemBottomPadding : Dp
 )
 
 private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
@@ -236,7 +238,8 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     groupButtonHeight = 82.dp,
     defaultCallingControlsSize = 66.dp,
     defaultSheetPeekHeight = 95.dp,
-    callingUserAvatarSize = 80.dp
+    callingUserAvatarSize = 80.dp,
+    messageItemBottomPadding = 12.dp
 )
 
 private val DefaultPhoneLandscapeWireDimensions: WireDimensions = DefaultPhonePortraitWireDimensions


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

_adjust message items paddings

### Attachments (Optional)



----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
