### PR TITLE
fix: member removed not stored in DB is blocking the flow

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -180,7 +180,7 @@ class MessageContentMapper @Inject constructor(
         } else null
     }
 
-    fun toSystemMessageMemberName(member: MemberDetails, type: SelfNameType = SelfNameType.NameOrDeleted): UIText = when (member) {
+    fun toSystemMessageMemberName(member: MemberDetails?, type: SelfNameType = SelfNameType.NameOrDeleted): UIText = when (member) {
         is MemberDetails.Other -> member.name?.let { UIText.DynamicString(it) }
             ?: UIText.StringResource(messageResourceProvider.memberNameDeleted)
         is MemberDetails.Self -> when (type) {
@@ -189,6 +189,7 @@ class MessageContentMapper @Inject constructor(
             SelfNameType.NameOrDeleted -> member.name?.let { UIText.DynamicString(it) }
                 ?: UIText.StringResource(messageResourceProvider.memberNameDeleted)
         }
+        else -> UIText.StringResource(messageResourceProvider.memberNameDeleted)
     }
 
     private suspend fun getRawAssetData(conversationId: QualifiedID, messageId: String) =

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -48,14 +48,14 @@ class MessageMapper @Inject constructor(
                 messageSource = if (sender is MemberDetails.Self) MessageSource.Self else MessageSource.OtherUser,
                 messageHeader = MessageHeader(
                     // TODO: Designs for deleted users?
-                    username = sender.name?.let { UIText.DynamicString(it) } ?: UIText.StringResource(R.string.member_name_deleted_label),
+                    username = sender?.name?.let { UIText.DynamicString(it) } ?: UIText.StringResource(R.string.member_name_deleted_label),
                     membership = if (sender is MemberDetails.Other) userTypeMapper.toMembership(sender.userType) else Membership.None,
                     isLegalHold = false,
                     time = message.date,
                     messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
                     messageId = message.id
                 ),
-                userAvatarData = UserAvatarData(asset = sender.previewAsset)
+                userAvatarData = UserAvatarData(asset = sender?.previewAsset)
             )
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
@@ -4,7 +4,7 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.user.UserId
 
-fun List<MemberDetails>.findUser(userId: UserId): MemberDetails = first { member ->
+fun List<MemberDetails>.findUser(userId: UserId): MemberDetails? = firstOrNull { member ->
     when (member) {
         is MemberDetails.Other -> member.otherUser.id == userId
         is MemberDetails.Self -> member.selfUser.id == userId


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Right now, we get old system messages and it can create the situation where we need data of user that was removed even before we started using the app so we don't have any data about that user stored in DB.

### Solutions

Check if user details are available from the DB, if not then replace the name with a generic "Deleted User".

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
