### PR TITLE
fix: asset size errors [AR-1476]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
             android:label="@string/app_name"
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
+            android:largeHeap="true"
             android:theme="@style/AppTheme.SplashScreen">
 
         <activity

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationErrors.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationErrors.kt
@@ -1,0 +1,7 @@
+package com.wire.android.ui.home.conversations
+
+sealed class ConversationErrors {
+    object ERROR_PICKING_ATTACHMENT : ConversationErrors()
+    object ERROR_MAX_IMAGE_SIZE : ConversationErrors()
+    object ERROR_SENDING_IMAGE : ConversationErrors()
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
@@ -7,7 +7,7 @@ data class ConversationViewState(
     val conversationName: String = "",
     val conversationAvatar: ConversationAvatar = ConversationAvatar.None,
     val messages: List<MessageViewWrapper> = emptyList(),
-    val failedMessages: String = "",
+    val onError: ConversationErrors? = null,
     val messageText: String = ""
 )
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -1,5 +1,6 @@
 package com.wire.android.ui.home.conversations.model
 
+import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -33,6 +34,8 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import coil.compose.rememberAsyncImagePainter
 import com.wire.android.R
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.ConversationViewModel
 import com.wire.android.ui.home.conversations.MessageItem
 import com.wire.android.ui.home.conversations.mock.mockAssetMessage
 import com.wire.android.ui.home.conversations.mock.mockMessageWithText
@@ -41,7 +44,6 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getUriFromDrawable
 import com.wire.android.util.toBitmap
-import com.wire.kalium.logic.data.user.UserAssetId
 import kotlin.math.roundToInt
 
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
@@ -61,18 +63,15 @@ fun MessageImage(rawImgData: ByteArray?, imgParams: ImageMessageParams, onImageC
         .clip(shape = RoundedCornerShape(MaterialTheme.wireDimensions.messageAssetBorderRadius))
         .clickable { onImageClick() }
     ) {
+        val imageData: Bitmap? =
+            if (rawImgData != null && rawImgData.size < ConversationViewModel.IMAGE_SIZE_LIMIT_BYTES) rawImgData.toBitmap() else null
         Image(
-            painter = rememberAsyncImagePainter(
-                rawImgData?.toBitmap() ?: getUriFromDrawable(
-                    LocalContext.current,
-                    R.drawable.ic_gallery
-                )
-            ),
+            painter = rememberAsyncImagePainter(imageData ?: getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
             alignment = Alignment.CenterStart,
             contentDescription = stringResource(R.string.content_description_image_message),
             modifier = Modifier
-            .width(imgParams.normalizedWidth)
-            .height(imgParams.normalizedHeight),
+                .width(if (imageData != null) imgParams.normalizedWidth else dimensions().spacing24x)
+                .height(if (imageData != null) imgParams.normalizedHeight else dimensions().spacing24x),
             contentScale = ContentScale.Crop
         )
     }
@@ -105,7 +104,8 @@ internal fun MessageAsset(assetName: String, assetExtension: String, assetSizeIn
             ConstraintLayout(
                 Modifier
                     .fillMaxWidth()
-                    .padding(top = MaterialTheme.wireDimensions.spacing8x)) {
+                    .padding(top = MaterialTheme.wireDimensions.spacing8x)
+            ) {
                 val (icon, description, downloadStatus) = createRefs()
                 Image(
                     modifier = Modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -62,6 +62,7 @@ import com.wire.android.ui.common.button.WireIconButton
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.textfield.WireTextField
 import com.wire.android.ui.common.textfield.wireTextFieldColors
+import com.wire.android.ui.home.conversations.ConversationErrors
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.messagecomposer.attachment.AttachmentOptionsComponent
 import com.wire.android.ui.theme.wireColorScheme
@@ -77,7 +78,7 @@ fun MessageComposer(
     onMessageChanged: (String) -> Unit,
     onSendButtonClicked: () -> Unit,
     onSendAttachment: (AttachmentBundle?) -> Unit,
-    onError: (String) -> Unit,
+    onMessageComposerError: (ConversationErrors) -> Unit,
     onMessageComposerInputStateChange: (MessageComposerStateTransition) -> Unit,
 ) {
     BoxWithConstraints {
@@ -108,7 +109,7 @@ fun MessageComposer(
                 onSendAttachment(it)
                 messageComposerState.toggleAttachmentOptionsVisibility()
             },
-            onError = onError
+            onMessageComposerError = onMessageComposerError
         )
     }
 }
@@ -129,7 +130,7 @@ private fun MessageComposer(
     onMessageChanged: (TextFieldValue) -> Unit,
     onSendButtonClicked: () -> Unit,
     onSendAttachment: (AttachmentBundle?) -> Unit,
-    onError: (String) -> Unit
+    onMessageComposerError: (ConversationErrors) -> Unit
 ) {
     val focusManager = LocalFocusManager.current
     // when MessageComposer is composed for the first time we do not know the height
@@ -370,7 +371,7 @@ private fun MessageComposer(
                     AttachmentOptionsComponent(
                         messageComposerState.attachmentInnerState,
                         onSendAttachment,
-                        onError,
+                        onMessageComposerError,
                         Modifier.align(Alignment.Center)
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
@@ -19,6 +19,8 @@ import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.ui.common.AttachmentButton
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversations.ConversationErrors
+import com.wire.android.ui.home.conversations.ConversationErrors.ERROR_PICKING_ATTACHMENT
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.messagecomposer.AttachmentInnerState
 import com.wire.android.ui.home.messagecomposer.AttachmentState
@@ -39,7 +41,7 @@ import kotlinx.coroutines.launch
 fun AttachmentOptionsComponent(
     attachmentInnerState: AttachmentInnerState,
     onSendAttachment: (AttachmentBundle?) -> Unit,
-    onError: (String) -> Unit,
+    onError: (ConversationErrors) -> Unit,
     modifier : Modifier= Modifier
 ) {
     val scope = rememberCoroutineScope()
@@ -63,7 +65,7 @@ fun AttachmentOptionsComponent(
 private fun configureStateHandling(
     attachmentInnerState: AttachmentInnerState,
     onSendAttachment: (AttachmentBundle?) -> Unit,
-    onError: (String) -> Unit
+    onError: (ConversationErrors) -> Unit
 ) {
     when (val state = attachmentInnerState.attachmentState) {
         is AttachmentState.NotPicked -> appLogger.d("Not picked yet")
@@ -72,8 +74,7 @@ private fun configureStateHandling(
             attachmentInnerState.resetAttachmentState()
         }
         is AttachmentState.Error -> {
-            // FIXME. later on expand to other possible errors
-            onError(stringResource(R.string.error_unknown_message))
+            onError(ERROR_PICKING_ATTACHMENT)
             attachmentInnerState.resetAttachmentState()
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -276,6 +276,9 @@
     <string name="error_downloading_user_info">There was an error downloading the user information. Please check your Internet connection</string>
     <string name="error_uploading_user_avatar">Image could not be uploaded</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>
+    <string name="error_conversation_sending_image">There was an error trying to send the image message. Please check your Internet connection and try again</string>
+    <string name="error_conversation_max_image_size_limit">The image you chose is too large. Please choose an image smaller than 15MB</string>
+    <string name="error_conversation_generic">There was an unknown error when trying to send the message</string>
 
     <!-- Animation label -->
     <string name="animation_label_messagecomposeinput_state_transistion" translatable="false">MessageComposeInputState transition</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When user tries to upload large asset files, the app crashes with an `OutOfMemoryError`. This is due to fact that we pass around and manipulate the asset data in a ByteArray form, so when performing some operation that require these byte arrays to be copied, such exceptions are thrown. 

### Solutions

In order to solve this problem, one could decide between two solutions:
1. **The dirty and quick one**: Launching the app with a large memory heap flag + setting up an asset send limit. This will permit users send assets that weigh up to 100MB.  This would however cause that the garbage collector runs less often than with a normal heap limit, increasing the time until we notice about certain memory leaks, and making the debug of these more complicated.
2. **The clean but laborious one**: Instead of handling the raw data on the shape of ByteArrays, we could use files or inputStream like methods to make the upload, download, encryption and decryption processes. The main problem is that Ktor doesn't provide such methods to certain targets like iOS and JS. Therefore we would need to use a different library for this. A strong candidate would be (Okio)[https://square.github.io/okio/], as it seems it offers already a set of helper methods supporting Files and data stream for all platforms. 

For the moment, and due to the pressing circumstances to deliver an MVP, I'm proposing to go with option **1.** 
However, a future refactor to accommodate for option 2. will be much needed once we are done with the first prototype of the app.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
