### PR TITLE
fix: adjust test to comply with function not returning an exception

### DIFF
--- a/app/src/test/kotlin/com/wire/android/navigation/NavigationUtilsTest.kt
+++ b/app/src/test/kotlin/com/wire/android/navigation/NavigationUtilsTest.kt
@@ -45,12 +45,21 @@ internal class NavigationUtilsTest {
     }
 
     @Test
-    fun `Given an incorrect string, when parsing it to QualifiedId, then it throws an exception`() {
+    fun `Given an incorrect string, when parsing it to QualifiedId, then returns a qualifiedID with an empty domain`() {
         // Given
         val mockWrongImagePrivateAssetString = "wrong-private-asset/image"
 
-        // When, Then
-        assertThrows<Exception> { mockWrongImagePrivateAssetString.parseIntoQualifiedID() }
+        // When
+        val result = mockWrongImagePrivateAssetString.parseIntoQualifiedID()
+
+        // Then
+        assertEquals(
+            QualifiedID(
+                value = "wrong-private-asset/image",
+                domain = ""
+            ),
+            result
+        )
     }
 
     @Test


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

A change on `parseIntoQualifiedID` broke a test.

### Solutions

Adjust test to comply with changed `parseIntoQualifiedID` as it doesn't return an exception anymore.