### PR TITLE
feat: add request camera permission in calling

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
@@ -94,7 +94,7 @@ private fun CallingControls(
             .padding(0.dp, MaterialTheme.wireDimensions.spacing16x, 0.dp, 0.dp)
     ) {
         MicrophoneButton(ongoingCallState.isMuted) { onMuteOrUnMuteCall() }
-        CameraButton(cameraPermissionDenied = { }, onCameraButtonClicked = { })
+        CameraButton(onCameraPermissionDenied = { }, onCameraButtonClicked = { })
         SpeakerButton(onSpeakerButtonClicked = { })
         HangUpButton { onHangUpCall() }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
@@ -94,7 +94,7 @@ private fun CallingControls(
             .padding(0.dp, MaterialTheme.wireDimensions.spacing16x, 0.dp, 0.dp)
     ) {
         MicrophoneButton(ongoingCallState.isMuted) { onMuteOrUnMuteCall() }
-        CameraButton(onHangUpButtonClicked = { })
+        CameraButton(cameraPermissionDenied = { }, onCameraButtonClicked = { })
         SpeakerButton(onSpeakerButtonClicked = { })
         HangUpButton { onHangUpCall() }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CallOptionsControls.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CallOptionsControls.kt
@@ -40,7 +40,7 @@ fun CallOptionsControls() {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CameraButton(isCameraOn = false, cameraPermissionDenied = { }) { }
+            CameraButton(isCameraOn = false, onCameraPermissionDenied = { }) { }
             Text(
                 text = stringResource(id = R.string.calling_label_camera).uppercase(),
                 style = MaterialTheme.wireTypography.label01,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CallOptionsControls.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CallOptionsControls.kt
@@ -40,7 +40,7 @@ fun CallOptionsControls() {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CameraButton(isCameraOn = false) { }
+            CameraButton(isCameraOn = false, cameraPermissionDenied = { }) { }
             Text(
                 text = stringResource(id = R.string.calling_label_camera).uppercase(),
                 style = MaterialTheme.wireTypography.label01,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraButton.kt
@@ -25,7 +25,7 @@ import com.wire.android.util.extension.checkPermission
 @Composable
 fun CameraButton(
     isCameraOn: Boolean = false,
-    cameraPermissionDenied: () -> Unit,
+    onCameraPermissionDenied: () -> Unit,
     onCameraButtonClicked: () -> Unit
 ) {
     var isCameraOn by remember { mutableStateOf(isCameraOn) }
@@ -37,7 +37,7 @@ fun CameraButton(
         if (isGranted) {
             onCameraButtonClicked()
         } else {
-            cameraPermissionDenied()
+            onCameraPermissionDenied()
         }
     }
 
@@ -75,5 +75,5 @@ private fun verifyCameraPermission(
 @Preview
 @Composable
 fun ComposableCameraButtonPreview() {
-    CameraButton(cameraPermissionDenied = { }, onCameraButtonClicked = { })
+    CameraButton(onCameraPermissionDenied = { }, onCameraButtonClicked = { })
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraButton.kt
@@ -1,5 +1,9 @@
 package com.wire.android.ui.calling.controlButtons
 
+import android.content.Context
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.IconButton
@@ -10,22 +14,41 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.util.extension.checkPermission
 
 @Composable
 fun CameraButton(
     isCameraOn: Boolean = false,
-    onHangUpButtonClicked: () -> Unit
+    cameraPermissionDenied: () -> Unit,
+    onCameraButtonClicked: () -> Unit
 ) {
     var isCameraOn by remember { mutableStateOf(isCameraOn) }
+    val context = LocalContext.current
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            onCameraButtonClicked()
+        } else {
+            cameraPermissionDenied()
+        }
+    }
 
     IconButton(
         modifier = Modifier.width(MaterialTheme.wireDimensions.defaultCallingControlsSize),
-        onClick = onHangUpButtonClicked
+        onClick = {
+            verifyCameraPermission(
+                context = context,
+                cameraPermissionLauncher = cameraPermissionLauncher
+            )
+        }
     ) {
         Image(
             painter = painterResource(
@@ -40,8 +63,17 @@ fun CameraButton(
     }
 }
 
+private fun verifyCameraPermission(
+    context: Context,
+    cameraPermissionLauncher: ManagedActivityResultLauncher<String, Boolean>
+) {
+    if (context.checkPermission(android.Manifest.permission.CAMERA).not()) {
+        cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
+    }
+}
+
 @Preview
 @Composable
 fun ComposableCameraButtonPreview() {
-    CameraButton(onHangUpButtonClicked = { })
+    CameraButton(cameraPermissionDenied = { }, onCameraButtonClicked = { })
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -142,7 +142,7 @@ private fun CallingControls(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CameraButton(isCameraOn = state.isCameraOn) { }
+            CameraButton(isCameraOn = state.isCameraOn, cameraPermissionDenied = { }) { }
             Text(
                 text = stringResource(id = R.string.calling_label_camera),
                 style = MaterialTheme.wireTypography.label01,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -142,7 +142,7 @@ private fun CallingControls(
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CameraButton(isCameraOn = state.isCameraOn, cameraPermissionDenied = { }) { }
+            CameraButton(isCameraOn = state.isCameraOn, onCameraPermissionDenied = { }) { }
             Text(
                 text = stringResource(id = R.string.calling_label_camera),
                 style = MaterialTheme.wireTypography.label01,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-1260 - request camera permission](https://wearezeta.atlassian.net/browse/AR-1260)

### Issues

When receiving an incoming call or on an ongoing call, and the user hasn't given permission to access the camera, when clicking on camera button nothing would happen.

### Solutions

Ask for user permission to use its camera when receiving an incoming call or on an ongoing call.

#### How to Test

- Open the app
- send a message to the caller
- receive an incoming call
- tap on the camera button
- permission prompt should pop up
