### PR TITLE
feat: add timestamps to messages AR-1420

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -1,19 +1,20 @@
 package com.wire.android.mapper
 
+import com.wire.android.R
+import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.MessageHeader
 import com.wire.android.ui.home.conversations.model.MessageSource
 import com.wire.android.ui.home.conversations.model.MessageStatus
-import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.ui.home.conversations.name
 import com.wire.android.ui.home.conversations.previewAsset
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.UIText
+import com.wire.android.util.uiMessageDateTime
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.message.Message
-import com.wire.android.R
-import com.wire.android.ui.home.conversations.model.UIMessage
-import com.wire.android.ui.home.conversations.name
-import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.message.MessageContent
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -51,7 +52,7 @@ class MessageMapper @Inject constructor(
                     username = sender?.name?.let { UIText.DynamicString(it) } ?: UIText.StringResource(R.string.member_name_deleted_label),
                     membership = if (sender is MemberDetails.Other) userTypeMapper.toMembership(sender.userType) else Membership.None,
                     isLegalHold = false,
-                    time = message.date,
+                    time = message.date.uiMessageDateTime() ?: "",
                     messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
                     messageId = message.id
                 ),
@@ -59,5 +60,4 @@ class MessageMapper @Inject constructor(
             )
         }
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,11 +24,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.LegalHoldIndicator
 import com.wire.android.ui.common.MembershipQualifierLabel
-import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversations.model.DeletedMessage
@@ -94,8 +96,8 @@ fun MessageItem(
 private fun MessageHeader(messageHeader: MessageHeader) {
     with(messageHeader) {
         Column {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Username(username.asString())
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+                Username(username.asString(), modifier = Modifier.weight(weight = 1F))
 
                 if (membership != Membership.None) {
                     Spacer(modifier = Modifier.width(dimensions().spacing6x))
@@ -106,16 +108,8 @@ private fun MessageHeader(messageHeader: MessageHeader) {
                     Spacer(modifier = Modifier.width(dimensions().spacing6x))
                     LegalHoldIndicator()
                 }
-/*
-for now this feature is disabled as Wolfgang suggested
-Box(Modifier.fillMaxWidth()) {
-MessageTimeLabel(
-time, modifier = Modifier
-.align(Alignment.CenterEnd)
-.padding(end = 8.dp)
-)
-}
-*/
+
+                MessageTimeLabel(messageHeader.time)
             }
         }
         if (messageStatus != MessageStatus.Untouched) {
@@ -124,21 +118,22 @@ time, modifier = Modifier
     }
 }
 
-//TODO: just a mock label, later when back-end is ready we are going to format it correctly, probably not as a String?
 @Composable
-private fun MessageTimeLabel(time: String, modifier: Modifier) {
+private fun MessageTimeLabel(time: String) {
     Text(
         text = time,
         style = MaterialTheme.typography.labelSmall.copy(color = MaterialTheme.wireColorScheme.secondaryText),
-        modifier = modifier
     )
 }
 
 @Composable
-private fun Username(username: String) {
+private fun Username(username: String, modifier: Modifier) {
     Text(
         text = username,
-        style = MaterialTheme.wireTypography.body02
+        style = MaterialTheme.wireTypography.body02,
+        modifier = modifier,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
     )
 }
 

--- a/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/DateTimeUtil.kt
@@ -1,13 +1,35 @@
 package com.wire.android.util
 
+import android.text.format.DateUtils
 import java.text.DateFormat
 import java.text.ParseException
 import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
 
-private val serverDateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-private val mediumDateTimeFormat = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM)
+private val serverDateTimeFormat = SimpleDateFormat(
+    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+    Locale.getDefault()
+).apply { timeZone = TimeZone.getTimeZone("UTC") }
+private val mediumDateTimeFormat = DateFormat
+    .getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM)
+private val messageTimeFormatter = DateFormat
+    .getTimeInstance(DateFormat.SHORT)
+    .apply { timeZone = TimeZone.getDefault() }
+private val messageDateTimeFormatter = DateFormat
+    .getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT)
+    .apply { timeZone = TimeZone.getDefault() }
 
 fun String.formatMediumDateTime(): String? =
-    try { serverDateTimeFormat.parse(this)?.let { mediumDateTimeFormat.format(it) } } catch (e: ParseException) { null }
+    try { this.serverDate()?.let { mediumDateTimeFormat.format(it) } } catch (e: ParseException) { null }
+fun String.serverDate(): Date? = serverDateTimeFormat.parse(this)
+fun String.uiMessageDateTime(): String? = this
+    .serverDate()?.let { serverDate ->
+        when(DateUtils.isToday(serverDate.time)) {
+            true -> messageTimeFormatter.format(serverDate)
+            false -> messageDateTimeFormatter.format(serverDate)
+        }
+    }
 
 fun getCurrentParsedDateTime(): String = mediumDateTimeFormat.format(System.currentTimeMillis())


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1420" title="AR-1420" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1420</a>  Timestamp 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Messages didn't display timestamps

### Solutions

Display timestamps according to:

```
when timestamp.isToday 
   true -> timestamp.justTheTime
   false -> timestamp.timeAndDate
```

### Attachments (Optional)

<img width="461" alt="Screen Shot 2022-06-16 at 10 26 48" src="https://user-images.githubusercontent.com/196761/174047449-e68d24ff-cdd3-40e0-8433-ec520cddf604.png">

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
