### PR TITLE
feat: map the user type to the ui on conversation

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/UserTypeMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UserTypeMapper.kt
@@ -1,0 +1,16 @@
+package com.wire.android.mapper
+
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.kalium.logic.data.conversation.UserType
+import javax.inject.Inject
+
+class UserTypeMapper @Inject constructor() {
+
+    fun toMembership(userType: UserType) = when (userType) {
+        UserType.GUEST -> Membership.Guest
+        UserType.FEDERATED -> Membership.Federated
+        UserType.EXTERNAL -> Membership.External
+        UserType.INTERNAL -> Membership.None
+    }
+
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
 import com.wire.android.appLogger
+import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.model.ImageAsset.PrivateAsset
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.UserStatus
@@ -93,7 +94,8 @@ class ConversationViewModel @Inject constructor(
     private val markMessagesAsNotified: MarkMessagesAsNotifiedUseCase,
     private val updateAssetMessageDownloadStatus: UpdateAssetMessageDownloadStatusUseCase,
     private val getSelfUserTeam: GetSelfTeamUseCase,
-    private val fileManager: FileManager
+    private val fileManager: FileManager,
+    private val userTypeMapper: UserTypeMapper
 ) : ViewModel() {
 
     var conversationViewState by mutableStateOf(ConversationViewState())
@@ -436,7 +438,7 @@ class ConversationViewModel @Inject constructor(
                 messageHeader = MessageHeader(
                     // TODO: Designs for deleted users?
                     username = sender.name?.let { UIText.DynamicString(it) } ?: UIText.StringResource(R.string.member_name_deleted_label),
-                    membership = if (sender is MemberDetails.Other) mapUserType(sender.userType) else Membership.None,
+                    membership = if (sender is MemberDetails.Other) userTypeMapper.toMembership(sender.userType) else Membership.None,
                     isLegalHold = false,
                     time = message.date,
                     messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
@@ -446,15 +448,6 @@ class ConversationViewModel @Inject constructor(
                     avatarAsset = sender.previewAsset, availabilityStatus = UserStatus.NONE
                 )
             )
-        }
-    }
-
-    private fun mapUserType(userType: UserType): Membership {
-        return when (userType) {
-            UserType.GUEST -> Membership.Guest
-            UserType.FEDERATED -> Membership.Federated
-            UserType.EXTERNAL -> Membership.External
-            UserType.INTERNAL -> Membership.None
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -455,9 +455,6 @@ class ConversationViewModel @Inject constructor(
             UserType.FEDERATED -> Membership.Federated
             UserType.EXTERNAL -> Membership.External
             UserType.INTERNAL -> Membership.None
-            else -> {
-                throw IllegalStateException("Unknown UserType")
-            }
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -428,48 +428,24 @@ class ConversationViewModel @Inject constructor(
     // region ------------------------------ Mapper Helpers ------------------------------
     private suspend fun List<Message>.toUIMessages(members: List<MemberDetails>): List<MessageViewWrapper> {
         return map { message ->
-            when (val sender = members.findSender(message.senderUserId)) {
-                is MemberDetails.Other -> {
-                    MessageViewWrapper(
-                        messageContent = fromMessageModelToMessageContent(message),
-                        messageSource = MessageSource.Self,
-                        messageHeader = MessageHeader(
-                            // TODO: Designs for deleted users?
-                            username = sender.name?.let { UIText.DynamicString(it) }
-                                ?: UIText.StringResource(R.string.member_name_deleted_label),
-                            membership = mapUserType(sender.userType),
-                            isLegalHold = false,
-                            time = message.date,
-                            messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
-                            messageId = message.id
-                        ),
-                        user = User(
-                            avatarAsset = sender.previewAsset, availabilityStatus = UserStatus.NONE
-                        )
-                    )
-                }
-                is MemberDetails.Self -> {
-                    MessageViewWrapper(
-                        messageContent = fromMessageModelToMessageContent(message),
-                        messageSource = MessageSource.OtherUser,
-                        messageHeader = MessageHeader(
-                            // TODO: Designs for deleted users?
-                            username = sender.name?.let { UIText.DynamicString(it) }
-                                ?: UIText.StringResource(R.string.member_name_deleted_label),
-                            membership = Membership.None,
-                            isLegalHold = false,
-                            time = message.date,
-                            messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
-                            messageId = message.id
-                        ),
-                        user = User(
-                            avatarAsset = sender.previewAsset, availabilityStatus = UserStatus.NONE
-                        )
-                    )
-                }
-                else -> throw IllegalStateException("The sender has a illegal state different than Self or Other")
-            }
+            val sender = members.findSender(message.senderUserId)
 
+            MessageViewWrapper(
+                messageContent = fromMessageModelToMessageContent(message),
+                messageSource = if (sender is MemberDetails.Self) MessageSource.Self else MessageSource.OtherUser,
+                messageHeader = MessageHeader(
+                    // TODO: Designs for deleted users?
+                    username = sender.name?.let { UIText.DynamicString(it) } ?: UIText.StringResource(R.string.member_name_deleted_label),
+                    membership = if (sender is MemberDetails.Other) mapUserType(sender.userType) else Membership.None,
+                    isLegalHold = false,
+                    time = message.date,
+                    messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
+                    messageId = message.id
+                ),
+                user = User(
+                    avatarAsset = sender.previewAsset, availabilityStatus = UserStatus.NONE
+                )
+            )
         }
     }
 

--- a/app/src/test/kotlin/com/wire/android/mapper/UserTypeMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/UserTypeMapperTest.kt
@@ -1,0 +1,36 @@
+package com.wire.android.mapper
+
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.kalium.logic.data.conversation.UserType
+import org.amshove.kluent.internal.assertEquals
+import org.junit.Test
+
+class UserTypeMapperTest {
+
+    private val userTypeMapper = UserTypeMapper()
+
+    @Test
+    fun `given guest as a user type correctly map to guest as membership`() {
+        val result = userTypeMapper.toMembership(UserType.GUEST)
+        assertEquals(Membership.Guest, result)
+    }
+
+    @Test
+    fun `given federated as a user type correctly map to federated as membership`() {
+        val result = userTypeMapper.toMembership(UserType.FEDERATED)
+        assertEquals(Membership.Federated, result)
+    }
+
+    @Test
+    fun `given external as a user type correctly map to external as membership`() {
+        val result = userTypeMapper.toMembership(UserType.EXTERNAL)
+        assertEquals(Membership.External, result)
+    }
+
+    @Test
+    fun `given internal as a user type correctly map to none as membership`() {
+        val result = userTypeMapper.toMembership(UserType.INTERNAL)
+        assertEquals(Membership.None, result)
+    }
+
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.SendAssetMessageResult
 import com.wire.kalium.logic.feature.asset.SendAssetMessageUseCase
@@ -387,6 +388,7 @@ class ConversationsViewModelTest {
             coEvery { observeConversationDetails(any()) } returns flowOf()
             coEvery { markMessagesAsNotified(any(), any()) } returns Success
             coEvery { getSelfUserTeam() } returns flowOf()
+            coEvery { userTypeMapper.toMembership(any()) } returns Membership.None
         }
 
         @MockK
@@ -546,7 +548,7 @@ class ConversationsViewModelTest {
             every { user.name } returns name
             every { user.previewPicture } returns null
         }
-        every{ it.userType} returns userType
+        every{ it.userType } returns userType
     }
 
     private fun mockedMessage(senderId: UserId) = Message(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -533,13 +533,15 @@ class ConversationsViewModelTest {
 
     private fun mockOtherUserDetails(
         name: String,
-        id: UserId = UserId("other", "user")
+        id: UserId = UserId("other", "user"),
+        userType : UserType = UserType.INTERNAL
     ): MemberDetails.Other = mockk<MemberDetails.Other>().also {
         every { it.otherUser } returns mockk<OtherUser>().also { user ->
             every { user.id } returns id
             every { user.name } returns name
             every { user.previewPicture } returns null
         }
+        every{ it.userType} returns userType
     }
 
     private fun mockedMessage(senderId: UserId) = Message(

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -27,6 +27,7 @@ import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.android.mapper.UserTypeMapper
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.SendAssetMessageResult
 import com.wire.kalium.logic.feature.asset.SendAssetMessageUseCase
@@ -431,6 +432,9 @@ class ConversationsViewModelTest {
         lateinit var fileManager: FileManager
 
         @MockK
+        lateinit var userTypeMapper: UserTypeMapper
+
+        @MockK
         lateinit var context: Context
 
         @MockK
@@ -456,7 +460,8 @@ class ConversationsViewModelTest {
                 markMessagesAsNotified = markMessagesAsNotified,
                 updateAssetMessageDownloadStatus = updateAssetMessageDownloadStatus,
                 getSelfUserTeam = getSelfUserTeam,
-                fileManager = fileManager
+                fileManager = fileManager,
+                userTypeMapper = userTypeMapper
             )
         }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Kalium exposes now a user type on conversation details, which we can map now into the ui 

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
