### PR TITLE
chore: add proper handling of media player to stop it ringing

### DIFF
--- a/app/src/main/kotlin/com/wire/android/media/CallRinger.kt
+++ b/app/src/main/kotlin/com/wire/android/media/CallRinger.kt
@@ -28,8 +28,7 @@ class CallRinger @Inject constructor(private val context: Context) {
     }
 
     fun ring(resource: Int, isLooping: Boolean = true) {
-        mediaPlayer?.reset()
-        mediaPlayer?.release()
+        stop()
         createMediaPlayer(resource, isLooping)
         mediaPlayer?.start()
     }

--- a/app/src/main/kotlin/com/wire/android/media/CallRinger.kt
+++ b/app/src/main/kotlin/com/wire/android/media/CallRinger.kt
@@ -28,6 +28,7 @@ class CallRinger @Inject constructor(private val context: Context) {
     }
 
     fun ring(resource: Int, isLooping: Boolean = true) {
+        mediaPlayer?.reset()
         mediaPlayer?.release()
         createMediaPlayer(resource, isLooping)
         mediaPlayer?.start()
@@ -35,9 +36,13 @@ class CallRinger @Inject constructor(private val context: Context) {
 
     fun stop() {
         try {
-            if (mediaPlayer?.isPlaying == true)
-                mediaPlayer?.stop()
-            mediaPlayer?.release()
+            mediaPlayer?.apply {
+                if (isPlaying) stop()
+                reset()
+                release()
+            }
+
+            mediaPlayer = null
         } catch (e: IllegalStateException) {
             appLogger.e("There was an error while stopping ringing", e)
         }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-1386 - Reject group call](https://wearezeta.atlassian.net/browse/AR-1386)

### Issues

When rejecting a call, ringer should stop ringing, but it also crashed the app or the screen was not dismissed.

The exception that was being thrown:
`java.lang.IllegalStateException at android.media.MediaPlayer.isPlaying(Native Method)`

### Solutions

Add proper handling of mediaPlayer if null or not null to handle the ringing stop.
