### PR TITLE
fix: remove device keyboard behavior

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDevice.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDevice.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -175,9 +174,10 @@ private fun RemoveDeviceDialog(
                     .padding(bottom = MaterialTheme.wireDimensions.spacing8x)
                     .testTag("remove device password field")
             )
-            SideEffect {
-                if (state.keyboardVisible) focusRequester.requestFocus()
-                else keyboardController?.hide()
+            if (state.hideKeyboard)
+                keyboardController?.hide()
+            LaunchedEffect(Unit) { // executed only once when showing the dialog
+                focusRequester.requestFocus()
             }
         }
     )

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceState.kt
@@ -21,7 +21,7 @@ sealed class RemoveDeviceDialogState {
         val password: TextFieldValue = TextFieldValue(""),
         val loading: Boolean = false,
         val removeEnabled: Boolean = false,
-        val keyboardVisible: Boolean = false,
+        val hideKeyboard: Boolean = false,
         val error: RemoveDeviceError = RemoveDeviceError.None
     ) : RemoveDeviceDialogState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/remove/RemoveDeviceViewModel.kt
@@ -66,7 +66,7 @@ class RemoveDeviceViewModel @Inject constructor(
 
     fun onDialogDismissed() {
         // it has to be 2-step process, first we have to hide the keyboard for the dialog's content and then dismiss the dialog
-        updateStateIfDialogVisible { it.copy(keyboardVisible = false) }
+        updateStateIfDialogVisible { it.copy(hideKeyboard = true) }
         updateStateIfDialogVisible { RemoveDeviceDialogState.Hidden }
     }
 
@@ -93,7 +93,7 @@ class RemoveDeviceViewModel @Inject constructor(
                             deleteClientResult.toRemoveDeviceError()
                     updateStateIfDialogVisible { it.copy(loading = false, error = removeDeviceError) }
                     if (removeDeviceError is RemoveDeviceError.None) {
-                        updateStateIfDialogVisible { it.copy(keyboardVisible = false) }
+                        updateStateIfDialogVisible { it.copy(hideKeyboard = true) }
                         navigateToConvScreen()
                     }
                 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The keyboard behaviour on "remove device" screen and its dialog was still wrong - the previous fix that prevented keyboard from opening when the password was pasted actually made the keyboard hide when it shouldn't, for instance during entering the characters.

### Solutions

Changed the name of the state field to `hideKeyboard` to only be used when it should really hide the keyboard and text field focus should be requested once when the dialog is shown, thus `LaunchedEffect` is used.

### Testing

#### How to Test

Login having too many devices registered to trigger the "remove device" screen and then try to enter or paste the password when removing any device.

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
