### PR TITLE
fix: ignore or hide some message types [AR-1827]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -95,11 +95,10 @@ class MessageContentMapper @Inject constructor(
         else -> toText(content, Message.EditStatus.NotEdited)
     }
 
-    private fun toText(
+    fun toText(
         content: MessageContent,
         editStatus: Message.EditStatus
-    ) = MessageBody(
-        message = when (content) {
+    ) = MessageBody(when (content) {
             is MessageContent.Text -> UIText.DynamicString(content.value)
             is MessageContent.Unknown -> UIText.StringResource(
                 messageResourceProvider.sentAMessageWithContent, content.typeName ?: content::javaClass.name

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -100,9 +100,9 @@ class MessageContentMapper @Inject constructor(
     ) = MessageBody(when (content) {
             is MessageContent.Text -> UIText.DynamicString(content.value)
             is MessageContent.Unknown -> UIText.StringResource(
-                messageResourceProvider.sentAMessageWithContent, content.typeName ?: content::javaClass.name
+                messageResourceProvider.sentAMessageWithContent, content.typeName ?: "Unknown"
             )
-            else -> UIText.StringResource(messageResourceProvider.sentAMessageWithContent, content::javaClass.name)
+            else -> UIText.StringResource(messageResourceProvider.sentAMessageWithContent, "Unknown")
         }
     ).let { messageBody ->
         when (editStatus) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -266,7 +266,7 @@ fun MessageList(
         items(messages, key = {
             it.messageHeader.messageId
         }) { message ->
-            if (message.messageContent is MessageContent.ServerMessage)
+            if (message.messageContent is MessageContent.SystemMessage)
                 SystemMessageItem(message = message.messageContent)
             else
                 MessageItem(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -31,6 +31,7 @@ import com.wire.android.util.extractImageParams
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.id.parseIntoQualifiedID
+import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.SAVED_EXTERNALLY
@@ -107,7 +108,10 @@ class ConversationViewModel @Inject constructor(
     // region ------------------------------ Init Methods -------------------------------------
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun fetchMessages() = viewModelScope.launch {
-        getMessages(conversationId).flatMapLatest { messages ->
+        getMessages(
+            conversationId = conversationId,
+            visibility = listOf(Message.Visibility.VISIBLE, Message.Visibility.DELETED)
+        ).flatMapLatest { messages ->
             observeMemberDetailsByIds(messageMapper.memberIdList(messages))
                 .map { members -> messageMapper.toUIMessages(messages, members) }
         }.flowOn(dispatchers.default()).collect { uiMessages ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SystemMessageItem.kt
@@ -35,14 +35,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.R
 import com.wire.android.ui.common.button.WireSecondaryButton
 import com.wire.android.ui.common.dimensions
-import com.wire.android.ui.home.conversations.model.MessageContent.ServerMessage
+import com.wire.android.ui.home.conversations.model.MessageContent.SystemMessage
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.toUIText
 
 @Composable
-fun SystemMessageItem(message: ServerMessage) {
+fun SystemMessageItem(message: SystemMessage) {
     Row(
         Modifier
             .padding(
@@ -114,7 +114,7 @@ fun SystemMessageItem(message: ServerMessage) {
 @Composable
 fun SystemMessageAdded7UsersPreview() {
     SystemMessageItem(
-        message = ServerMessage.MemberAdded(
+        message = SystemMessage.MemberAdded(
             "Barbara Cotolina".toUIText(),
             listOf(
                 "Albert Lewis".toUIText(), "Bert Strunk".toUIText(), "Claudia Schiffer".toUIText(), "Dorothee Friedrich".toUIText(),
@@ -128,7 +128,7 @@ fun SystemMessageAdded7UsersPreview() {
 @Composable
 fun SystemMessageAdded4UsersPreview() {
     SystemMessageItem(
-        message = ServerMessage.MemberAdded(
+        message = SystemMessage.MemberAdded(
             "Barbara Cotolina".toUIText(),
             listOf("Albert Lewis".toUIText(), "Bert Strunk".toUIText(), "Claudia Schiffer".toUIText(), "Dorothee Friedrich".toUIText())
         )
@@ -139,7 +139,7 @@ fun SystemMessageAdded4UsersPreview() {
 @Composable
 fun SystemMessageRemoved4UsersPreview() {
     SystemMessageItem(
-        message = ServerMessage.MemberRemoved(
+        message = SystemMessage.MemberRemoved(
             "Barbara Cotolina".toUIText(),
             listOf("Albert Lewis".toUIText(), "Bert Strunk".toUIText(), "Claudia Schiffer".toUIText(), "Dorothee Friedrich".toUIText())
         )
@@ -149,14 +149,14 @@ fun SystemMessageRemoved4UsersPreview() {
 @Preview
 @Composable
 fun SystemMessageLeftPreview() {
-    SystemMessageItem(message = ServerMessage.MemberLeft(UIText.DynamicString("Barbara Cotolina")))
+    SystemMessageItem(message = SystemMessage.MemberLeft(UIText.DynamicString("Barbara Cotolina")))
 }
 
-private val ServerMessage.expandable
+private val SystemMessage.expandable
     get() = when (this) {
-        is ServerMessage.MemberAdded -> this.memberNames.size > EXPANDABLE_THRESHOLD
-        is ServerMessage.MemberRemoved -> this.memberNames.size > EXPANDABLE_THRESHOLD
-        is ServerMessage.MemberLeft -> false
+        is SystemMessage.MemberAdded -> this.memberNames.size > EXPANDABLE_THRESHOLD
+        is SystemMessage.MemberRemoved -> this.memberNames.size > EXPANDABLE_THRESHOLD
+        is SystemMessage.MemberLeft -> false
     }
 
 private fun String.bold() = STYLE_SEPARATOR + this + STYLE_SEPARATOR
@@ -176,24 +176,24 @@ private fun List<UIText>.limitUserNamesList(res: Resources, threshold: Int): Lis
             .plus(res.getQuantityString(R.plurals.label_system_message_x_more, moreCount, moreCount))
     }
 
-fun ServerMessage.getAnnotatedString(
+fun SystemMessage.getAnnotatedString(
     res: Resources,
     expanded: Boolean,
     normalStyle: SpanStyle,
     boldStyle: SpanStyle
 ): AnnotatedString {
     val string = when (this) {
-        is ServerMessage.MemberAdded -> res.getString(
+        is SystemMessage.MemberAdded -> res.getString(
             stringResId,
             author.asString(res).bold(),
             memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD).toUserNamesListString(res)
         )
-        is ServerMessage.MemberRemoved -> res.getString(
+        is SystemMessage.MemberRemoved -> res.getString(
             stringResId,
             author.asString(res).bold(),
             memberNames.limitUserNamesList(res, if (expanded) memberNames.size else EXPANDABLE_THRESHOLD).toUserNamesListString(res)
         )
-        is ServerMessage.MemberLeft -> res.getString(stringResId, author.asString(res).bold())
+        is SystemMessage.MemberLeft -> res.getString(stringResId, author.asString(res).bold())
     }
     return buildAnnotatedString {
         string.split(STYLE_SEPARATOR).forEachIndexed { index, text ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -317,7 +317,7 @@ fun PreviewAssetMessage() {
 fun PreviewMessageWithSystemMessage() {
     Column {
         MessageItem(mockMessageWithText, {}, {}, { _, _ -> })
-        SystemMessageItem(MessageContent.ServerMessage.MemberAdded(
+        SystemMessageItem(MessageContent.SystemMessage.MemberAdded(
             UIText.DynamicString("You"),
             listOf(UIText.DynamicString("Adam Smmith"))
         ))

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -68,18 +68,18 @@ sealed class MessageContent {
             return rawImgData.contentHashCode()
         }
     }
-    sealed class ServerMessage(@DrawableRes val iconResId: Int?, @StringRes val stringResId: Int) : MessageContent() {
+    sealed class SystemMessage(@DrawableRes val iconResId: Int?, @StringRes val stringResId: Int) : MessageContent() {
         data class MemberAdded(
             val author: UIText,
             val memberNames: List<UIText>
-            ) : ServerMessage(R.drawable.ic_add, R.string.label_system_message_added)
+            ) : SystemMessage(R.drawable.ic_add, R.string.label_system_message_added)
         data class MemberRemoved(
             val author: UIText,
             val memberNames: List<UIText>
-            ) : ServerMessage(R.drawable.ic_minus, R.string.label_system_message_removed)
+            ) : SystemMessage(R.drawable.ic_minus, R.string.label_system_message_removed)
         data class MemberLeft(
             val author: UIText
-            ) : ServerMessage(R.drawable.ic_minus, R.string.label_system_message_left_the_conversation)
+            ) : SystemMessage(R.drawable.ic_minus, R.string.label_system_message_left_the_conversation)
     }
 
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
@@ -4,10 +4,11 @@ import com.wire.android.mapper.MessageMapper
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveMemberDetailsByIdsUseCase
 import com.wire.kalium.logic.feature.message.GetRecentMessagesUseCase
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -15,16 +16,17 @@ import javax.inject.Inject
 class GetMessagesForConversationUseCase
 @Inject constructor(
     private val getMessages: GetRecentMessagesUseCase,
-    private val observeMemberDetails: ObserveConversationMembersUseCase,
+    private val observeMemberDetailsByIds: ObserveMemberDetailsByIdsUseCase,
     private val messageMapper: MessageMapper,
     private val dispatchers: DispatcherProvider,
 ) {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     suspend operator fun invoke(conversationId: ConversationId): Flow<List<UIMessage>> =
         getMessages(conversationId)
-            .combine(observeMemberDetails(conversationId), ::Pair)
-            .map { (messages, members) ->
-                messageMapper.toUIMessages(members, messages)
+            .flatMapLatest { messages ->
+                observeMemberDetailsByIds(messageMapper.memberIdList(messages))
+                    .map { members -> messageMapper.toUIMessages(members, messages) }
             }.flowOn(dispatchers.io())
 
 }

--- a/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
@@ -13,12 +13,14 @@ sealed class UIText {
         vararg val formatArgs: Any
     ) : UIText()
 
+    @Suppress("SpreadOperator")
     @Composable
     fun asString() = when (this) {
         is DynamicString -> value
         is StringResource -> stringResource(id = resId, *formatArgs)
     }
 
+    @Suppress("SpreadOperator")
     fun asString(resources: Resources) = when (this) {
         is DynamicString -> value
         is StringResource -> resources.getString(resId, *formatArgs)

--- a/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
@@ -16,12 +16,12 @@ sealed class UIText {
     @Composable
     fun asString() = when (this) {
         is DynamicString -> value
-        is StringResource -> stringResource(id = resId, args)
+        is StringResource -> stringResource(id = resId, *args)
     }
 
     fun asString(resources: Resources) = when (this) {
         is DynamicString -> value
-        is StringResource -> resources.getString(resId, args)
+        is StringResource -> resources.getString(resId, *args)
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/UIText.kt
@@ -10,18 +10,18 @@ sealed class UIText {
 
     class StringResource(
         @StringRes val resId: Int,
-        vararg val args: Any
+        vararg val formatArgs: Any
     ) : UIText()
 
     @Composable
     fun asString() = when (this) {
         is DynamicString -> value
-        is StringResource -> stringResource(id = resId, *args)
+        is StringResource -> stringResource(id = resId, *formatArgs)
     }
 
     fun asString(resources: Resources) = when (this) {
         is DynamicString -> value
-        is StringResource -> resources.getString(resId, *args)
+        is StringResource -> resources.getString(resId, *formatArgs)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,7 +195,7 @@
     <string name="conversations_all_tab_title">All</string>
     <string name="conversations_calls_tab_title">Calls</string>
     <string name="conversations_mentions_tab_title">Mentions</string>
-    <string name="content_is_not_available">content is not available</string>
+    <string name="sent_a_message_with_content">sent a message with %s content</string>
     <string name="new_group_title">New Group</string>
     <string name="new_group_description">Up to 500 people can join a group conversation.</string>
     <string name="group_name">Group name</string>

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -19,7 +19,7 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 
 object TestMessage {
-    val TEXT_MESSAGE = Message.Client(
+    val TEXT_MESSAGE = Message.Regular(
         id = "messageID",
         content = MessageContent.Text("Some Text Message"),
         conversationId = ConversationId("convo-id", "convo.domain"),
@@ -40,7 +40,7 @@ object TestMessage {
     val ASSET_IMAGE_CONTENT = AssetContent(
         0L, "name", "image", null, ASSET_REMOTE_DATA, Message.DownloadStatus.NOT_DOWNLOADED
     )
-    val MEMBER_REMOVED_MESSAGE = Message.Server(
+    val MEMBER_REMOVED_MESSAGE = Message.System(
         id = "messageID",
         content = MessageContent.MemberChange.Removed(listOf(Member(UserId("user-id", "domain")))),
         conversationId = ConversationId("convo-id", "convo.domain"),

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -101,17 +101,17 @@ class MessageContentMapperTest {
         val resultContentAdded = mapper.toServer(contentAdded, userId1, listOf(member1, member2, member3))
         // Then
         assert(
-            resultContentLeft is MessageViewContent.ServerMessage.MemberLeft
+            resultContentLeft is MessageViewContent.SystemMessage.MemberLeft
                     && resultContentLeft.author.asString(arrangement.resources) == member1.otherUser.name
         )
         assert(
-            resultContentRemoved is MessageViewContent.ServerMessage.MemberRemoved
+            resultContentRemoved is MessageViewContent.SystemMessage.MemberRemoved
                     && resultContentRemoved.author.asString(arrangement.resources) == member1.otherUser.name
                     && resultContentRemoved.memberNames.size == 1
                     && resultContentRemoved.memberNames[0].asString(arrangement.resources) == member2.otherUser.name
         )
         assert(
-            resultContentAdded is MessageViewContent.ServerMessage.MemberAdded
+            resultContentAdded is MessageViewContent.SystemMessage.MemberAdded
                     && resultContentAdded.author.asString(arrangement.resources) == member1.otherUser.name
                     && resultContentAdded.memberNames.size == 2
                     && resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.otherUser.name

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/GetMessageForConversationsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/GetMessageForConversationsUseCaseTest.kt
@@ -18,6 +18,7 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveMemberDetailsByIdsUseCase
 import com.wire.kalium.logic.feature.message.GetRecentMessagesUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -43,7 +44,7 @@ class GetMessageForConversationsUseCaseTest {
     lateinit var getMessages: GetRecentMessagesUseCase
 
     @MockK
-    lateinit var observeMemberDetails: ObserveConversationMembersUseCase
+    lateinit var observeMemberDetails: ObserveMemberDetailsByIdsUseCase
 
     @MockK
     lateinit var messageMapper: MessageMapper
@@ -84,6 +85,7 @@ class GetMessageForConversationsUseCaseTest {
                     messageBody = (mockTextMessage.content as com.wire.kalium.logic.data.message.MessageContent.Text).value
                 )
             )
+            every { messageMapper.memberIdList(any()) } returns listOf(mockSelfUserDetails.selfUser.id)
 
             // When
             getMessagesForConversationUseCase(ConversationId("someValue", "someId")).collect { messages ->
@@ -103,7 +105,7 @@ class GetMessageForConversationsUseCaseTest {
             coVerify { messageMapper.toUIMessages(listOf(mockSelfUserDetails), listOf(mockTextMessage)) }
         }
 
-    private fun mockedTextMessage(content: String = "Some Text Message") = Message.Client(
+    private fun mockedTextMessage(content: String = "Some Text Message") = Message.Regular(
         id = "messageID",
         content = com.wire.kalium.logic.data.message.MessageContent.Text(content),
         conversationId = ConversationId("someId", "someDomain"),


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1827" title="AR-1827" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1827</a>  All message types are stored and visible on conversation screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Currently all message types, even ones not yet handled by app, are stored in DB as "Unknown" and visible with "content is not available".

### Solutions

"HIDDEN" messages aren't displayed at all, "Unknown" types have more meaningful texts, updated kalium reference and names of types adjusted to reflect changes in kalium.

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/579

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Just open conversation and check what messages are displayed.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
