### PR TITLE
fix: Message textColor for dark mode

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -62,7 +61,11 @@ import kotlin.math.roundToInt
 // waiting for the backend to implement mapping logic for the MessageBody
 @Composable
 internal fun MessageBody(messageBody: MessageBody) {
-    LinkifyText(text = messageBody.message.asString(), mask = Linkify.WEB_URLS or Linkify.EMAIL_ADDRESSES)
+    LinkifyText(
+        text = messageBody.message.asString(),
+        mask = Linkify.WEB_URLS or Linkify.EMAIL_ADDRESSES,
+        color = MaterialTheme.colorScheme.onBackground
+    )
 }
 
 @Composable


### PR DESCRIPTION
# What's new in this PR?

Made message's text color depends on device's dark/light mode, so it will be visible in both.

### Attachments (Optional)

![photo5262785747944061630](https://user-images.githubusercontent.com/6539347/172580701-52bbd74a-a8f6-4824-b122-71123a192f1d.jpg)
