### PR TITLE
chore(login): change the location of server title in login page

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/Login.kt
@@ -50,8 +50,6 @@ fun LoginScreen(serverConfig: ServerConfig, ssoLoginResult: DeepLinkResult.SSOLo
     loginViewModel.updateServerConfig(ssoLoginResult, serverConfig)
     LoginContent(
         onBackPressed = { loginViewModel.navigateBack() },
-        //todo: temporary to show the remoteConfig
-        serverTitle = loginViewModel.serverConfig.title,
         serverConfig = loginViewModel.serverConfig,
         ssoLoginResult = ssoLoginResult
     )
@@ -61,7 +59,6 @@ fun LoginScreen(serverConfig: ServerConfig, ssoLoginResult: DeepLinkResult.SSOLo
 @Composable
 private fun LoginContent(
     onBackPressed: () -> Unit,
-    serverTitle: String,
     serverConfig: ServerConfig,
     ssoLoginResult: DeepLinkResult.SSOLogin?
 ) {
@@ -73,7 +70,7 @@ private fun LoginContent(
         topBar = {
             WireCenterAlignedTopAppBar(
                 elevation = scrollState.appBarElevation(),
-                title = "${stringResource(R.string.login_title)} $serverTitle",
+                title = stringResource(R.string.login_title),
                 onNavigationPressed = onBackPressed
             ) {
                 WireTabRow(
@@ -126,7 +123,7 @@ enum class LoginTabItem(@StringRes override val titleResId: Int) : TabItem {
 @Composable
 private fun LoginScreenPreview() {
     WireTheme(isPreview = true) {
-        LoginContent(onBackPressed = { }, serverTitle = "", serverConfig = ServerConfig.STAGING, ssoLoginResult = null)
+        LoginContent(onBackPressed = { }, serverConfig = ServerConfig.STAGING, ssoLoginResult = null)
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmail.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmail.kt
@@ -50,7 +50,6 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.DialogErrorStrings
-import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.dialogErrorStrings
 import com.wire.kalium.logic.configuration.ServerConfig
 import kotlinx.coroutines.CoroutineScope
@@ -64,7 +63,7 @@ fun LoginEmailScreen(
 ) {
     val scope = rememberCoroutineScope()
     val loginEmailViewModel: LoginEmailViewModel = hiltViewModel()
-    loginEmailViewModel.updateServerConfig(ssoLoginResult = null , serverConfig)
+    loginEmailViewModel.updateServerConfig(ssoLoginResult = null, serverConfig)
     val loginEmailState: LoginEmailState = loginEmailViewModel.loginState
     LoginEmailContent(
         scrollState = scrollState,
@@ -75,7 +74,8 @@ fun LoginEmailScreen(
         onRemoveDeviceOpen = { loginEmailViewModel.onTooManyDevicesError() },
         onLoginButtonClick = suspend { loginEmailViewModel.login() },
         accountsBaseUrl = loginEmailViewModel.serverConfig.accountsBaseUrl,
-        scope = scope
+        scope = scope,
+        serverTitle = loginEmailViewModel.serverConfig.title
     )
 }
 
@@ -90,7 +90,9 @@ private fun LoginEmailContent(
     onRemoveDeviceOpen: () -> Unit,
     onLoginButtonClick: suspend () -> Unit,
     accountsBaseUrl: String,
-    scope: CoroutineScope
+    scope: CoroutineScope,
+    //todo: temporary to show to pointing server
+    serverTitle: String
 ) {
     Column(
         modifier = Modifier
@@ -108,7 +110,8 @@ private fun LoginEmailContent(
             error = when (loginEmailState.loginEmailError) {
                 LoginError.TextFieldError.InvalidValue -> stringResource(R.string.login_error_invalid_user_identifier)
                 else -> null
-            }
+            },
+            serverTitle = serverTitle
         )
         PasswordInput(
             modifier = Modifier
@@ -175,13 +178,15 @@ private fun UserIdentifierInput(
     modifier: Modifier,
     userIdentifier: TextFieldValue,
     error: String?,
-    onUserIdentifierChange: (TextFieldValue) -> Unit
+    onUserIdentifierChange: (TextFieldValue) -> Unit,
+    //todo: temporary to show to pointing server
+    serverTitle: String
 ) {
     WireTextField(
         value = userIdentifier,
         onValueChange = onUserIdentifierChange,
         placeholderText = stringResource(R.string.login_user_identifier_placeholder),
-        labelText = stringResource(R.string.login_user_identifier_label),
+        labelText = stringResource(R.string.login_user_identifier_label) + " on $serverTitle",
         state = if (error != null) WireTextFieldState.Error(error) else WireTextFieldState.Default,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
         modifier = modifier.testTag("emailField")
@@ -261,7 +266,8 @@ private fun LoginEmailScreenPreview() {
             onRemoveDeviceOpen = { },
             onLoginButtonClick = suspend { },
             accountsBaseUrl = "",
-            scope = scope
+            scope = scope,
+            serverTitle = "Test Server"
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSO.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSO.kt
@@ -71,7 +71,8 @@ fun LoginSSOScreen(
         //TODO: replace with retrieved ServerConfig from sso login
         onLoginButtonClick = suspend { loginSSOViewModel.login() },
         scope = scope,
-        ssoLoginResult
+        ssoLoginResult,
+        serverTitle = loginSSOViewModel.serverConfig.title
     )
 
     LaunchedEffect(loginSSOViewModel) {
@@ -91,7 +92,9 @@ private fun LoginSSOContent(
     onRemoveDeviceOpen: () -> Unit,
     onLoginButtonClick: suspend () -> Unit,
     scope: CoroutineScope,
-    ssoLoginResult: DeepLinkResult.SSOLogin?
+    ssoLoginResult: DeepLinkResult.SSOLogin?,
+    //todo: temporary to show to pointing server
+    serverTitle: String
 ) {
     Column(
         modifier = Modifier
@@ -109,7 +112,8 @@ private fun LoginSSOContent(
             error = when (loginSSOState.loginSSOError) {
                 LoginError.TextFieldError.InvalidValue -> stringResource(R.string.login_error_invalid_sso_code_format)
                 else -> null
-            }
+            },
+            serverTitle = serverTitle
         )
         Spacer(modifier = Modifier.weight(1f))
         LoginButton(
@@ -169,13 +173,15 @@ private fun SSOCodeInput(
     modifier: Modifier,
     ssoCode: TextFieldValue,
     error: String?,
-    onCodeChange: (TextFieldValue) -> Unit
+    onCodeChange: (TextFieldValue) -> Unit,
+    //todo: temporary to show to pointing server
+    serverTitle: String
 ) {
     WireTextField(
         value = ssoCode,
         onValueChange = onCodeChange,
         placeholderText = stringResource(R.string.login_sso_code_placeholder),
-        labelText = stringResource(R.string.login_sso_code_label),
+        labelText = stringResource(R.string.login_sso_code_label) + " on $serverTitle",
         state = if (error != null) WireTextFieldState.Error(error) else WireTextFieldState.Default,
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Next),
         modifier = modifier.testTag("ssoCodeField")
@@ -205,7 +211,7 @@ private fun LoginButton(modifier: Modifier, loading: Boolean, enabled: Boolean, 
 @Composable
 private fun LoginSSOScreenPreview() {
     WireTheme(isPreview = true) {
-        LoginSSOContent(rememberScrollState(), LoginSSOState(), {}, {}, {}, suspend {}, rememberCoroutineScope(), null)
+        LoginSSOContent(rememberScrollState(), LoginSSOState(), {}, {}, {}, suspend {}, rememberCoroutineScope(), null, "Test Server")
     }
 }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Changed the location of server title in each login tab, to see which server we are pointing to

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing



#### How to Test

In login page and in login with email and login with sso tabs, the input label has the pointing server title in it.

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
