### PR TITLE
fix: app crash on create new account screen and broken links

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/CreateAccountBaseViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/CreateAccountBaseViewModel.kt
@@ -1,6 +1,6 @@
 package com.wire.android.ui.authentication.create.common
 
-import androidx.compose.material.ExperimentalMaterialApi
+import android.net.Uri
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.BuildConfig
 import com.wire.android.appLogger
+import com.wire.android.di.AuthServerConfigProvider
 import com.wire.android.di.ClientScopeProvider
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -23,7 +24,6 @@ import com.wire.android.ui.authentication.create.email.CreateAccountEmailViewMod
 import com.wire.android.ui.authentication.create.email.CreateAccountEmailViewState
 import com.wire.android.ui.authentication.create.overview.CreateAccountOverviewViewModel
 import com.wire.android.ui.common.textfield.CodeFieldValue
-import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.ValidateEmailUseCase
@@ -38,6 +38,8 @@ import com.wire.kalium.logic.feature.register.RequestActivationCodeUseCase
 import com.wire.kalium.logic.feature.session.RegisterTokenResult
 import com.wire.kalium.logic.feature.session.RegisterTokenUseCase
 import kotlinx.coroutines.launch
+import java.net.URL
+import java.net.URLDecoder
 
 @Suppress("TooManyFunctions", "LongParameterList")
 abstract class CreateAccountBaseViewModel(
@@ -50,12 +52,17 @@ abstract class CreateAccountBaseViewModel(
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
     private val registerAccountUseCase: RegisterAccountUseCase,
     private val clientScopeProviderFactory: ClientScopeProvider.Factory,
-    private val pushTokenUseCase: RegisterTokenUseCase
+    private val authServerConfigProvider: AuthServerConfigProvider
 ) : ViewModel(),
     CreateAccountOverviewViewModel,
     CreateAccountEmailViewModel,
     CreateAccountDetailsViewModel,
     CreateAccountCodeViewModel {
+
+    override fun tosUrl(): String = authServerConfigProvider.authServer.value.tos
+
+    override fun learnMoreUrl(): String = authServerConfigProvider.authServer.value.pricing
+
     override var emailState: CreateAccountEmailViewState by mutableStateOf(
         CreateAccountEmailViewState(
             type,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailScreen.kt
@@ -51,7 +51,6 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
-import com.wire.kalium.logic.configuration.server.ServerConfig
 
 @Composable
 fun CreateAccountEmailScreen(viewModel: CreateAccountEmailViewModel) {
@@ -64,7 +63,7 @@ fun CreateAccountEmailScreen(viewModel: CreateAccountEmailViewModel) {
         onTermsDialogDismiss = viewModel::onTermsDialogDismiss,
         onTermsAccept = { viewModel.onTermsAccept() },
         onErrorDismiss = viewModel::onEmailErrorDismiss,
-        websiteBaseUrl = TODO()
+        tosUrl = viewModel.tosUrl()
     )
 }
 
@@ -79,7 +78,7 @@ private fun EmailContent(
     onTermsDialogDismiss: () -> Unit,
     onTermsAccept: () -> Unit,
     onErrorDismiss: () -> Unit,
-    websiteBaseUrl: String
+    tosUrl: String
 ) {
     Scaffold(topBar = {
         WireCenterAlignedTopAppBar(
@@ -130,7 +129,7 @@ private fun EmailContent(
         TermsConditionsDialog(
             onDialogDismiss = onTermsDialogDismiss,
             onContinuePressed = onTermsAccept,
-            onViewPolicyPressed = { CustomTabsHelper.launchUrl(context, "$websiteBaseUrl/legal") }
+            onViewPolicyPressed = { CustomTabsHelper.launchUrl(context, tosUrl) }
         )
     }
     if (state.error is CreateAccountEmailViewState.EmailError.DialogError.GenericError)

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/email/CreateAccountEmailViewModel.kt
@@ -1,10 +1,10 @@
 package com.wire.android.ui.authentication.create.email
 
 import androidx.compose.ui.text.input.TextFieldValue
-import com.wire.kalium.logic.configuration.server.ServerConfig
 
 interface CreateAccountEmailViewModel {
     val emailState: CreateAccountEmailViewState
+    fun tosUrl(): String
     fun onEmailChange(newText: TextFieldValue)
     fun goBackToPreviousStep()
     fun onEmailContinue()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreateAccountOverviewScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreateAccountOverviewScreen.kt
@@ -24,12 +24,12 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.appLogger
 import com.wire.android.ui.common.textfield.WirePrimaryButton
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
-import com.wire.kalium.logic.configuration.server.ServerConfig
 
 @Composable
 fun CreateAccountOverviewScreen(viewModel: CreateAccountOverviewViewModel) {
@@ -42,7 +42,7 @@ fun CreateAccountOverviewScreen(viewModel: CreateAccountOverviewViewModel) {
             contentText = stringResource(id = viewModel.type.overviewResources.overviewContentTextResId),
             contentIconResId = viewModel.type.overviewResources.overviewContentIconResId,
             learnMoreText = stringResource(id = viewModel.type.overviewResources.overviewLearnMoreTextResId),
-            learnMoreUrl = TODO("get server config from viewModel  websiteUrl}/pricing")
+            learnMoreUrl = viewModel.learnMoreUrl()
         )
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreateAccountOverviewViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/overview/CreateAccountOverviewViewModel.kt
@@ -3,6 +3,7 @@ package com.wire.android.ui.authentication.create.overview
 import com.wire.android.ui.authentication.create.common.CreateAccountFlowType
 
 interface CreateAccountOverviewViewModel {
+    fun learnMoreUrl(): String
     fun onOverviewContinue()
     fun goBackToPreviousStep()
     val type: CreateAccountFlowType

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/personalaccount/CreatePersonalAccountViewModel.kt
@@ -2,6 +2,7 @@ package com.wire.android.ui.authentication.create.personalaccount
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.wire.android.di.AuthServerConfigProvider
 import com.wire.android.di.ClientScopeProvider
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.android.navigation.BackStackMode
@@ -31,7 +32,7 @@ class CreatePersonalAccountViewModel @Inject constructor(
     addAuthenticatedUserUseCase: AddAuthenticatedUserUseCase,
     registerAccountUseCase: RegisterAccountUseCase,
     clientScopeProviderFactory: ClientScopeProvider.Factory,
-    pushTokenUseCase: RegisterTokenUseCase
+    authServerConfigProvider: AuthServerConfigProvider
 ) : CreateAccountBaseViewModel(
     CreateAccountFlowType.CreatePersonalAccount,
     savedStateHandle,
@@ -42,7 +43,7 @@ class CreatePersonalAccountViewModel @Inject constructor(
     addAuthenticatedUserUseCase,
     registerAccountUseCase,
     clientScopeProviderFactory,
-    pushTokenUseCase
+    authServerConfigProvider
 ) {
     var moveToStep = MutableSharedFlow<CreatePersonalAccountNavigationItem>()
     var moveBack = MutableSharedFlow<Unit>()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/team/CreateTeamViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/team/CreateTeamViewModel.kt
@@ -3,6 +3,7 @@ package com.wire.android.ui.authentication.create.team
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.wire.android.di.AuthServerConfigProvider
 import com.wire.android.di.ClientScopeProvider
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -32,7 +33,7 @@ class CreateTeamViewModel @Inject constructor(
     addAuthenticatedUserUseCase: AddAuthenticatedUserUseCase,
     registerAccountUseCase: RegisterAccountUseCase,
     clientScopeProviderFactory: ClientScopeProvider.Factory,
-    pushTokenUseCase: RegisterTokenUseCase
+    authServerConfigProvider: AuthServerConfigProvider
 ) : CreateAccountBaseViewModel(
     CreateAccountFlowType.CreateTeam,
     savedStateHandle,
@@ -43,7 +44,7 @@ class CreateTeamViewModel @Inject constructor(
     addAuthenticatedUserUseCase,
     registerAccountUseCase,
     clientScopeProviderFactory,
-    pushTokenUseCase
+    authServerConfigProvider
 ) {
     var moveToStep = MutableSharedFlow<CreateTeamNavigationItem>()
     var moveBack = MutableSharedFlow<Unit>()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.wire.android.R
+import com.wire.android.appLogger
 import com.wire.android.ui.authentication.login.LoginError
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
@@ -51,7 +52,6 @@ import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.DialogErrorStrings
 import com.wire.android.util.dialogErrorStrings
-import com.wire.kalium.logic.configuration.server.ServerConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -71,7 +71,7 @@ fun LoginEmailScreen(
         onDialogDismiss = { loginEmailViewModel.onDialogDismiss() },
         onRemoveDeviceOpen = { loginEmailViewModel.onTooManyDevicesError() },
         onLoginButtonClick = suspend { loginEmailViewModel.login() },
-        accountsBaseUrl = loginEmailViewModel.serverConfig.api,
+        forgotPasswordUrl = loginEmailViewModel.serverConfig.forgotPassword,
         scope = scope,
         serverTitle = loginEmailViewModel.serverConfig.title
     )
@@ -86,7 +86,7 @@ private fun LoginEmailContent(
     onDialogDismiss: () -> Unit,
     onRemoveDeviceOpen: () -> Unit,
     onLoginButtonClick: suspend () -> Unit,
-    accountsBaseUrl: String,
+    forgotPasswordUrl: String,
     scope: CoroutineScope,
     //todo: temporary to show to pointing server
     serverTitle: String
@@ -121,7 +121,7 @@ private fun LoginEmailContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = MaterialTheme.wireDimensions.spacing16x),
-            accountsBaseUrl = accountsBaseUrl
+            forgotPasswordUrl = forgotPasswordUrl
         )
         Spacer(modifier = Modifier.weight(1f))
 
@@ -204,7 +204,7 @@ private fun PasswordInput(modifier: Modifier, password: TextFieldValue, onPasswo
 }
 
 @Composable
-private fun ForgotPasswordLabel(modifier: Modifier, accountsBaseUrl: String) {
+private fun ForgotPasswordLabel(modifier: Modifier, forgotPasswordUrl: String) {
     Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
         val context = LocalContext.current
         Text(
@@ -218,16 +218,17 @@ private fun ForgotPasswordLabel(modifier: Modifier, accountsBaseUrl: String) {
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                    onClick = { openForgotPasswordPage(context, accountsBaseUrl) }
+                    onClick = { openForgotPasswordPage(context, forgotPasswordUrl) }
                 )
                 .testTag("Forgot password?")
         )
     }
 }
 
-private fun openForgotPasswordPage(context: Context, accountsBaseUrl: String) {
-    val url = "$accountsBaseUrl/forgot"
-    CustomTabsHelper.launchUrl(context, url)
+private fun openForgotPasswordPage(context: Context, forgotPasswordUrl: String) {
+    CustomTabsHelper.launchUrl(context, forgotPasswordUrl).also {
+        appLogger.d(forgotPasswordUrl)
+    }
 }
 
 @OptIn(ExperimentalAnimationApi::class)
@@ -262,7 +263,7 @@ private fun LoginEmailScreenPreview() {
             onDialogDismiss = { },
             onRemoveDeviceOpen = { },
             onLoginButtonClick = suspend { },
-            accountsBaseUrl = "",
+            forgotPasswordUrl = "",
             scope = scope,
             serverTitle = "Test Server"
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

1. app crashing when opening screen.
2. forgot password, tos and pricing url are not working 

### Solutions

1. in `CreateAccountViewModel` `RegisterPushToken` was injected in the constructor which is a user session use case, when injecting such usecases in viewmodels before the account is authenticated the app crash because there is no session for the user.
2. changes to the `ServerConfig` class in kalium can brake how the links should be created.
3. the path was added to the end of the url string with out any consecration to correct url building.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
