### PR TITLE
fix: pass an function reference instead of a lambda [AR-1663]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -51,7 +51,7 @@ fun ConversationScreen(conversationViewModel: ConversationViewModel) {
         onSendButtonClicked = conversationViewModel::sendMessage,
         onSendAttachment = conversationViewModel::sendAttachmentMessage,
         onDownloadAsset = conversationViewModel::downloadAsset,
-        onImageFullScreenMode =  conversationViewModel::navigateToGallery ,
+        onImageFullScreenMode = conversationViewModel::navigateToGallery,
         onBackButtonClick = conversationViewModel::navigateBack,
         onDeleteMessage = conversationViewModel::showDeleteMessageDialog,
         onCallStart = audioPermissionCheck::launch,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
@@ -28,7 +29,6 @@ import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
 import com.wire.android.ui.home.conversations.ConversationErrors.ErrorMaxAssetSize
 import com.wire.android.ui.home.conversations.ConversationErrors.ErrorMaxImageSize
-import com.wire.android.ui.home.conversations.ConversationErrors.ErrorSendingAsset
 import com.wire.android.ui.home.conversations.ConversationErrors.ErrorSendingImage
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
 import com.wire.android.ui.home.conversations.mock.getMockedMessages
@@ -51,7 +51,7 @@ fun ConversationScreen(conversationViewModel: ConversationViewModel) {
         onSendButtonClicked = conversationViewModel::sendMessage,
         onSendAttachment = conversationViewModel::sendAttachmentMessage,
         onDownloadAsset = conversationViewModel::downloadAsset,
-        onImageFullScreenMode = { conversationViewModel.navigateToGallery(it) },
+        onImageFullScreenMode =  conversationViewModel::navigateToGallery ,
         onBackButtonClick = conversationViewModel::navigateBack,
         onDeleteMessage = conversationViewModel::showDeleteMessageDialog,
         onCallStart = audioPermissionCheck::launch,
@@ -130,11 +130,11 @@ private fun ConversationScreen(
                             onMessageChanged = onMessageChanged,
                             messageText = conversationViewState.messageText,
                             onSendButtonClicked = onSendButtonClicked,
-                            onShowContextMenu = { message -> conversationScreenState.showEditContextMenu(message) },
+                            onShowContextMenu =  conversationScreenState::showEditContextMenu,
                             onSendAttachment = onSendAttachment,
                             onDownloadAsset = onDownloadAsset,
                             onImageFullScreenMode = onImageFullScreenMode,
-                            conversationState = this,
+                            conversationState = conversationViewState,
                             onMessageComposerError = onError,
                             conversationScreenState = conversationScreenState
                         )
@@ -216,12 +216,7 @@ private fun ConversationScreenContent(
     conversationState: ConversationViewState,
     conversationScreenState: ConversationScreenState
 ) {
-    val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
-
-    LaunchedEffect(conversationState.messages) {
-        lazyListState.animateScrollToItem(0)
-    }
 
     conversationState.onError?.let { errorCode ->
         val errorMessage = getErrorMessage(errorCode)
@@ -230,26 +225,21 @@ private fun ConversationScreenContent(
         }
     }
 
+    val lazyListState = rememberLazyListState()
+
+    LaunchedEffect(messages){
+        lazyListState.animateScrollToItem(0)
+    }
+
     MessageComposer(
         content = {
-            LazyColumn(
-                state = lazyListState,
-                reverseLayout = true,
-                modifier = Modifier
-                    .fillMaxHeight()
-                    .fillMaxWidth()
-            ) {
-                items(messages, key = {
-                    it.messageHeader.messageId
-                }) { message ->
-                    MessageItem(
-                        message = message,
-                        onLongClicked = { onShowContextMenu(message) },
-                        onAssetMessageClicked = onDownloadAsset,
-                        onImageMessageClicked = onImageFullScreenMode
-                    )
-                }
-            }
+            MessageList(
+                messages = messages,
+                lazyListState = lazyListState,
+                onShowContextMenu = onShowContextMenu,
+                onDownloadAsset = onDownloadAsset,
+                onImageFullScreenMode = onImageFullScreenMode
+            )
         },
         messageText = messageText,
         onMessageChanged = onMessageChanged,
@@ -264,6 +254,34 @@ private fun ConversationScreenContent(
             }
         }
     )
+}
+
+@Composable
+fun MessageList(
+    messages: List<MessageViewWrapper>,
+    lazyListState: LazyListState,
+    onShowContextMenu: (MessageViewWrapper) -> Unit,
+    onDownloadAsset: (String) -> Unit,
+    onImageFullScreenMode: (String) -> Unit
+) {
+    LazyColumn(
+        state = lazyListState,
+        reverseLayout = true,
+        modifier = Modifier
+            .fillMaxHeight()
+            .fillMaxWidth()
+    ) {
+        items(messages, key = {
+            it.messageHeader.messageId
+        }) { message ->
+            MessageItem(
+                message = message,
+                onLongClicked = onShowContextMenu,
+                onAssetMessageClicked = onDownloadAsset,
+                onImageMessageClicked = onImageFullScreenMode
+            )
+        }
+    }
 }
 
 @Preview

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -130,7 +130,7 @@ private fun ConversationScreen(
                             onMessageChanged = onMessageChanged,
                             messageText = conversationViewState.messageText,
                             onSendButtonClicked = onSendButtonClicked,
-                            onShowContextMenu =  conversationScreenState::showEditContextMenu,
+                            onShowContextMenu = conversationScreenState::showEditContextMenu,
                             onSendAttachment = onSendAttachment,
                             onDownloadAsset = onDownloadAsset,
                             onImageFullScreenMode = onImageFullScreenMode,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -47,7 +47,7 @@ import com.wire.android.ui.theme.wireTypography
 @Composable
 fun MessageItem(
     message: MessageViewWrapper,
-    onLongClicked: () -> Unit,
+    onLongClicked: (MessageViewWrapper) -> Unit,
     onAssetMessageClicked: (String) -> Unit,
     onImageMessageClicked: (String) -> Unit
 ) {
@@ -62,7 +62,7 @@ fun MessageItem(
                 .combinedClickable(
                     //TODO: implement some action onClick
                     onClick = { },
-                    onLongClick = onLongClicked
+                    onLongClick = { onLongClicked(message) }
                 )
         ) {
             Spacer(Modifier.padding(start = dimensions().spacing2x))

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -49,7 +49,6 @@ private fun getTempWritableAttachmentUri(context: Context, fileName: String): Ur
     return FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", file)
 }
 
-
 fun Uri.getMimeType(context: Context): String? {
     val extension = MimeTypeMap.getFileExtensionFromUrl(path)
     return context.contentResolver.getType(this)

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -49,6 +49,7 @@ private fun getTempWritableAttachmentUri(context: Context, fileName: String): Ur
     return FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID + ".provider", file)
 }
 
+
 fun Uri.getMimeType(context: Context): String? {
     val extension = MimeTypeMap.getFileExtensionFromUrl(path)
     return context.contentResolver.getType(this)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1663" title="AR-1663" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1663</a>  Scrolling in the conversation is not smooth and images are flickering
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

While typing a message the ConversationScreen were recomposed causing images and other items being recomposed.

### Causes

The lambda was recreated invalidating the items
 
### Solutions

pass a function reference instead of a lambda

#### How to Test

1. Open a conversation with image assets
2. Start typing

The image should no longer flicker.

### Notes

I found not really intuitive issue causing the Image Assets being recomposed inside the ConversationScreen:

If we have something like this :

```
@Composable
fun SomeParentComposable(someString : String, someLambda : () -> Unit, someOtherLambda : () -> Unit){
SomeOtherInnerComposableTakingOnlyString(someString)
SomeInnerComposable({ someLambda() } , { someOtherLambda() } )
}

@Composable
fun SomeInnerComposable(someLambda : () -> Unit, someOtherLambda : () -> Unit){
... something else here
}
```

and imagine that the someString changes,  SomeOtherInnerComposableTakingOnlyString() will get recomposed of course because String changes, but I was expecting SomeInnerComposable() not being recomposed but because everything gets invalidated inside SomeParentComposable, new lambda is being created and since lambda is an anonymous class object, it gets new hashcode and SomeInnerComposable() gets recomposed a fix to would be to do it like this ;

```
@Composable
fun SomeParentComposable(someString : String, someLambda : () -> Unit, someOtherLambda : () -> Unit){
SomeOtherInnerComposableTakingOnlyString(someString)
SomeInnerComposable(someLambda , someOtherLambda )
}

```
that way we are passing a reference

the same goes for calling a ViewModel functions for example this will recompose SomeInnerComposable,

```
@Composable
fun SomeParentComposable(someString : String,viewModel : ViewModel){
SomeOtherInnerComposableTakingOnlyString(someString)
SomeInnerComposable({ viewModel.someMethod() } , {  viewModel.someOtherMethod() } )
}

@Composable
fun SomeInnerComposable(someLambda : () -> Unit, someOtherLambda : () -> Unit){
... something else here
}

```

this will not because we are passing an object reference :

```
@Composable
fun SomeParentComposable(someString : String,viewModel : ViewModel){
SomeOtherInnerComposableTakingOnlyString(someString)
SomeInnerComposable( viewModel::someMethod , {viewModel::someOtherMethod )
}

@Composable
fun SomeInnerComposable(someLambda : () -> Unit, someOtherLambda : () -> Unit){
... something else here
}
```

### Attachments

![not-flickering](https://user-images.githubusercontent.com/15973138/168818418-f389996b-2aec-476d-afff-4ca7fd8e2438.gif)

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### 

References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
