### PR TITLE
feat(conn-events): user connection pending and accepted as new activities (AR-1733)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConnectionLabel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConnectionLabel.kt
@@ -1,20 +1,31 @@
 package com.wire.android.ui.home.conversationslist
 
+import androidx.annotation.StringRes
+import androidx.compose.material.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.ui.home.conversationslist.model.ConnectionInfo
+import com.wire.android.ui.home.conversationslist.model.toMessageId
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
+import com.wire.kalium.logic.data.user.ConnectionState
 
 @Composable
 fun ConnectionLabel(connectionInfo: ConnectionInfo) {
-    androidx.compose.material.Text(
-        text = connectionInfo.message, style = MaterialTheme.wireTypography.subline01.copy(
-            color = MaterialTheme.wireColorScheme.secondaryText
-        ),
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis
-    )
+    if (connectionInfo.connectionState == ConnectionState.PENDING) {
+        Text(
+            text = getConnectionStringLabel(labelId = connectionInfo.connectionState.toMessageId()),
+            style = MaterialTheme.wireTypography.subline01.copy(
+                color = MaterialTheme.wireColorScheme.secondaryText
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
 }
 
+@Composable
+fun getConnectionStringLabel(@StringRes labelId: Int) =
+    if (labelId == -1) "" else stringResource(id = labelId)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -16,7 +16,6 @@ import com.wire.android.ui.home.conversationslist.model.PendingConnectionItem
 import com.wire.android.ui.home.conversationslist.model.toUserInfoLabel
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.data.user.toUserId
 
 @Composable
 fun ConversationItemFactory(
@@ -34,13 +33,13 @@ fun ConversationItemFactory(
             when (conversation) {
                 is ConversationMissedCall -> CallLabel(callInfo = conversation.callInfo)
                 is ConversationUnreadMention -> MentionLabel(mentionMessage = conversation.mentionInfo.mentionMessage)
-                is GeneralConversation -> null //TODO implement last conversation message
+                is GeneralConversation -> null // TODO implement last conversation message
                 is PendingConnectionItem -> ConnectionLabel(conversation.connectionInfo)
             }
         },
         onConversationItemClick = {
             when (conversation) {
-                is PendingConnectionItem -> openUserProfile(conversation.connectionInfo.userId.toUserId())
+                is PendingConnectionItem -> openUserProfile(conversation.connectionInfo.userId)
                 else -> openConversation()
             }
         },
@@ -52,7 +51,6 @@ fun ConversationItemFactory(
         },
         onMutedIconClick = onMutedIconClick,
     )
-
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/EventBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/EventBadge.kt
@@ -3,6 +3,7 @@ package com.wire.android.ui.home.conversationslist.common
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,8 +16,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversationslist.model.EventType
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
@@ -29,7 +33,8 @@ fun EventBadgeFactory(eventType: EventType, modifier: Modifier = Modifier) {
         EventType.UnreadMention -> UnreadMentionBadge(modifier)
         is EventType.UnreadMessage -> UnreadMessageEventBadge(unreadMessageCount = eventType.unreadMessageCount, modifier)
         EventType.UnreadReply -> UnreadReplyBadge(modifier)
-        EventType.ConnectRequest -> ConnectRequestBadge(modifier)
+        EventType.ReceivedConnectionRequest -> ConnectRequestBadge(modifier)
+        EventType.SentConnectRequest -> ConnectPendingRequestBadge(modifier)
     }
 }
 
@@ -57,7 +62,8 @@ private fun UnreadMentionBadge(modifier: Modifier = Modifier) {
                 colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
                 modifier = modifier
             )
-        })
+        }
+    )
 }
 
 @Composable
@@ -70,7 +76,8 @@ private fun UnreadReplyBadge(modifier: Modifier = Modifier) {
                 colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
                 modifier = modifier
             )
-        })
+        }
+    )
 }
 
 @Composable
@@ -83,7 +90,24 @@ private fun ConnectRequestBadge(modifier: Modifier = Modifier) {
                 colorFilter = ColorFilter.tint(MaterialTheme.wireColorScheme.onBadge),
                 modifier = modifier
             )
-        })
+        }
+    )
+}
+
+@Composable
+private fun ConnectPendingRequestBadge(modifier: Modifier = Modifier) {
+    WireSecondaryButton(
+        onClick = { },
+        leadingIcon = {
+            Text(text = stringResource(id = R.string.connection_pending_label))
+        },
+        fillMaxWidth = false,
+        minHeight = dimensions().badgeSmallMinSize.height,
+        minWidth = dimensions().badgeSmallMinSize.width,
+        shape = RoundedCornerShape(size = dimensions().spacing6x),
+        contentPadding = PaddingValues(horizontal = dimensions().spacing6x),
+        textStyle = MaterialTheme.wireTypography.label01
+    )
 }
 
 @Composable
@@ -104,7 +128,8 @@ private fun UnreadMessageEventBadge(unreadMessageCount: Int, modifier: Modifier 
                     color = MaterialTheme.wireColorScheme.onBadge,
                     style = MaterialTheme.wireTypography.label02,
                 )
