### PR TITLE
fix: add bottomNavigation height as padding to the main home navHost [AR-1474]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/BottomNavigation.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/BottomNavigation.kt
@@ -46,9 +46,9 @@ fun WireBottomNavigationBar(
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(60.dp),
+            .height(MaterialTheme.wireDimensions.bottomNavigationHeight),
         color = MaterialTheme.colorScheme.surface,
-        shadowElevation = 8.dp,
+        shadowElevation = MaterialTheme.wireDimensions.bottomNavigationHeight,
     ) {
         Row(horizontalArrangement = Arrangement.SpaceBetween) {
             items.forEachIndexed { index, item ->
@@ -60,9 +60,9 @@ fun WireBottomNavigationBar(
                         top = MaterialTheme.wireDimensions.bottomNavigationVerticalPadding,
                         bottom = MaterialTheme.wireDimensions.bottomNavigationVerticalPadding,
                         start = if (index == 0) MaterialTheme.wireDimensions.bottomNavigationHorizontalPadding
-                                else MaterialTheme.wireDimensions.bottomNavigationBetweenItemsPadding,
+                        else MaterialTheme.wireDimensions.bottomNavigationBetweenItemsPadding,
                         end = if (index == items.lastIndex) MaterialTheme.wireDimensions.bottomNavigationHorizontalPadding
-                              else MaterialTheme.wireDimensions.bottomNavigationBetweenItemsPadding
+                        else MaterialTheme.wireDimensions.bottomNavigationBetweenItemsPadding
                     )
 
                 WireBottomNavigationItem(
@@ -91,7 +91,7 @@ fun RowScope.WireBottomNavigationItem(
     modifier: Modifier = Modifier,
     onItemClick: (WireBottomNavigationItemData) -> Unit
 ) {
-    val backgroundColor = if(selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
+    val backgroundColor = if (selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
     val contentColor = if (selected) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onBackground
     Box(
         modifier

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -33,6 +33,7 @@ import com.wire.android.ui.home.conversationslist.bottomsheet.ConversationSheetC
 import com.wire.android.ui.home.conversationslist.bottomsheet.NotificationsOptionsItem
 import com.wire.android.ui.home.conversationslist.model.ConversationType
 import com.wire.android.ui.home.conversationslist.navigation.ConversationsNavigationItem
+import com.wire.android.ui.theme.wireDimensions
 import com.wire.kalium.logic.data.id.ConversationId
 
 @ExperimentalAnimationApi
@@ -174,7 +175,10 @@ private fun ConversationRouter(
 
         with(uiState) {
             // Change to a AnimatedNavHost and composable from accompanist lib to add transitions animations
-            NavHost(conversationState.navHostController, startDestination = ConversationsNavigationItem.All.route) {
+            NavHost(
+                conversationState.navHostController, startDestination = ConversationsNavigationItem.All.route, modifier = Modifier
+                    .padding(bottom = MaterialTheme.wireDimensions.bottomNavigationHeight)
+            ) {
                 composable(
                     route = ConversationsNavigationItem.All.route,
                     content = {
@@ -222,7 +226,7 @@ private fun ConversationNavigationItems(
 ): List<WireBottomNavigationItemData> {
     return ConversationsNavigationItem.values().map { conversationsNavigationItem ->
         when (conversationsNavigationItem) {
-            ConversationsNavigationItem.All -> conversationsNavigationItem.toBottomNavigationItemData(uiListState.newActivityCount)
+            ConversationsNavigationItem.All -> conversationsNavigationItem.toBottomNavigationItemData(uiListState.conversations.size)
             ConversationsNavigationItem.Calls -> conversationsNavigationItem.toBottomNavigationItemData(uiListState.missedCallsCount)
             ConversationsNavigationItem.Mentions -> conversationsNavigationItem.toBottomNavigationItemData(uiListState.unreadMentionsCount)
         }

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -39,6 +39,8 @@ data class WireDimensions(
     val bottomNavigationVerticalPadding: Dp,
     val bottomNavigationBetweenItemsPadding: Dp,
     val bottomNavigationItemPadding: Dp,
+    val bottomNavigationHeight: Dp,
+    val bottomNavigationShadowElevation: Dp,
     // Conversation
     val conversationItemRowHeight: Dp,
     val conversationItemPadding: Dp,
@@ -170,6 +172,8 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     bottomNavigationVerticalPadding = 4.dp,
     bottomNavigationBetweenItemsPadding = 12.dp,
     bottomNavigationItemPadding = 6.dp,
+    bottomNavigationHeight = 60.dp,
+    bottomNavigationShadowElevation = 8.dp,
     conversationItemRowHeight = 56.dp,
     conversationItemPadding = 0.5.dp,
     conversationsListBottomPadding = 74.dp,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1474" title="AR-1474" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1474</a>  Conversations - Some groups appear on list only after restarting the app
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Detected suspicious missing conversations every time we open the app!

### Causes (Optional)
After some logging and checking, I found a spooky hidden thing! The lost conversation was below the bottomNavigation!

![FacePalm](https://media4.giphy.com/media/eH2uOQEmvcqcqgPoH3/giphy.gif
)

### Solutions

Added the height of the navigationBottom to the NavHost to the main screen.


Needs releases with:

- [ ] GitHub link to other pull request

### Testing
Manual testing
#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.

[AR-1474]: https://wearezeta.atlassian.net/browse/AR-1474