### PR TITLE
fix(sso-login): loading server config from deep link and set staging for SSO login

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
@@ -101,8 +101,10 @@ private fun LoginContent(
                 modifier = Modifier.fillMaxWidth()
             ) { pageIndex ->
                 when (LoginTabItem.values()[pageIndex]) {
-                    LoginTabItem.EMAIL -> LoginEmailScreen(scrollState)
-                    LoginTabItem.SSO -> LoginSSOScreen(ssoLoginResult, scrollState)
+                    LoginTabItem.EMAIL -> LoginEmailScreen(serverConfig, scrollState)
+                    //todo: remove after switching the sso to production
+                    //LoginTabItem.SSO -> LoginSSOScreen(serverConfig, ssoLoginResult)
+                    LoginTabItem.SSO -> LoginSSOScreen(ServerConfig.STAGING, ssoLoginResult)
                 }
             }
             if(!pagerState.isScrollInProgress && focusedTabIndex != pagerState.currentPage)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -54,11 +54,11 @@ open class LoginViewModel @Inject constructor(
         }
     }
 
-    fun updateServerConfig(ssoLoginResult: DeepLinkResult.SSOLogin?, default: ServerConfig) {
-        serverConfig = ssoLoginResult?.let {
+    fun updateServerConfig(ssoLoginResult: DeepLinkResult.SSOLogin?, serverConfig: ServerConfig) {
+        this.serverConfig = ssoLoginResult?.let {
             //todo: fetch the serverConfig by the uuid
             ServerConfig.STAGING
-        } ?: default
+        } ?: serverConfig
     }
 
     suspend fun registerClient(

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmail.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmail.kt
@@ -59,10 +59,12 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun LoginEmailScreen(
+    serverConfig: ServerConfig,
     scrollState: ScrollState = rememberScrollState()
 ) {
     val scope = rememberCoroutineScope()
     val loginEmailViewModel: LoginEmailViewModel = hiltViewModel()
+    loginEmailViewModel.updateServerConfig(ssoLoginResult = null , serverConfig)
     val loginEmailState: LoginEmailState = loginEmailViewModel.loginState
     LoginEmailContent(
         scrollState = scrollState,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSO.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSO.kt
@@ -43,6 +43,7 @@ import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.DialogErrorStrings
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.dialogErrorStrings
+import com.wire.kalium.logic.configuration.ServerConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -51,12 +52,14 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun LoginSSOScreen(
+    serverConfig: ServerConfig,
     ssoLoginResult: DeepLinkResult.SSOLogin?,
     scrollState: ScrollState = rememberScrollState()
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val loginSSOViewModel: LoginSSOViewModel = hiltViewModel()
+    loginSSOViewModel.updateServerConfig(ssoLoginResult, serverConfig)
     val loginSSOState: LoginSSOState = loginSSOViewModel.loginState
     loginSSOViewModel.handleSSOResult(ssoLoginResult)
     LoginSSOContent(

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/LoginViewModelTest.kt
@@ -5,11 +5,15 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.di.ClientScopeProvider
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.authentication.login.LoginViewModel
+import com.wire.android.util.deeplink.DeepLinkResult
+import com.wire.android.util.deeplink.SSOFailureCodes
+import com.wire.kalium.logic.configuration.ServerConfig
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.amshove.kluent.internal.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -38,4 +42,21 @@ class LoginViewModelTest {
         loginViewModel.navigateBack()
         coVerify(exactly = 1) { navigationManager.navigateBack() }
     }
+
+    @Test
+    fun `given updateServerConfig called, when ssoLoginResult is null & server config has a value, then result is same serverConfig`(){
+        loginViewModel.serverConfig = ServerConfig.PRODUCTION
+        loginViewModel.updateServerConfig(null, ServerConfig.STAGING)
+        assertEquals(loginViewModel.serverConfig, ServerConfig.STAGING)
+    }
+
+    @Test
+    fun `given updateServerConfig called, when ssoLoginResult & server config have values, then result is same staging`(){
+        loginViewModel.updateServerConfig(ssoLoginResult = DeepLinkResult.SSOLogin.Success("",""), ServerConfig.STAGING)
+        assertEquals(loginViewModel.serverConfig, ServerConfig.STAGING)
+
+        loginViewModel.updateServerConfig(ssoLoginResult = DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.ServerError), ServerConfig.STAGING)
+        assertEquals(loginViewModel.serverConfig, ServerConfig.STAGING)
+    }
+
 }

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/LoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/LoginViewModelTest.kt
@@ -44,18 +44,21 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `given updateServerConfig called, when ssoLoginResult is null & server config has a value, then result is same serverConfig`(){
+    fun `given updateServerConfig called, when ssoLoginResult is null & server config has a value, then result is same serverConfig`() {
         loginViewModel.serverConfig = ServerConfig.PRODUCTION
         loginViewModel.updateServerConfig(null, ServerConfig.STAGING)
         assertEquals(loginViewModel.serverConfig, ServerConfig.STAGING)
     }
 
     @Test
-    fun `given updateServerConfig called, when ssoLoginResult & server config have values, then result is same staging`(){
-        loginViewModel.updateServerConfig(ssoLoginResult = DeepLinkResult.SSOLogin.Success("",""), ServerConfig.STAGING)
+    fun `given updateServerConfig called, when ssoLoginResult & server config have values, then result is same staging`() {
+        loginViewModel.updateServerConfig(ssoLoginResult = DeepLinkResult.SSOLogin.Success("", ""), ServerConfig.STAGING)
         assertEquals(loginViewModel.serverConfig, ServerConfig.STAGING)
 
-        loginViewModel.updateServerConfig(ssoLoginResult = DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.ServerError), ServerConfig.STAGING)
+        loginViewModel.updateServerConfig(
+            ssoLoginResult = DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.ServerError),
+            ServerConfig.STAGING
+        )
         assertEquals(loginViewModel.serverConfig, ServerConfig.STAGING)
     }
 


### PR DESCRIPTION
…ogin

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Fixed assigning correct value for server config in login tabs and set the staging as default sso login

### Issues
The custom server config loaded from the deeplink wasn't assigned correctly to the next pages.

### Causes (Optional)

After refactoring, a place to set the value was missed! also added some new tests.

### Solutions

Added tests and fixed the value passing in other pages.

### Testing
added unit tests for the function.

#### How to Test

SSO login should work with staging directly.
Deeplinks has another server config that should change the app server config correctly.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
