### PR TITLE
fix: implement new asset download flow [AR-1323]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/AppModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/AppModule.kt
@@ -25,7 +25,8 @@ object AppModule {
 
     @Singleton
     @Provides
-    fun providesFileManager(@ApplicationContext appContext: Context): FileManager = FileManager(appContext)
+    fun providesFileManager(@ApplicationContext appContext: Context, dispatchers: DispatcherProvider): FileManager =
+        FileManager(appContext, dispatchers)
 
     @Singleton
     @Provides

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -55,7 +55,7 @@ fun ConversationScreen(conversationViewModel: ConversationViewModel) {
         onMessageChanged = conversationViewModel::onMessageChanged,
         onSendButtonClicked = conversationViewModel::sendMessage,
         onSendAttachment = conversationViewModel::sendAttachmentMessage,
-        onDownloadAsset = conversationViewModel::downloadOrFetchAsset,
+        onDownloadAsset = conversationViewModel::downloadOrFetchAssetToInternalStorage,
         onImageFullScreenMode = conversationViewModel::navigateToGallery,
         onBackButtonClick = conversationViewModel::navigateBack,
         onDeleteMessage = conversationViewModel::showDeleteMessageDialog,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -379,14 +379,10 @@ class ConversationViewModel @Inject constructor(
 
     fun onSaveFile(assetName: String?, assetData: ByteArray, messageId: String) {
         viewModelScope.launch {
-            withContext(dispatchers.io()) {
-                fileManager.saveToExternalStorage(assetName, assetData) {
-                    viewModelScope.launch {
-                        updateAssetMessageDownloadStatus(SAVED_EXTERNALLY, conversationId, messageId)
-                        onFileSavedToExternalStorage(assetName)
-                        hideOnAssetDownloadedDialog()
-                    }
-                }
+            fileManager.saveToExternalStorage(assetName, assetData) {
+                updateAssetMessageDownloadStatus(SAVED_EXTERNALLY, conversationId, messageId)
+                onFileSavedToExternalStorage(assetName)
+                hideOnAssetDownloadedDialog()
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -45,9 +45,10 @@ import com.wire.kalium.logic.data.id.parseIntoQualifiedID
 import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.AssetContent.AssetMetadata.Image
 import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.DOWNLOADED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
+import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
+import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_INTERNALLY
 import com.wire.kalium.logic.data.message.MessageContent.Asset
 import com.wire.kalium.logic.data.message.MessageContent.Text
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
@@ -222,7 +223,7 @@ class ConversationViewModel @Inject constructor(
 
     // This will download the asset remotely to an internal temporary storage or fetch it from the local database if it had been previously
     // downloaded. After doing so, a dialog is shown to ask the user whether he wants to open the file or download it to external storage
-    fun downloadOrFetchAsset(messageId: String) {
+    fun downloadOrFetchAssetToInternalStorage(messageId: String) {
         viewModelScope.launch {
             withContext(dispatchers.io()) {
                 try {
@@ -230,18 +231,18 @@ class ConversationViewModel @Inject constructor(
                         it.messageHeader.messageId == messageId && it.messageContent is AssetMessage
                     }
 
-                    val (isAssetDownloaded, assetName) = (assetMessage?.messageContent as AssetMessage).run {
-                        (downloadStatus == DOWNLOADED || downloadStatus == IN_PROGRESS) to assetName
+                    val (isAssetDownloadedInternally, assetName) = (assetMessage?.messageContent as AssetMessage).run {
+                        (downloadStatus == SAVED_INTERNALLY || downloadStatus == IN_PROGRESS) to assetName
                     }
 
-                    if (!isAssetDownloaded)
+                    if (!isAssetDownloadedInternally)
                         updateAssetMessageDownloadStatus(IN_PROGRESS, conversationId, messageId)
 
-                    val result = getRawAssetData(conversationId, messageId)
-                    updateAssetMessageDownloadStatus(if (result != null) DOWNLOADED else FAILED, conversationId, messageId)
+                    val resultData = getRawAssetData(conversationId, messageId)
+                    updateAssetMessageDownloadStatus(if (resultData != null) SAVED_INTERNALLY else FAILED, conversationId, messageId)
 
-                    if (result != null) {
-                        showOnAssetDownloadedDialog(assetName, result)
+                    if (resultData != null) {
+                        showOnAssetDownloadedDialog(assetName, resultData, messageId)
                     }
                 } catch (e: OutOfMemoryError) {
                     appLogger.e("There was an OutOfMemory error while downloading the asset")
@@ -251,8 +252,8 @@ class ConversationViewModel @Inject constructor(
         }
     }
 
-    fun showOnAssetDownloadedDialog(assetName: String?, assetData: ByteArray) {
-        conversationViewState = conversationViewState.copy(downloadedAssetDialogState = Displayed(assetName, assetData))
+    fun showOnAssetDownloadedDialog(assetName: String?, assetData: ByteArray, messageId: String) {
+        conversationViewState = conversationViewState.copy(downloadedAssetDialogState = Displayed(assetName, assetData, messageId))
     }
 
     fun hideOnAssetDownloadedDialog() {
@@ -376,12 +377,15 @@ class ConversationViewModel @Inject constructor(
         }
     }
 
-    fun onSaveFile(assetName: String?, assetData: ByteArray) {
+    fun onSaveFile(assetName: String?, assetData: ByteArray, messageId: String) {
         viewModelScope.launch {
             withContext(dispatchers.io()) {
                 fileManager.saveToExternalStorage(assetName, assetData) {
-                    onFileSavedToExternalStorage(assetName)
-                    hideOnAssetDownloadedDialog()
+                    viewModelScope.launch {
+                        updateAssetMessageDownloadStatus(SAVED_EXTERNALLY, conversationId, messageId)
+                        onFileSavedToExternalStorage(assetName)
+                        hideOnAssetDownloadedDialog()
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
@@ -22,5 +22,5 @@ sealed class ConversationAvatar {
 
 sealed class DownloadedAssetDialogVisibilityState {
     object Hidden : DownloadedAssetDialogVisibilityState()
-    class Displayed (val assetName: String?, val assetData: ByteArray) : DownloadedAssetDialogVisibilityState()
+    class Displayed (val assetName: String?, val assetData: ByteArray, val messageId: String) : DownloadedAssetDialogVisibilityState()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/DownloadedAssetDialog.kt
@@ -14,25 +14,25 @@ import com.wire.android.util.permission.WriteToExternalStorageRequestFlow
 @Composable
 fun DownloadedAssetDialog(
     downloadedAssetDialogState: DownloadedAssetDialogVisibilityState,
-    onSaveFileToExternalStorage: (String?, ByteArray) -> Unit,
+    onSaveFileToExternalStorage: (String?, ByteArray, String) -> Unit,
     onOpenFileWithExternalApp: (String?, ByteArray) -> Unit,
     hideOnAssetDownloadedDialog: () -> Unit
 ) {
-    val dialogState = downloadedAssetDialogState
     val context = LocalContext.current
 
-    if (dialogState is DownloadedAssetDialogVisibilityState.Displayed) {
-        val assetName = dialogState.assetName
-        val assetData = dialogState.assetData
+    if (downloadedAssetDialogState is DownloadedAssetDialogVisibilityState.Displayed) {
+        val assetName = downloadedAssetDialogState.assetName
+        val assetData = downloadedAssetDialogState.assetData
+        val messageId = downloadedAssetDialogState.messageId
 
         // Flow to get write to external storage permission
         val requestWriteToExternalStorageRequestFlow = WriteToExternalStorageRequestFlow(
             context = context,
-            onPermissionGranted = { onSaveFileToExternalStorage(assetName, assetData) },
+            onPermissionGranted = { onSaveFileToExternalStorage(assetName, assetData, messageId) },
             writeToExternalStoragePermissionLauncher =
             rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
                 if (isGranted) {
-                    onSaveFileToExternalStorage(assetName, assetData)
+                    onSaveFileToExternalStorage(assetName, assetData, messageId)
                 } else {
                     // TODO: Implement denied permission rationale
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -77,9 +77,8 @@ fun MessageItem(
                 if (!isDeleted) {
                     MessageContent(messageContent,
                         onAssetClick = { onAssetMessageClicked(message.messageHeader.messageId) },
-                        onImageClick = {
-                            onImageMessageClicked(message.messageHeader.messageId)
-                        })
+                        onImageClick = { onImageMessageClicked(message.messageHeader.messageId) }
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -49,10 +49,10 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.getUriFromDrawable
 import com.wire.android.util.toBitmap
 import com.wire.kalium.logic.data.message.Message
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.DOWNLOADED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.NOT_DOWNLOADED
+import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
 import kotlin.math.roundToInt
 
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
@@ -199,6 +199,12 @@ private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus) {
             size = dimensions().spacing16x
         )
         DOWNLOADED -> Icon(
+            painter = painterResource(id = R.drawable.ic_download),
+            contentDescription = stringResource(R.string.content_description_download_icon),
+            modifier = Modifier.size(dimensions().wireIconButtonSize),
+            tint = MaterialTheme.wireColorScheme.secondaryText
+        )
+        SAVED_EXTERNALLY -> Icon(
             painter = painterResource(id = R.drawable.ic_check_tick),
             contentDescription = stringResource(R.string.content_description_check),
             modifier = Modifier.size(dimensions().wireIconButtonSize),
@@ -212,8 +218,9 @@ private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus) {
 fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus): String =
     when (assetDownloadStatus) {
         NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
+        DOWNLOADED -> stringResource(R.string.asset_message_downloaded_internally_text)
         IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
-        DOWNLOADED -> stringResource(R.string.asset_message_downloaded_text)
+        SAVED_EXTERNALLY -> stringResource(R.string.asset_message_saved_externally_text)
         FAILED -> stringResource(R.string.asset_message_failed_download_text)
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -53,6 +53,7 @@ import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.NOT_DOWNLOADED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
+import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_INTERNALLY
 import kotlin.math.roundToInt
 
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
@@ -198,7 +199,7 @@ private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus) {
             progressColor = MaterialTheme.wireColorScheme.secondaryText,
             size = dimensions().spacing16x
         )
-        DOWNLOADED -> Icon(
+        SAVED_INTERNALLY -> Icon(
             painter = painterResource(id = R.drawable.ic_download),
             contentDescription = stringResource(R.string.content_description_download_icon),
             modifier = Modifier.size(dimensions().wireIconButtonSize),
@@ -218,7 +219,7 @@ private fun DownloadStatusIcon(assetDownloadStatus: Message.DownloadStatus) {
 fun getDownloadStatusText(assetDownloadStatus: Message.DownloadStatus): String =
     when (assetDownloadStatus) {
         NOT_DOWNLOADED -> stringResource(R.string.asset_message_tap_to_download_text)
-        DOWNLOADED -> stringResource(R.string.asset_message_downloaded_internally_text)
+        SAVED_INTERNALLY -> stringResource(R.string.asset_message_downloaded_internally_text)
         IN_PROGRESS -> stringResource(R.string.asset_message_download_in_progress_text)
         SAVED_EXTERNALLY -> stringResource(R.string.asset_message_saved_externally_text)
         FAILED -> stringResource(R.string.asset_message_failed_download_text)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageViewWrapper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageViewWrapper.kt
@@ -5,11 +5,8 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.UserStatus
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.ui.UIText
-import com.wire.kalium.logic.data.user.UserAssetId
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.DOWNLOADED
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.NOT_DOWNLOADED
-import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
 import com.wire.kalium.logic.data.message.Message
+import com.wire.kalium.logic.data.user.UserAssetId
 
 data class MessageViewWrapper(
     val user: User,

--- a/app/src/main/kotlin/com/wire/android/util/FileManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/FileManager.kt
@@ -1,11 +1,17 @@
 package com.wire.android.util
 
 import android.content.Context
+import com.wire.android.util.dispatchers.DispatcherProvider
 
-class FileManager(private val context: Context) {
-    fun saveToExternalStorage(assetName: String?, assetData: ByteArray, onFileSaved: (String?) -> Unit) {
-        saveFileToDownloadsFolder(assetName, assetData, context)
-        onFileSaved(assetName)
+class FileManager(
+    private val context: Context,
+    private val dispatchers: DispatcherProvider
+) {
+    suspend fun saveToExternalStorage(assetName: String?, assetData: ByteArray, onFileSaved: suspend (String?) -> Unit) {
+        with(dispatchers.io()) {
+            saveFileToDownloadsFolder(assetName, assetData, context)
+            onFileSaved(assetName)
+        }
     }
 
     fun openWithExternalApp(assetName: String?, assetData: ByteArray, onError: () -> Unit) {

--- a/app/src/main/res/drawable/ic_download.xml
+++ b/app/src/main/res/drawable/ic_download.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M0,14H16V16H0V14ZM7,0H9V7H13L8,11L3,7H7V0Z"
+      android:fillColor="#34373D"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="content_description_user_avatar">User avatar</string>
     <string name="content_description_mute">Mute</string>
     <string name="content_description_check">Check mark</string>
+    <string name="content_description_download_icon">Download icon</string>
     <string name="content_description_add_to_favourite">Add to favourite</string>
     <string name="content_description_move_to_folder">Move to folder</string>
     <string name="content_description_move_to_archive">Move to archive</string>
@@ -197,7 +198,8 @@
     <string name="group_name_exceeded_limit_error">Group name should not exceed 64 characters</string>
     <string name="asset_message_tap_to_download_text">Tap to download</string>
     <string name="asset_message_download_in_progress_text">Downloading...</string>
-    <string name="asset_message_downloaded_text">Downloaded</string>
+    <string name="asset_message_downloaded_internally_text">Downloaded</string>
+    <string name="asset_message_saved_externally_text">Saved</string>
     <string name="asset_message_failed_download_text">File not available</string>
     <string name="asset_download_dialog_text">Do you want to open the file, or save it to your devices downloads folder?</string>
     <string name="asset_download_dialog_open_text">Open</string>
@@ -288,7 +290,7 @@
     <string name="error_uploading_user_avatar">Image could not be uploaded</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>
     <string name="error_conversation_sending_image">There was an error trying to send the image message. Please check your Internet connection and try again</string>
-    <string name="error_conversation_sending_asset">There was an error trying to send that file. Please check the file you chose is not too big and try again</string>
+    <string name="error_conversation_sending_asset">There was an error trying to send that file. Please check your Internet connection and try again</string>
     <string name="error_conversation_downloading_asset">There was an error trying to download that file. Please try again</string>
     <string name="error_conversation_opening_asset_file">No app was found to open the selected file</string>
     <string name="error_conversation_max_image_size_limit">The image you chose is too large. Please choose an image smaller than 15MB</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -336,15 +336,16 @@ class ConversationsViewModelTest {
     fun `given an asset message, when downloading to external storage, then the file manager downloads the asset and closes the dialog`() =
         runTest {
             // Given
+            val messageId = "mocked-msg-id"
             val assetName = "mocked-asset"
             val assetData = assetName.toByteArray()
             val (arrangement, viewModel) = Arrangement()
-                .withSuccessfulSaveAssetMessage(assetName, assetData)
+                .withSuccessfulSaveAssetMessage(assetName, assetData, messageId)
                 .arrange()
 
             // When
             assert(viewModel.conversationViewState.downloadedAssetDialogState is DownloadedAssetDialogVisibilityState.Displayed)
-            viewModel.onSaveFile(assetName, assetData)
+            viewModel.onSaveFile(assetName, assetData, messageId)
 
             // Then
             verify(exactly = 1) { arrangement.fileManager.saveToExternalStorage(any(), any(), any()) }
@@ -355,10 +356,11 @@ class ConversationsViewModelTest {
     fun `given an asset message, when opening it, then the file manager open function gets invoked and closes the dialog`() =
         runTest {
             // Given
+            val messageId = "mocked-msg-id"
             val assetName = "mocked-asset"
             val assetData = assetName.toByteArray()
             val (arrangement, viewModel) = Arrangement()
-                .withSuccessfulOpenAssetMessage(assetName, assetData)
+                .withSuccessfulOpenAssetMessage(assetName, assetData, messageId)
                 .arrange()
 
             // When
@@ -477,16 +479,16 @@ class ConversationsViewModelTest {
             return this
         }
 
-        fun withSuccessfulSaveAssetMessage(assetName: String?, assetData: ByteArray): Arrangement {
-            viewModel.showOnAssetDownloadedDialog(assetName, assetData)
+        fun withSuccessfulSaveAssetMessage(assetName: String?, assetData: ByteArray, messageId: String): Arrangement {
+            viewModel.showOnAssetDownloadedDialog(assetName, assetData, messageId)
             every { fileManager.saveToExternalStorage(any(), any(), any()) }.answers {
                 viewModel.hideOnAssetDownloadedDialog()
             }
             return this
         }
 
-        fun withSuccessfulOpenAssetMessage(assetName: String?, assetData: ByteArray): Arrangement {
-            viewModel.showOnAssetDownloadedDialog(assetName, assetData)
+        fun withSuccessfulOpenAssetMessage(assetName: String?, assetData: ByteArray, messageId: String): Arrangement {
+            viewModel.showOnAssetDownloadedDialog(assetName, assetData, messageId)
             every { fileManager.openWithExternalApp(any(), any(), any()) }.answers {
                 viewModel.hideOnAssetDownloadedDialog()
             }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -348,7 +348,7 @@ class ConversationsViewModelTest {
             viewModel.onSaveFile(assetName, assetData, messageId)
 
             // Then
-            verify(exactly = 1) { arrangement.fileManager.saveToExternalStorage(any(), any(), any()) }
+            coVerify(exactly = 1) { arrangement.fileManager.saveToExternalStorage(any(), any(), any()) }
             assert(viewModel.conversationViewState.downloadedAssetDialogState == DownloadedAssetDialogVisibilityState.Hidden)
         }
 
@@ -481,7 +481,7 @@ class ConversationsViewModelTest {
 
         fun withSuccessfulSaveAssetMessage(assetName: String?, assetData: ByteArray, messageId: String): Arrangement {
             viewModel.showOnAssetDownloadedDialog(assetName, assetData, messageId)
-            every { fileManager.saveToExternalStorage(any(), any(), any()) }.answers {
+            coEvery { fileManager.saveToExternalStorage(any(), any(), any()) }.answers {
                 viewModel.hideOnAssetDownloadedDialog()
             }
             return this


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1323" title="AR-1323" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1323</a>  Process a file after it has been downloaded
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Design team decided to have [an alternative flow](https://www.figma.com/file/UgKehvwIbiIiQ2CCEdsVuf/Android?node-id=15741%3A130748) where asset messages would have several download states (internal and external). This PR just accommodates this new flow with the recently merged [PR on kalium](https://github.com/wireapp/kalium/pull/526)


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test
Just send and receive asset messages!


### Attachments (Optional)
![ezgif-4-qq](https://user-images.githubusercontent.com/2468164/169853735-a58d5c0e-d5cc-4088-9269-e06356689d2c.gif)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
