### PR TITLE
fix: SSO initiate login failure results

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSO.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSO.kt
@@ -39,6 +39,7 @@ import com.wire.android.ui.common.textfield.WireTextFieldState
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.CustomTabsHelper
+import com.wire.android.util.DialogErrorStrings
 import com.wire.android.util.dialogErrorStrings
 import com.wire.kalium.logic.configuration.ServerConfig
 import kotlinx.coroutines.CoroutineScope
@@ -95,7 +96,7 @@ private fun LoginSSOContent(
             ssoCode = loginSSOState.ssoCode,
             onCodeChange = onCodeChange,
             error = when (loginSSOState.loginSSOError) {
-                LoginSSOError.TextFieldError.InvalidCodeError -> stringResource(R.string.login_error_invalid_sso_code)
+                LoginSSOError.TextFieldError.InvalidCodeFormatError -> stringResource(R.string.login_error_invalid_sso_code_format)
                 else -> null
             }
         )
@@ -109,9 +110,12 @@ private fun LoginSSOContent(
 
     if (loginSSOState.loginSSOError is LoginSSOError.DialogError) {
         val (title, message) = when (loginSSOState.loginSSOError) {
-            is LoginSSOError.DialogError.GenericError -> {
+            is LoginSSOError.DialogError.GenericError ->
                 loginSSOState.loginSSOError.coreFailure.dialogErrorStrings(LocalContext.current.resources)
-            }
+            is LoginSSOError.DialogError.InvalidCodeError -> DialogErrorStrings(
+                title = stringResource(id = R.string.login_error_invalid_credentials_title),
+                message = stringResource(id = R.string.login_error_invalid_sso_code)
+            )
         }
         WireDialog(
             title = title,
@@ -170,3 +174,4 @@ private fun LoginSSOScreenPreview() {
         LoginSSOContent(rememberScrollState(), LoginSSOState(), {}, {}, suspend {}, rememberCoroutineScope())
     }
 }
+

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOState.kt
@@ -13,9 +13,11 @@ data class LoginSSOState(
 sealed class LoginSSOError {
     object None: LoginSSOError()
     sealed class TextFieldError: LoginSSOError() {
-        object InvalidCodeError: TextFieldError()
+        object InvalidCodeFormatError: TextFieldError()
     }
     sealed class DialogError: LoginSSOError() {
+        object InvalidCodeError: DialogError()
         data class GenericError(val coreFailure: CoreFailure): DialogError()
     }
 }
+

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -85,8 +85,10 @@ class LoginSSOViewModel @Inject constructor(
 }
 
 private fun SSOInitiateLoginResult.Failure.toLoginSSOError() = when (this) {
-    SSOInitiateLoginResult.Failure.InvalidCode -> LoginSSOError.TextFieldError.InvalidCodeError
+    SSOInitiateLoginResult.Failure.InvalidCodeFormat -> LoginSSOError.TextFieldError.InvalidCodeFormatError
+    SSOInitiateLoginResult.Failure.InvalidCode -> LoginSSOError.DialogError.InvalidCodeError
     is SSOInitiateLoginResult.Failure.Generic -> LoginSSOError.DialogError.GenericError(this.genericFailure)
     SSOInitiateLoginResult.Failure.InvalidRedirect ->
         LoginSSOError.DialogError.GenericError(CoreFailure.Unknown(IllegalArgumentException("Invalid Redirect")))
 }
+

--- a/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/textfield/WireTextField.kt
@@ -79,7 +79,12 @@ internal fun WireTextField(
             Label(labelText, labelMandatoryIcon, state, interactionSource, colors)
         BasicTextField(
             value = value,
-            onValueChange = onValueChange,
+            onValueChange = {
+                onValueChange(
+                    if(singleLine || maxLines == 1) it.copy(it.text.replace("\n", ""))
+                    else it
+                )
+            },
             textStyle = textStyle.copy(color = colors.textColor(state = state).value),
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,9 +85,10 @@
     <string name="login_password_label">PASSWORD</string>
     <string name="login_tab_email">EMAIL</string>
     <string name="login_tab_sso">SSO LOGIN</string>
-    <string name="login_sso_code_placeholder">wire://</string>
+    <string name="login_sso_code_placeholder">wire-</string>
     <string name="login_sso_code_label">SSO CODE</string>
     <string name="login_error_invalid_sso_code">Please enter a valid SSO code.</string>
+    <string name="login_error_invalid_sso_code_format">Enter a valid SSO code</string>
 
     <!-- Remove Device -->
     <string name="remove_device_title">Remove a Device</string>

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
@@ -105,12 +105,21 @@ class LoginSSOViewModelTest {
     }
 
     @Test
+    fun `given button is clicked, when login returns InvalidCodeFormat error, then InvalidCodeFormatError is passed`() {
+        coEvery { ssoInitiateLoginUseCase.invoke(any()) } returns SSOInitiateLoginResult.Failure.InvalidCodeFormat
+
+        runTest { loginViewModel.login(serverConfig) }
+
+        loginViewModel.loginState.loginSSOError shouldBeInstanceOf LoginSSOError.TextFieldError.InvalidCodeFormatError::class
+    }
+
+    @Test
     fun `given button is clicked, when login returns InvalidCode error, then InvalidCodeError is passed`() {
         coEvery { ssoInitiateLoginUseCase.invoke(any()) } returns SSOInitiateLoginResult.Failure.InvalidCode
 
         runTest { loginViewModel.login(serverConfig) }
 
-        loginViewModel.loginState.loginSSOError shouldBeInstanceOf LoginSSOError.TextFieldError.InvalidCodeError::class
+        loginViewModel.loginState.loginSSOError shouldBeInstanceOf LoginSSOError.DialogError.InvalidCodeError::class
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The SSO initiate login use case was returning wrong failure when invalid SSO code was entered (generic server error instead of proper InvalidCode one), also according to the designs there should be a distinction between the wrong code which is a result of the API request and the wrong code format when it doesn't pass the initial validation.

### Solutions

Implemented handling of new failure type InvalidCodeFormat the way InvalidCode used to be handled, and the latter one is now handled by showing the dialog info.
Added ignoring the new line character in WireTextField when it's set to have only a single line.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open SSO Login and enter code with wrong format ("wire-{UUID}") or made-up code having the valid format.

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
