### PR TITLE
chore: Back Navigation improve

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationManager.kt
@@ -39,9 +39,18 @@ data class NavigationCommand(
 )
 
 enum class BackStackMode {
-    CLEAR_TILL_START, // clear the whole backstack excluding "start screen"
-    CLEAR_WHOLE, // clear the whole backstack including "start screen" (use when you navigate to a new "start screen" )
-    NONE; // screen will be added to the existing backstack.
+    // clear the whole backstack excluding "start screen"
+    CLEAR_TILL_START,
 
-    fun shouldClear(): Boolean = this == CLEAR_WHOLE || this == CLEAR_TILL_START
+    // clear the whole backstack including "start screen" (use when you navigate to a new "start screen" )
+    CLEAR_WHOLE,
+
+    // remove the current item from backstack before adding the new one.
+    // use it instead of:
+    //  navigationManager.navigateBack()
+    //  navigationManager.navigate(SomeWhere)
+    REMOVE_CURRENT,
+
+    // screen will be added to the existing backstack.
+    NONE;
 }

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -23,21 +23,37 @@ internal fun navigateToItem(
                     }
                 }
             }
-            BackStackMode.NONE -> {}
+            BackStackMode.REMOVE_CURRENT -> {
+                navController.run {
+                    println("cyka 0 ${backQueue.map { it.destination.route }}")
+                    backQueue.lastOrNull { it.destination.route != null }?.let { entry ->
+                        println("cyka 1 ${entry.destination.route}")
+                        val inclusive = true
+                        val startId = entry.destination.id
+                        popBackStack(startId, inclusive)
+                    }
+                }
+            }
+            BackStackMode.NONE -> {
+            }
         }
         launchSingleTop = true
         restoreState = true
     }
 }
 
-internal fun NavController.popWithArguments(arguments: Map<String, Any>?) {
+/**
+ * @return true if the stack was popped at least once and the user has been navigated to another destination,
+ * false otherwise
+ */
+internal fun NavController.popWithArguments(arguments: Map<String, Any>?): Boolean {
     previousBackStackEntry?.let {
         arguments?.forEach { (key, value) ->
             appLogger.d("Destination is ${it.destination}")
             it.savedStateHandle[key] = value
         }
     }
-    popBackStack()
+    return popBackStack()
 }
 
 @ExperimentalMaterial3Api

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -25,9 +25,7 @@ internal fun navigateToItem(
             }
             BackStackMode.REMOVE_CURRENT -> {
                 navController.run {
-                    println("cyka 0 ${backQueue.map { it.destination.route }}")
                     backQueue.lastOrNull { it.destination.route != null }?.let { entry ->
-                        println("cyka 1 ${entry.destination.route}")
                         val inclusive = true
                         val startId = entry.destination.id
                         popBackStack(startId, inclusive)

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -32,8 +32,7 @@ internal fun navigateToItem(
                     }
                 }
             }
-            BackStackMode.NONE -> {
-            }
+            BackStackMode.NONE -> {}
         }
         launchSingleTop = true
         restoreState = true

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -83,16 +83,18 @@ class WireActivity : AppCompatActivity() {
             navigationManager.navigateState
                 .onEach { command ->
                     if (command == null) return@onEach
-                    keyboardController?.hide()
                     navigateToItem(navController, command)
                 }
                 .launchIn(scope)
 
             navigationManager.navigateBack
                 .onEach {
-                    keyboardController?.hide()
-                    navController.popWithArguments(it)
+                    if (!navController.popWithArguments(it)) finish()
                 }.launchIn(scope)
+
+            navController.addOnDestinationChangedListener { _, _, _ ->
+                keyboardController?.hide()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
 import com.wire.android.media.CallRinger
+import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
@@ -72,10 +73,10 @@ class IncomingCallViewModel @Inject constructor(
         viewModelScope.launch {
             observeIncomingCallJob.cancel()
             acceptCall(conversationId = conversationId)
-            navigationManager.navigateBack()
             navigationManager.navigate(
                 command = NavigationCommand(
-                    destination = NavigationItem.OngoingCall.getRouteWithArgs(listOf(conversationId))
+                    destination = NavigationItem.OngoingCall.getRouteWithArgs(listOf(conversationId)),
+                    backStackMode = BackStackMode.REMOVE_CURRENT
                 )
             )
         }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.R
 import com.wire.android.media.CallRinger
+import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.EXTRA_CONVERSATION_ID
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
@@ -84,10 +85,10 @@ class InitiatingCallViewModel @Inject constructor(
 
     private suspend fun onCallEstablished() {
         callRinger.ring(R.raw.ready_to_talk, isLooping = false)
-        navigateBack()
         navigationManager.navigate(
             command = NavigationCommand(
-                destination = NavigationItem.OngoingCall.getRouteWithArgs(listOf(conversationId))
+                destination = NavigationItem.OngoingCall.getRouteWithArgs(listOf(conversationId)),
+                backStackMode = BackStackMode.REMOVE_CURRENT
             )
         )
     }


### PR DESCRIPTION
# What's new in this PR?

- change handling `NavigationManager.navigateBack()`
- added new `BackStackMode.REMOVE_CURRENT` it removes the current item from the navigation backStack before navigating to the new one.

### Issues

In cases when `NavController.popBackStack()` is called and the current screen is the only item in backStack, then empty screen is displayed. 
That issue could appear when the app was opened by `PendingIntent` from the notification and `NavController.popBackStack()` is called (NOT android back button).
Example scenario: 
- kill the app on device1
- call from device2 to device1
- device1 shows IncomingCallScreen (it's not yet implemented but will be soon :) )
- cancel a call on device2, or decline a call on device1

As a result: 
empty screen is displayed (kinda default compose-navigation screen, before even `startDestination` is set)

### Causes (Optional)

As texed before: when we call `NavController.popBackStack()` and there is no backstack in NavController then empty screen is shown. 

### Solutions

To solve that we check if `NavController.popBackStack()`  popped stack at least once (`popBackStack()` returns `true` in that case) and if not - we assume that was the very first screen and we need to close the whole app (`finish()` the WireActivity).

The other problem occurs after that solution: some of the screens (IncomingCallScreen e.g.) does something like: 
step1:`navigateBack` 
step2: `navigateToSomeScreen` 
because we need to remove a current screen from a backStack and navigate to another screen. 

But with the solution described above, we'll get the whole app closed on step1, if the current screen was a very first (for example IncomingCallScreen was opened from the PendingIntent in notifications).

So to solve that secondary issue we add `BackStackMode.REMOVE_CURRENT`, which does all the `navigateBack+navigateTo` magic by itself. 
