### PR TITLE
feat(calling): display user avatar and name

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -27,6 +28,7 @@ import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.R
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -40,7 +42,13 @@ private fun OngoingCallContent(ongoingCallViewModel: OngoingCallViewModel) {
 
     val scaffoldState = rememberBottomSheetScaffoldState()
     BottomSheetScaffold(
-        topBar = { OngoingCallTopBar(ongoingCallViewModel.callEstablishedState.conversationName!!) {} },
+        topBar = {
+            //TODO to handle null name in different way
+            OngoingCallTopBar(
+                ongoingCallViewModel.callEstablishedState.conversationName
+                    ?: stringResource(id = R.string.calling_label_default_caller_name)
+            ) {}
+        },
         sheetShape = RoundedCornerShape(topStart = MaterialTheme.wireDimensions.corner16x, topEnd = MaterialTheme.wireDimensions.corner16x),
         backgroundColor = MaterialTheme.wireColorScheme.ongoingCallBackground,
         sheetPeekHeight = MaterialTheme.wireDimensions.defaultSheetPeekHeight,
@@ -60,7 +68,10 @@ private fun OngoingCallContent(ongoingCallViewModel: OngoingCallViewModel) {
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            UserProfileAvatar(size = MaterialTheme.wireDimensions.onGoingCallUserAvatarSize)
+            UserProfileAvatar(
+                userAvatarAsset = ongoingCallViewModel.callEstablishedState.avatarAssetId,
+                size = MaterialTheme.wireDimensions.onGoingCallUserAvatarSize
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/OngoingCallState.kt
@@ -1,8 +1,10 @@
 package com.wire.android.ui.calling
 
+import com.wire.android.model.UserAvatarAsset
+
 data class OngoingCallState(
-    val conversationName: String = "default",
-    val avatarAssetByteArray: ByteArray? = null,
+    val conversationName: String? = null,
+    val avatarAssetId: UserAvatarAsset? = null,
     val isMuted: Boolean = false,
     val isCameraOn: Boolean = false,
     val isSpeakerOn: Boolean = false

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -92,6 +92,7 @@ private fun IncomingCallContent(
                 modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing8x)
             )
             UserProfileAvatar(
+                userAvatarAsset = state.avatarAssetId,
                 size = MaterialTheme.wireDimensions.callingIncomingUserAvatarSize,
                 modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing56x)
             )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallState.kt
@@ -1,8 +1,10 @@
 package com.wire.android.ui.calling.incoming
 
+import com.wire.android.model.UserAvatarAsset
+
 data class IncomingCallState(
     val conversationName: String? = null,
-    val avatarAssetByteArray: ByteArray? = null,
+    val avatarAssetId: UserAvatarAsset? = null,
     val isMicrophoneMuted: Boolean = false,
     val isCameraOn: Boolean = false,
     val isSpeakerOn: Boolean = false

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.model.UserAvatarAsset
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
@@ -20,6 +21,7 @@ import com.wire.kalium.logic.feature.call.CallStatus
 import com.wire.kalium.logic.feature.call.usecase.GetAllCallsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.lang.IllegalStateException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -40,7 +42,7 @@ class IncomingCallViewModel @Inject constructor(
         viewModelScope.launch {
             launch {
                 conversationDetails(conversationId = conversationId)
-                    .collect { observeConversationDetails(conversationDetails = it) }
+                    .collect { initializeScreenState(conversationDetails = it) }
             }
             launch {
                 observeIncomingCall()
@@ -78,14 +80,16 @@ class IncomingCallViewModel @Inject constructor(
         }
     }
 
-    private fun observeConversationDetails(conversationDetails: ConversationDetails) {
-        val conversationName = when (conversationDetails) {
-            is ConversationDetails.Group -> conversationDetails.conversation.name
-            is ConversationDetails.OneOne -> conversationDetails.otherUser.name
-            else -> null
+    private fun initializeScreenState(conversationDetails: ConversationDetails) {
+        callState = when (conversationDetails) {
+            is ConversationDetails.Group -> callState.copy(conversationName = conversationDetails.conversation.name)
+            is ConversationDetails.OneOne -> {
+                callState.copy(
+                    conversationName = conversationDetails.otherUser.name,
+                    avatarAssetId = UserAvatarAsset(conversationDetails.otherUser.completePicture ?: "")
+                )
+            }
+            else -> throw IllegalStateException("Invalid conversation type")
         }
-        callState = callState.copy(
-            conversationName = conversationName
-        )
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description

This PR aims to display the name and the avatar of current user in incomingCall and OngoingCall screens 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
