### PR TITLE
fix: clear the search on back press

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/AppTopBarWithSearchBarLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/AppTopBarWithSearchBarLayout.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -120,7 +121,7 @@ private fun AppTopBarWithSearchBar(
         searchQuery = if (searchBarState.isSearchActive) searchQuery else "",
         onSearchQueryChanged = onSearchQueryChanged,
         onInputClicked = {
-            searchBarState.startSearch()
+            searchBarState.openSearch()
 
             onSearchClicked()
         },
@@ -182,8 +183,8 @@ private fun AppTopBarWithSearchBarContent(
 
                     LaunchedEffect(isSearchActive) {
                         if (!isSearchActive) {
-                            onSearchQueryChanged("")
                             focusManager.clearFocus()
+                            onSearchQueryChanged("")
                         }
                     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/AppTopBarWithSearchBarLayout.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/AppTopBarWithSearchBarLayout.kt
@@ -126,7 +126,6 @@ private fun AppTopBarWithSearchBar(
         },
         onCloseSearchClicked = {
             onCloseSearchClicked()
-            searchBarState.cancelSearch()
         },
         appTopBar = appTopBar
     )
@@ -181,8 +180,11 @@ private fun AppTopBarWithSearchBarContent(
 
                     val focusManager = LocalFocusManager.current
 
-                    LaunchedEffect(isSearchActive){
-                        if(!isSearchActive)focusManager.clearFocus()
+                    LaunchedEffect(isSearchActive) {
+                        if (!isSearchActive) {
+                            onSearchQueryChanged("")
+                            focusManager.clearFocus()
+                        }
                     }
 
                     SearchBarInput(

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
@@ -9,7 +9,7 @@ import androidx.compose.runtime.setValue
 
 @Composable
 fun rememberSearchbarState(): SearchBarState {
-    val searchBarState = rememberSaveable(saver = SearchBarState.Saver()) {
+    val searchBarState = rememberSaveable(saver = SearchBarState.saver()) {
         SearchBarState(
             isSearchActive = false,
             isSearchBarCollapsed = false
@@ -35,7 +35,7 @@ class SearchBarState(isSearchActive: Boolean, isSearchBarCollapsed: Boolean) {
     }
 
     companion object {
-        fun Saver(): Saver<SearchBarState, *> = Saver(
+        fun saver(): Saver<SearchBarState, *> = Saver(
             save = { Pair(it.isSearchActive, it.isSearchBarCollapsed) },
             restore = { (isSearchActive, isSearchBarCollapsed) ->
                 SearchBarState(isSearchActive, isSearchBarCollapsed)

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/search/SearchBarState.kt
@@ -3,31 +3,43 @@ package com.wire.android.ui.common.topappbar.search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import com.wire.android.ui.common.effects.ScrollingDownEffect
 
 @Composable
 fun rememberSearchbarState(): SearchBarState {
-    val searchBarState = remember {
-        SearchBarState()
+    val searchBarState = rememberSaveable(saver = SearchBarState.Saver()) {
+        SearchBarState(
+            isSearchActive = false,
+            isSearchBarCollapsed = false
+        )
     }
 
     return searchBarState
 }
 
-class SearchBarState {
+class SearchBarState(isSearchActive: Boolean, isSearchBarCollapsed: Boolean) {
 
-    var isSearchBarCollapsed by mutableStateOf(false)
+    var isSearchBarCollapsed by mutableStateOf(isSearchBarCollapsed)
 
-    var isSearchActive by mutableStateOf(false)
+    var isSearchActive by mutableStateOf(isSearchActive)
         private set
 
-    fun cancelSearch() {
+    fun closeSearch() {
         isSearchActive = false
     }
 
-    fun startSearch() {
+    fun openSearch() {
         isSearchActive = true
+    }
+
+    companion object {
+        fun Saver(): Saver<SearchBarState, *> = Saver(
+            save = { Pair(it.isSearchActive, it.isSearchBarCollapsed) },
+            restore = { (isSearchActive, isSearchBarCollapsed) ->
+                SearchBarState(isSearchActive, isSearchBarCollapsed)
+            }
+        )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchPeopleRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchPeopleRouter.kt
@@ -2,6 +2,8 @@ package com.wire.android.ui.home.newconversation
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
@@ -11,6 +13,7 @@ import com.wire.android.R
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.common.topappbar.search.AppTopBarWithSearchBar
+import com.wire.android.ui.common.topappbar.search.SearchBarState
 import com.wire.android.ui.common.topappbar.search.rememberSearchbarState
 import com.wire.android.ui.home.newconversation.common.SearchListScreens
 import com.wire.android.ui.home.newconversation.contacts.ContactsScreen
@@ -51,7 +54,7 @@ fun SearchPeopleRouter(
                 searchNavController.navigate(SearchListScreens.SearchPeopleScreen.route)
             },
             onCloseSearchClicked = {
-                searchBarState.cancelSearch()
+                searchBarState.closeSearch()
                 searchNavController.popBackStack()
             },
             appTopBar = {
@@ -106,7 +109,7 @@ fun SearchPeopleRouter(
     }
 
     BackHandler(searchBarState.isSearchActive) {
-        searchBarState.cancelSearch()
+        searchBarState.closeSearch()
         searchNavController.popBackStack()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchPeopleRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/SearchPeopleRouter.kt
@@ -51,6 +51,7 @@ fun SearchPeopleRouter(
                 searchNavController.navigate(SearchListScreens.SearchPeopleScreen.route)
             },
             onCloseSearchClicked = {
+                searchBarState.cancelSearch()
                 searchNavController.popBackStack()
             },
             appTopBar = {

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/SearchPeopleScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/SearchPeopleScreen.kt
@@ -317,7 +317,6 @@ fun LazyListScope.inProgressItem() {
 }
 
 fun LazyListScope.failureItem(@StringRes failureMessage: Int) {
-
     item {
         Box(
             Modifier


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- When pressing the back button the search result was not cleared 
- When navigate to other user profile screen, the search results were cleared, due to not having rememberSaveable for the search state.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
