### PR TITLE
fix: don't send video when clicking navigation back from camera app [AR-1469]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
@@ -3,7 +3,6 @@ package com.wire.android.ui.home.messagecomposer.attachment
 import android.net.Uri
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -100,7 +99,10 @@ private fun TakePictureFlow(onPictureTaken: (Uri) -> Unit): UseCameraRequestFlow
     val context = LocalContext.current
     val imageAttachmentUri = context.getTempWritableImageUri()
     return rememberTakePictureFlow(
-        onPictureTaken = { onPictureTaken(imageAttachmentUri) },
+        onPictureTaken = { hasTakenPicture ->
+            if (hasTakenPicture)
+                onPictureTaken(imageAttachmentUri)
+        },
         targetPictureFileUri = imageAttachmentUri,
         onPermissionDenied = { /* TODO: Implement denied permission rationale */ }
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
@@ -81,7 +81,7 @@ private fun configureStateHandling(
 @Composable
 private fun FileBrowserFlow(onFilePicked: (Uri) -> Unit): UseStorageRequestFlow {
     return rememberOpenFileBrowserFlow(
-        onFileBrowserItemPicked = { pickedFileUri -> onFilePicked(pickedFileUri) },
+        onFileBrowserItemPicked = onFilePicked,
         onPermissionDenied = { /* TODO: Implement denied permission rationale */ }
     )
 }
@@ -89,7 +89,7 @@ private fun FileBrowserFlow(onFilePicked: (Uri) -> Unit): UseStorageRequestFlow 
 @Composable
 private fun GalleryFlow(onFilePicked: (Uri) -> Unit): UseStorageRequestFlow {
     return rememberOpenGalleryFlow(
-        onGalleryItemPicked = { pickedPictureUri -> onFilePicked(pickedPictureUri) },
+        onGalleryItemPicked = onFilePicked,
         onPermissionDenied = { /* TODO: Implement denied permission rationale */ }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
@@ -36,13 +36,12 @@ import com.wire.android.util.permission.rememberRecordAudioRequestFlow
 import com.wire.android.util.permission.rememberTakePictureFlow
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AttachmentOptionsComponent(
     attachmentInnerState: AttachmentInnerState,
     onSendAttachment: (AttachmentBundle?) -> Unit,
     onError: (ConversationSnackbarMessages) -> Unit,
-    modifier : Modifier= Modifier
+    modifier: Modifier = Modifier
 ) {
     val scope = rememberCoroutineScope()
     val attachmentOptions = buildAttachmentOptionItems { pickedUri -> scope.launch { attachmentInnerState.pickAttachment(pickedUri) } }
@@ -112,7 +111,10 @@ private fun CaptureVideoFlow(onVideoCaptured: (Uri) -> Unit): UseCameraRequestFl
     val context = LocalContext.current
     val videoAttachmentUri = context.getTempWritableVideoUri()
     return rememberCaptureVideoFlow(
-        onVideoRecorded = { onVideoCaptured(videoAttachmentUri) },
+        onVideoRecorded = { hasCapturedVideo ->
+            if (hasCapturedVideo)
+                onVideoCaptured(videoAttachmentUri)
+        },
         targetVideoFileUri = videoAttachmentUri,
         onPermissionDenied = { /* TODO: Implement denied permission rationale */ }
     )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1469" title="AR-1469" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1469</a>  Video is sent when tapping back button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Video or picture files were being sent even if the user didn't confirm the video/photo taken and navigated back. This was caused because we were not checking the boolean flag `hasCapturedVideo/hasTakenPicture` when passing through the file uri to the requestFlow. Now we will only send these files if this flag is set to `true`

#### How to Test

Open a conversation, click on take video or picture, when on the camera screen, click back button on the device. Check that no file was shared.

### Attachments (Optional)

https://user-images.githubusercontent.com/2468164/169787790-ae65d833-0172-4e10-aff3-d598f6d2275a.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
