### PR TITLE
fix: profile pic issue and muting options ui adjustment (AR-1413) (AR-1043)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/ModalSheetHeaderItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/ModalSheetHeaderItem.kt
@@ -9,18 +9,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireTypography
 
 @Composable
 fun ModalSheetHeaderItem(
     title: String? = null,
-    leadingIcon: @Composable () -> Unit = {}
+    leadingIcon: @Composable () -> Unit = {},
+    modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
             .padding(
                 start = dimensions().modalBottomSheetHeaderStartPadding,
                 top = dimensions().modalBottomSheetHeaderTopPadding,
@@ -28,7 +28,7 @@ fun ModalSheetHeaderItem(
             )
     ) {
         leadingIcon()
-        Spacer(modifier = Modifier.width(8.dp))
+        Spacer(modifier = Modifier.width(dimensions().spacing8x))
         if (title != null) {
             Text(
                 text = title,

--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/WireModalSheetLayout.kt
@@ -9,7 +9,6 @@ import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -74,10 +73,12 @@ fun MenuModalSheetContent(
     headerTitle: String? = null,
     headerIcon: @Composable () -> Unit = {},
     menuItems: List<@Composable () -> Unit>,
+    headerModifier: Modifier = Modifier
 ) {
     ModalSheetHeaderItem(
         title = headerTitle,
-        leadingIcon = headerIcon
+        leadingIcon = headerIcon,
+        modifier = headerModifier
     )
 
     buildMenuSheetItems(items = menuItems)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/MutingOptionsSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/MutingOptionsSheetContent.kt
@@ -2,6 +2,7 @@ package com.wire.android.ui.home.conversationslist
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.ExperimentalMaterialApi
@@ -75,7 +76,12 @@ fun MutingOptionsSheetContent(
         headerIcon = {
             ArrowLeftIcon(modifier = Modifier.clickable { onBackClick() })
             Spacer(modifier = Modifier.width(dimensions().spacing8x))
-        }
+        },
+        headerModifier = Modifier.padding(
+            start = dimensions().spacing8x,
+            top = dimensions().spacing16x,
+            bottom = dimensions().spacing16x
+        )
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -27,6 +27,7 @@ import com.wire.android.ui.common.ArrowRightIcon
 import com.wire.android.ui.common.bottomsheet.MenuBottomSheetItem
 import com.wire.android.ui.common.bottomsheet.MenuItemIcon
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
+import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.imagepreview.BulletHoleImagePreview
@@ -136,7 +137,8 @@ private fun AvatarPickerContent(
                         hasPickedImage = hasPickedImage(viewModel.pictureState),
                         onSaveClick = onSaveClick,
                         onCancelClick = { viewModel.loadInitialAvatarState() },
-                        onChangeImage = { state.showModalBottomSheet() }
+                        onChangeImage = { state.showModalBottomSheet() },
+                        isUploadingImage = isUploadingImage(viewModel.pictureState)
                     )
                 }
             }
@@ -144,14 +146,16 @@ private fun AvatarPickerContent(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AvatarPickerActionButtons(
+    isUploadingImage: Boolean,
     hasPickedImage: Boolean,
     onSaveClick: () -> Unit,
     onCancelClick: () -> Unit,
     onChangeImage: () -> Unit
 ) {
-    if (hasPickedImage) {
+    if (hasPickedImage || isUploadingImage) {
         Row(Modifier.fillMaxWidth()) {
             WireSecondaryButton(
                 modifier = Modifier
@@ -165,7 +169,9 @@ private fun AvatarPickerActionButtons(
                     .padding(dimensions().spacing16x)
                     .weight(1f),
                 text = stringResource(R.string.label_confirm),
-                onClick = { onSaveClick() }
+                onClick = { onSaveClick() },
+                loading = isUploadingImage,
+                state = if (isUploadingImage) WireButtonState.Disabled else WireButtonState.Default
             )
         }
     } else {
@@ -197,3 +203,6 @@ private fun mapErrorCodeToString(errorCode: ErrorCodes): String {
 
 @OptIn(ExperimentalMaterial3Api::class)
 private fun hasPickedImage(state: AvatarPickerViewModel.PictureState): Boolean = state is AvatarPickerViewModel.PictureState.Picked
+
+@OptIn(ExperimentalMaterial3Api::class)
+private fun isUploadingImage(state: AvatarPickerViewModel.PictureState): Boolean = state is AvatarPickerViewModel.PictureState.Uploading

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -58,6 +58,7 @@ class AvatarPickerViewModel @Inject constructor(
 
     fun uploadNewPickedAvatarAndBack() {
         val imgUri = pictureState.avatarUri
+        pictureState = PictureState.Uploading(imgUri)
         viewModelScope.launch {
             withContext(dispatchers.io()) {
                 val data = avatarImageManager.uriToByteArray(imgUri)
@@ -71,6 +72,8 @@ class AvatarPickerViewModel @Inject constructor(
                         is NetworkFailure.NoNetworkConnection -> ErrorCodes.NoNetworkError
                         else -> ErrorCodes.UploadAvatarError
                     }
+                    // reset picked state
+                    pictureState = PictureState.Picked(imgUri)
                 }
             }
         }
@@ -105,6 +108,7 @@ class AvatarPickerViewModel @Inject constructor(
     }
 
     sealed class PictureState(open val avatarUri: Uri) {
+        data class Uploading(override val avatarUri: Uri) : PictureState(avatarUri)
         data class Initial(override val avatarUri: Uri) : PictureState(avatarUri)
         data class Picked(override val avatarUri: Uri) : PictureState(avatarUri)
         object Empty : PictureState("".toUri())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1413" title="AR-1413" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1413</a>  Update profile picture by Gallery - tapping confirm button fastly many times crashes the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR fixes 2 unrelated issues:
1. User avatar picture uploading crash, when hitting desperately the confirm button, we added an uploading state to block the button
2. Adjust padding for header in muting options bottom sheet

### Attachments (Optional)
<img src="https://user-images.githubusercontent.com/5806454/166440567-a40ca1e9-7c3b-4324-943a-24655bb5a83c.gif" width="300"/>

<img src="https://user-images.githubusercontent.com/5806454/166440548-3fc25df7-31ab-49a3-bf3b-f45cc3a2fee2.png" width="300"/>

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [X] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
