### PR TITLE
feat: respect mute options per conversation

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -37,6 +37,7 @@ import com.wire.android.ui.home.conversationslist.model.ConversationItem
 import com.wire.android.ui.home.conversationslist.navigation.ConversationsNavigationItem
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 
 @ExperimentalAnimationApi
 @ExperimentalMaterial3Api
@@ -66,10 +67,10 @@ fun ConversationRouterHomeBridge(
             onHomeBottomSheetContentChange {
                 ConversationSheetContent(
                     conversationSheetContent = conversationSheetContent,
-                    conversationOptionSheetState = conversationOptionSheetState,
-                    onMutingConversationStatusChange = {
-                        conversationState.muteConversation(it)
-                        viewModel.muteConversation(conversationSheetContent.conversationId, it)
+                    // FIXME: Compose - Find a way to not recreate this lambda
+                    onMutingConversationStatusChange = { mutedStatus ->
+                        conversationState.muteConversation(mutedStatus)
+                        viewModel.muteConversation(conversationId = conversationSheetContent.conversationId)
                     },
                     addConversationToFavourites = viewModel::addConversationToFavourites,
                     moveConversationToFolder = viewModel::moveConversationToFolder,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Mute options per conversations are respected

### Solutions

Check the mute options and fake mentions by checking if the text of the message contains either the user's display name or it's handle

### Dependencies (Optional)

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/565/

### Testing

#### How to Test

Use the Echo bot that mentions you when it echoes back a message
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
