### PR TITLE
fix: app crash when receiving notification for unauthenticated account

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -31,7 +31,7 @@ class WireNotificationManager @Inject constructor(
      * @param userId QualifiedID of User that need to check Notifications for
      */
     suspend fun fetchAndShowMessageNotificationsOnce(userIdValue: String) {
-        checkifUserIsAuthenticated(userId = userIdValue)?.let { userId ->
+        checkIfUserIsAuthenticated(userId = userIdValue)?.let { userId ->
             coreLogic.getSessionScope(userId).syncPendingEvents()
             val notificationsList = getNotificationProvider.create(userId)
                 .getNotifications()
@@ -45,22 +45,24 @@ class WireNotificationManager @Inject constructor(
      * return the userId if the user is authenticated and null otherwise
      */
     @Suppress("NestedBlockDepth")
-    private fun checkifUserIsAuthenticated(userId: String): QualifiedID? {
+    private fun checkIfUserIsAuthenticated(userId: String): QualifiedID? =
         coreLogic.getAuthenticationScope().getSessions().let {
             when (it) {
                 is GetAllSessionsResult.Success -> {
                     for (sessions in it.sessions) {
                         if (sessions.userId.value == userId)
-                            return sessions.userId
+                            return@let sessions.userId
                     }
+                    null
                 }
                 is GetAllSessionsResult.Failure.Generic -> {
                     appLogger.e("get sessions failed ${it.genericFailure} ")
+                    null
                 }
+                GetAllSessionsResult.Failure.NoSessionFound -> null
             }
         }
-        return null
-    }
+
 
     /**
      * Infinitely listen for the new Message notifications and show it.

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -31,19 +31,21 @@ class WireNotificationManager @Inject constructor(
      * @param userId QualifiedID of User that need to check Notifications for
      */
     suspend fun fetchAndShowMessageNotificationsOnce(userIdValue: String) {
-        val userId = getQualifiedIDFromUserId(userId = userIdValue)
-        coreLogic.getSessionScope(userId).syncPendingEvents()
-
-        val notificationsList = getNotificationProvider.create(userId)
-            .getNotifications()
-            .first()
-
-        notificationManager.handleNotification(listOf(), notificationsList, userId)
+        checkifUserIsAuthenticated(userId = userIdValue)?.let { userId ->
+            coreLogic.getSessionScope(userId).syncPendingEvents()
+            val notificationsList = getNotificationProvider.create(userId)
+                .getNotifications()
+                .first()
+            notificationManager.handleNotification(listOf(), notificationsList, userId)
+        }
     }
 
     // todo to be deleted as soon as we get the qualifiedID from the notification payload
+    /**
+     * return the userId if the user is authenticated and null otherwise
+     */
     @Suppress("NestedBlockDepth")
-    private fun getQualifiedIDFromUserId(userId: String): QualifiedID {
+    private fun checkifUserIsAuthenticated(userId: String): QualifiedID? {
         coreLogic.getAuthenticationScope().getSessions().let {
             when (it) {
                 is GetAllSessionsResult.Success -> {
@@ -57,7 +59,7 @@ class WireNotificationManager @Inject constructor(
                 }
             }
         }
-        return QualifiedID(userId, "wire.com")
+        return null
     }
 
     /**

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -40,7 +40,7 @@ class WireNotificationManager @Inject constructor(
         }
     }
 
-    // todo to be deleted as soon as we get the qualifiedID from the notification payload
+    // TODO: to be changed as soon as we get the qualifiedID from the notification payload
     /**
      * return the userId if the user is authenticated and null otherwise
      */


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

App crash when receiving notification for unauthenticated account

### Solutions

the notification should be handled if and only if the user is authenticated.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
