### PR TITLE
fix: rename the get all contacts use case

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -19,7 +19,7 @@ import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversatio
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
 import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
-import com.wire.kalium.logic.feature.publicuser.GetAllKnownUsersUseCase
+import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.GetKnownUserUseCase
 import com.wire.kalium.logic.feature.publicuser.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.SearchUserDirectoryUseCase
@@ -274,10 +274,10 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun providesGetAllKnownUsers(
+    fun providesGetAllContactsUseCase(
         @KaliumCoreLogic coreLogic: CoreLogic,
         @CurrentAccount currentAccount: UserId
-    ): GetAllKnownUsersUseCase =
+    ): GetAllContactsUseCase =
         coreLogic.getSessionScope(currentAccount).users.getAllKnownUsers
 
     @ViewModelScoped

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -20,7 +20,7 @@ import com.wire.android.ui.home.newconversation.search.SearchResultState
 import com.wire.android.util.flow.SearchQueryStateFlow
 import com.wire.kalium.logic.data.conversation.ConversationOptions
 import com.wire.kalium.logic.feature.conversation.CreateGroupConversationUseCase
-import com.wire.kalium.logic.feature.publicuser.GetAllKnownUsersUseCase
+import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.SearchUserDirectoryUseCase
 import com.wire.kalium.logic.functional.Either
@@ -40,7 +40,7 @@ class NewConversationViewModel
     private val navigationManager: NavigationManager,
     private val searchKnownUsers: SearchKnownUsersUseCase,
     private val searchPublicUsers: SearchUserDirectoryUseCase,
-    private val getAllKnownUsersUseCase: GetAllKnownUsersUseCase,
+    private val getAllContacts: GetAllContactsUseCase,
     private val createGroupConversation: CreateGroupConversationUseCase
 ) : ViewModel() {
 
@@ -89,15 +89,9 @@ class NewConversationViewModel
     init {
         viewModelScope.launch {
             launch {
-                getAllKnownUsersUseCase()
-                    .onStart {
-                        innerSearchPeopleState = innerSearchPeopleState.copy()
-                    }
-                    .collect {
-                        innerSearchPeopleState = innerSearchPeopleState.copy(
-                            allKnownContacts = it.map { publicUser -> publicUser.toContact() }
-                        )
-                    }
+                innerSearchPeopleState = innerSearchPeopleState.copy(
+                    allKnownContacts = getAllContacts().map { otherUser -> otherUser.toContact() }
+                )
             }
 
             searchQueryStateFlow.onSearchAction { searchTerm ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -89,8 +89,10 @@ class NewConversationViewModel
     init {
         viewModelScope.launch {
             launch {
+                val allContacts = getAllContacts()
+
                 innerSearchPeopleState = innerSearchPeopleState.copy(
-                    allKnownContacts = getAllContacts().map { otherUser -> otherUser.toContact() }
+                    allKnownContacts = allContacts.map { otherUser -> otherUser.toContact() }
                 )
             }
 
@@ -117,7 +119,7 @@ class NewConversationViewModel
 
         }.flowOn(Dispatchers.IO).collect {
             localContactSearchResult = ContactSearchResult.InternalContact(
-                SearchResultState.Success(it.result.map { publicUser -> publicUser.toContact() })
+                SearchResultState.Success(it.result.map { otherUser -> otherUser.toContact() })
             )
         }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- the use case was renamed on the Kalium
- the use case does not return Flow any more

### Solutions

- use correct name
- consume the list instead of flow

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
