### PR TITLE
ci: add playtest branch workflow

### DIFF
--- a/.github/workflows/create-playtest-branch.yml
+++ b/.github/workflows/create-playtest-branch.yml
@@ -1,0 +1,38 @@
+name: "Create a new Playtest branch"
+
+on:
+  schedule:
+    - cron: '30 2 * * THU' # every Thursday at 02:30 UTC
+  workflow_dispatch:
+    inputs:
+      playtest-branch-manual-name:
+        description: 'A name for a playtest/$name branch'
+        required: true
+
+jobs:
+  create-playtest-branch:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: develop
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Manually create a named playtest branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        if: ${{ github.event.inputs.playtest-branch-manual-name }}  
+        env:
+          PLAYTEST_BRANCH_NAME: playtest/${{ github.event.inputs.playtest-branch-manual-name }}
+        with:
+          branch: ${{env.PLAYTEST_BRANCH_NAME}}
+      - name: Automatically Create a named playtest branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        if: "${{ github.event.inputs.playtest-branch-manual-name != '' }}"
+        env:
+          PLAYTEST_BRANCH_NAME: playtest/${{ steps.date.outputs.date }}
+        with:
+          branch: ${{env.PLAYTEST_BRANCH_NAME}}
+  


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Internal playtest are a bit messy at times since we wait till the last moment to cut from a build from the `main` branch. 

### Solutions

Add a workflow to manually or automatically create a branch starting with `playtest/` for playtest purposes. Triggered automatically every Thursday morning or manually at will.


----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
