### PR TITLE
fix: catch crashes on out of memory errors [AR-1323]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -27,9 +27,11 @@ import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.bottomsheet.MenuModalSheetLayout
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
+import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorDownloadingAsset
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxAssetSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxImageSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorOpeningAssetFile
+import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingAsset
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingImage
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnFileDownloaded
 import com.wire.android.ui.home.conversations.delete.DeleteMessageDialog
@@ -223,6 +225,8 @@ private fun getSnackbarMessage(messageCode: ConversationSnackbarMessages): Pair<
         is ErrorMaxAssetSize -> stringResource(R.string.error_conversation_max_asset_size_limit, messageCode.maxLimitInMB)
         is ErrorMaxImageSize -> stringResource(R.string.error_conversation_max_image_size_limit)
         is ErrorSendingImage -> stringResource(R.string.error_conversation_sending_image)
+        is ErrorSendingAsset -> stringResource(R.string.error_conversation_sending_asset)
+        is ErrorDownloadingAsset -> stringResource(R.string.error_conversation_downloading_asset)
         is ErrorOpeningAssetFile -> stringResource(R.string.error_conversation_opening_asset_file)
         is OnFileDownloaded -> stringResource(R.string.conversation_on_file_downloaded, messageCode.assetName ?: "")
         else -> stringResource(R.string.error_conversation_generic)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSnackbarMessages.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationSnackbarMessages.kt
@@ -4,6 +4,7 @@ sealed class ConversationSnackbarMessages {
     object ErrorPickingAttachment : ConversationSnackbarMessages()
     object ErrorMaxImageSize : ConversationSnackbarMessages()
     object ErrorSendingAsset : ConversationSnackbarMessages()
+    object ErrorDownloadingAsset : ConversationSnackbarMessages()
     object ErrorSendingImage : ConversationSnackbarMessages()
     object ErrorOpeningAssetFile : ConversationSnackbarMessages()
     class ErrorMaxAssetSize(val maxLimitInMB: Int) : ConversationSnackbarMessages()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -76,9 +76,7 @@ fun MessageItem(
                 Spacer(modifier = Modifier.height(dimensions().spacing6x))
                 if (!isDeleted) {
                     MessageContent(messageContent,
-                        onAssetClick = { assetId ->
-                            onAssetMessageClicked(message.messageHeader.messageId)
-                        },
+                        onAssetClick = { onAssetMessageClicked(message.messageHeader.messageId) },
                         onImageClick = {
                             onImageMessageClicked(message.messageHeader.messageId)
                         })
@@ -141,7 +139,7 @@ private fun Username(username: String) {
 }
 
 @Composable
-private fun MessageContent(messageContent: MessageContent?, onAssetClick: (String) -> Unit, onImageClick: () -> Unit = {}) {
+private fun MessageContent(messageContent: MessageContent?, onAssetClick: () -> Unit, onImageClick: () -> Unit = {}) {
     when (messageContent) {
         is MessageContent.ImageMessage -> MessageImage(
             rawImgData = messageContent.rawImgData,
@@ -155,7 +153,7 @@ private fun MessageContent(messageContent: MessageContent?, onAssetClick: (Strin
             assetExtension = messageContent.assetExtension,
             assetSizeInBytes = messageContent.assetSizeInBytes,
             assetDownloadStatus = messageContent.downloadStatus,
-            onAssetClick = { onAssetClick(messageContent.assetId) }
+            onAssetClick = { onAssetClick() }
         )
         else -> {}
     }

--- a/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileUtil.kt
@@ -130,7 +130,7 @@ fun Context.startFileShareIntent(path: String) {
 }
 
 fun saveFileToDownloadsFolder(assetName: String?, assetData: ByteArray, context: Context) {
-    val file = File(context.getExternalFilesDir(DIRECTORY_DOWNLOADS), "${System.currentTimeMillis()}_$assetName")
+    val file = File(context.getExternalFilesDir(DIRECTORY_DOWNLOADS), "${assetName}")
     file.setWritable(true)
     file.writeBytes(assetData)
     context.saveFileDataToDownloadsFolder(file, assetData.size)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,6 +288,8 @@
     <string name="error_uploading_user_avatar">Image could not be uploaded</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>
     <string name="error_conversation_sending_image">There was an error trying to send the image message. Please check your Internet connection and try again</string>
+    <string name="error_conversation_sending_asset">There was an error trying to send that file. Please check the file you chose is not too big and try again</string>
+    <string name="error_conversation_downloading_asset">There was an error trying to download that file. Please try again</string>
     <string name="error_conversation_opening_asset_file">No app was found to open the selected file</string>
     <string name="error_conversation_max_image_size_limit">The image you chose is too large. Please choose an image smaller than 15MB</string>
     <string name="error_conversation_max_asset_size_limit">The file you chose is too large. Please choose a file smaller than %sMB</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes, when the device memory is too high, and we choose a big asset download to download or upload, an `OutOfMemory` error can be thrown. This PR makes sure that the app doesn't crash and displays some useful information to the user.  

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
