### PR TITLE
chore: adjust calling button dimensions

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/AcceptButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/AcceptButton.kt
@@ -1,20 +1,22 @@
 package com.wire.android.ui.calling.controlButtons
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
-import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.common.dimensions
 
 @Composable
 fun AcceptButton(buttonClicked: () -> Unit) {
     IconButton(
-        modifier = Modifier.width(MaterialTheme.wireDimensions.defaultCallingControlsSize),
+        modifier = Modifier
+            .height(dimensions().initiatingCallHangUpButtonSize)
+            .width(dimensions().initiatingCallHangUpButtonSize),
         onClick = buttonClicked
     ) {
         Image(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraButton.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -42,7 +43,9 @@ fun CameraButton(
     }
 
     IconButton(
-        modifier = Modifier.width(MaterialTheme.wireDimensions.defaultCallingControlsSize),
+        modifier = Modifier
+            .width(MaterialTheme.wireDimensions.defaultCallingControlsSize)
+            .height(MaterialTheme.wireDimensions.defaultCallingControlsSize),
         onClick = {
             verifyCameraPermission(
                 context = context,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraFlipButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/CameraFlipButton.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.calling.controlButtons
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -24,7 +25,9 @@ fun CameraFlipButton(
     var isCameraFlipped by remember { mutableStateOf(isCameraFlipped) }
 
     IconButton(
-        modifier = Modifier.width(MaterialTheme.wireDimensions.defaultCallingControlsSize),
+        modifier = Modifier
+            .width(MaterialTheme.wireDimensions.defaultCallingControlsSize)
+            .height(MaterialTheme.wireDimensions.defaultCallingControlsSize),
         onClick = onCameraFlipButtonClicked
     ) {
         Image(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/DeclineButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/DeclineButton.kt
@@ -1,20 +1,22 @@
 package com.wire.android.ui.calling.controlButtons
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.wire.android.R
-import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.common.dimensions
 
 @Composable
 fun DeclineButton(buttonClicked: () -> Unit) {
     IconButton(
-        modifier = Modifier.width(MaterialTheme.wireDimensions.defaultCallingControlsSize),
+        modifier = Modifier
+            .height(dimensions().initiatingCallHangUpButtonSize)
+            .width(dimensions().initiatingCallHangUpButtonSize),
         onClick = buttonClicked
     ) {
         Image(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/MicrophoneButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/MicrophoneButton.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.calling.controlButtons
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -18,7 +19,9 @@ fun MicrophoneButton(
     onMicrophoneButtonClicked: () -> Unit
 ) {
     IconButton(
-        modifier = Modifier.width(MaterialTheme.wireDimensions.defaultCallingControlsSize),
+        modifier = Modifier
+            .width(MaterialTheme.wireDimensions.defaultCallingControlsSize)
+            .height(MaterialTheme.wireDimensions.defaultCallingControlsSize),
         onClick = onMicrophoneButtonClicked
     ) {
         Image(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/SpeakerButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/SpeakerButton.kt
@@ -1,6 +1,7 @@
 package com.wire.android.ui.calling.controlButtons
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -18,7 +19,9 @@ fun SpeakerButton(
     onSpeakerButtonClicked: () -> Unit
 ) {
     IconButton(
-        modifier = Modifier.width(MaterialTheme.wireDimensions.defaultCallingControlsSize),
+        modifier = Modifier
+            .width(MaterialTheme.wireDimensions.defaultCallingControlsSize)
+            .height(MaterialTheme.wireDimensions.defaultCallingControlsSize),
         onClick = onSpeakerButtonClicked
     ) {
         Image(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Due to upgrading Material version to v3, icons dimensions were changed (due to not having both width/height specified)

### Solutions

Add both width AND height to calling icons


### Images
| OLD Design | New Design |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/5890660/170263522-f0749693-bd5a-4a10-a988-767518a0aea0.jpeg" alt="old_init" width="300" height="400" />  | <img src="https://user-images.githubusercontent.com/5890660/170263670-26925e28-32cc-40e3-b74d-54134169397e.jpeg" alt="new_init" width="300" height="400" />  |
| <img src="https://user-images.githubusercontent.com/5890660/170263753-dd345e51-d2fc-4f39-9db7-c72c6af63f16.jpeg" alt="old_incoming" width="300" height="400" />  | <img src="https://user-images.githubusercontent.com/5890660/170263763-9d46c412-a0bf-4989-b35c-1b7e3ae7385f.jpeg" alt="new_incoming" width="300" height="400" />  |