-            })
+            }
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/mock/Mock.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/mock/Mock.kt
@@ -19,6 +19,8 @@ import com.wire.android.ui.home.conversationslist.model.PendingConnectionItem
 import com.wire.android.ui.home.conversationslist.model.UserInfo
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.UserId
 
 val mockConversations1 = listOf(
     GeneralConversation(
@@ -106,7 +108,7 @@ val mockConversation = ConversationType.PrivateConversation(
     conversationId = ConversationId("someId", "someDomain"),
     mutedStatus = MutedConversationStatus.AllAllowed,
     isLegalHold = true,
-    )
+)
 
 val mockGroupConversation = ConversationType.GroupConversation(
     groupColorValue = 0xFFFF0000,
@@ -126,11 +128,11 @@ val mockGeneralConversation = GeneralConversation(
         conversationId = ConversationId("someId", "someDomain"),
         mutedStatus = MutedConversationStatus.AllAllowed,
         isLegalHold = true,
-        )
+    )
 )
 
 val mockGeneralConversationPending = PendingConnectionItem(
-    ConnectionInfo("Wants to connect", "someId"),
+    ConnectionInfo(ConnectionState.PENDING, UserId("someId", "someDomain")),
     ConversationType.PrivateConversation(
         conversationId = ConversationId("someId", "someDomain"),
         mutedStatus = MutedConversationStatus.AllAllowed,
@@ -212,7 +214,7 @@ val mockCallInfo4 = CallInfo(CallTime("Today", "5:34 PM"), CallEvent.NoAnswerCal
 val mockCallInfo5 = CallInfo(CallTime("Today", "6:59 PM"), CallEvent.NoAnswerCall)
 
 val mockNewActivities = listOf(
-    (NewActivity(EventType.ConnectRequest, mockGeneralConversationPending))
+    (NewActivity(EventType.ReceivedConnectionRequest, mockGeneralConversationPending))
 )
 
 val mockMissedCalls = listOf(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConnectionInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConnectionInfo.kt
@@ -1,4 +1,13 @@
 package com.wire.android.ui.home.conversationslist.model
 
-// TODO pass connection status instead of message and UserId
-data class ConnectionInfo(val message: String, val userId: String)
+import com.wire.android.R
+import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.UserId
+
+data class ConnectionInfo(val connectionState: ConnectionState, val userId: UserId)
+
+// We can expand this to show more detailed messages for other cases
+fun ConnectionState.toMessageId(): Int = when (this) {
+    ConnectionState.PENDING -> R.string.connection_pending_message
+    else -> -1
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/ConversationItem.kt
@@ -13,7 +13,8 @@ sealed class ConversationItem(val conversationType: ConversationType) {
 class GeneralConversation(conversationType: ConversationType) : ConversationItem(conversationType)
 class ConversationMissedCall(val callInfo: CallInfo, conversationType: ConversationType) : ConversationItem(conversationType)
 class ConversationUnreadMention(val mentionInfo: MentionInfo, conversationType: ConversationType) : ConversationItem(conversationType)
-class PendingConnectionItem(val connectionInfo: ConnectionInfo, pendingConversation: ConversationType) : ConversationItem(pendingConversation)
+class PendingConnectionItem(val connectionInfo: ConnectionInfo, pendingConversation: ConversationType) :
+    ConversationItem(pendingConversation)
 
 sealed class ConversationType {
     abstract val conversationId: ConversationId
@@ -35,7 +36,6 @@ sealed class ConversationType {
         override val mutedStatus: MutedConversationStatus,
         override val isLegalHold: Boolean = false
     ) : ConversationType()
-
 }
 
 data class ConversationInfo(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/EventType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/model/EventType.kt
@@ -5,5 +5,6 @@ sealed class EventType {
     object UnreadMention : EventType()
     object UnreadReply : EventType()
     object MissedCall : EventType()
-    object ConnectRequest: EventType()
+    object ReceivedConnectionRequest : EventType()
+    object SentConnectRequest : EventType()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,6 +342,8 @@
     <string name="connection_label_member_not_belongs_to_team">This user does not belong to your team. If they accept your connection request, they are available as a contact</string>
     <string name="connection_request_sent">Connection request sent</string>
     <string name="connection_request_sent_error">Connection request could not be sent</string>
+    <string name="connection_pending_message">Wants to connect</string>
+    <string name="connection_pending_label">pending</string>
 
     <!-- Gallery -->
     <string name="media_gallery_default_title_name">Media Gallery</string>


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Add the handling of the pending and sent requests into the new activity list

Needs releases with: https://github.com/wireapp/kalium/pull/537

- [X] GitHub link to other pull request

### Testing

Later will be addressed the testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

### Attachments (Optional)

https://user-images.githubusercontent.com/5806454/170367849-f0cbc35a-2d97-4e35-b87b-c95daf623743.mov

https://user-images.githubusercontent.com/5806454/170367856-5b1b968b-6fd3-451c-af03-5491a14141b6.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
