### PR TITLE
fix: system messages design review changes [AR-1143]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -50,36 +50,47 @@ class MessageContentMapper @Inject constructor(
         message: Message.System,
         members: List<MemberDetails>
     ) = when (val content = message.content) {
-        is MemberChange -> {
-            val sender = members.findUser(userId = message.senderUserId)
-            val isAuthorSelfAction = content.members.size == 1 && message.senderUserId == content.members.first().id
-            val authorName = toSystemMessageMemberName(
-                member = sender,
-                type = SelfNameType.ResourceTitleCase
+        is MemberChange -> mapMemberChangeMessage(content, message.senderUserId, members)
+    }
+
+    fun mapMemberChangeMessage(
+        content: MessageContent.MemberChange,
+        senderUserId: UserId,
+        members: List<MemberDetails>
+    ) : UIMessageContent.SystemMessage? {
+        val sender = members.findUser(userId = senderUserId)
+        val isAuthorSelfAction = members.size == 1 && senderUserId == content.members.first().id
+        val authorName = toSystemMessageMemberName(
+            member = sender,
+            type = SelfNameType.ResourceTitleCase
+        )
+        val memberNameList = content.members.map {
+            toSystemMessageMemberName(
+                member = members.findUser(userId = it.id),
+                type = SelfNameType.ResourceLowercase
             )
-            val memberNameList = content.members.map {
-                toSystemMessageMemberName(
-                    member = members.findUser(userId = it.id),
-                    type = SelfNameType.ResourceLowercase
-                )
-            }
-            when (content) {
-                is Added -> UIMessageContent.SystemMessage.MemberAdded(
-                    author = authorName,
-                    memberNames = memberNameList
-                )
-                is Removed ->
-                    if (isAuthorSelfAction) {
-                        UIMessageContent.SystemMessage.MemberLeft(
-                            author = authorName
-                        )
-                    } else {
-                        UIMessageContent.SystemMessage.MemberRemoved(
-                            author = authorName,
-                            memberNames = memberNameList
-                        )
-                    }
-            }
+        }
+        return when (content) {
+            is Added ->
+                if (isAuthorSelfAction) {
+                    null // we don't want to show "You added you to the conversation"
+                } else {
+                    UIMessageContent.SystemMessage.MemberAdded(
+                        author = authorName,
+                        memberNames = memberNameList
+                    )
+                }
+            is Removed ->
+                if (isAuthorSelfAction) {
+                    UIMessageContent.SystemMessage.MemberLeft(
+                        author = authorName
+                    )
+                } else {
+                    UIMessageContent.SystemMessage.MemberRemoved(
+                        author = authorName,
+                        memberNames = memberNameList
+                    )
+                }
         }
     }
 
@@ -115,30 +126,6 @@ class MessageContentMapper @Inject constructor(
             }
             Message.EditStatus.NotEdited -> {
                 UIMessageContent.TextMessage(messageBody = messageBody)
-            }
-        }
-    }
-
-    fun toServer(
-        content: System,
-        senderUserId: UserId,
-        members: List<MemberDetails>
-    ): UIMessageContent = when (content) {
-        is MemberChange -> {
-            val sender = members.findUser(senderUserId)
-            val isAuthorSelfAction = content.members.size == 1 && senderUserId == content.members.first().id
-            val authorName = toSystemMessageMemberName(sender, SelfNameType.ResourceTitleCase)
-            val memberNameList = content.members.map {
-                toSystemMessageMemberName(members.findUser(it.id), SelfNameType.ResourceLowercase)
-            }
-            when (content) {
-                is Added -> UIMessageContent.SystemMessage.MemberAdded(
-                    authorName,
-                    memberNameList
-                )
-                is Removed ->
-                    if (isAuthorSelfAction) UIMessageContent.SystemMessage.MemberLeft(authorName)
-                    else UIMessageContent.SystemMessage.MemberRemoved(authorName, memberNameList)
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -59,7 +59,7 @@ class MessageContentMapper @Inject constructor(
         members: List<MemberDetails>
     ) : UIMessageContent.SystemMessage? {
         val sender = members.findUser(userId = senderUserId)
-        val isAuthorSelfAction = members.size == 1 && senderUserId == content.members.first().id
+        val isAuthorSelfAction = content.members.size == 1 && senderUserId == content.members.first().id
         val authorName = toSystemMessageMemberName(
             member = sender,
             type = SelfNameType.ResourceTitleCase

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -39,8 +39,12 @@ class MessageMapper @Inject constructor(
     ): List<UIMessage> = withContext(dispatcherProvider.io()) {
         messages.map { message ->
             val sender = members.findUser(message.senderUserId)
-
-            UIMessage(
+            val content = messageContentMapper.fromMessage(
+                message = message,
+                members = members
+            )
+            if (message is Message.System && content == null) null // system messages doesn't have header so there is nothing to be displayed
+            else UIMessage(
                 messageContent = messageContentMapper.fromMessage(
                     message = message,
                     members = members
@@ -57,7 +61,7 @@ class MessageMapper @Inject constructor(
                 ),
                 userAvatarData = UserAvatarData(asset = sender.previewAsset)
             )
-        }
+        }.filterNotNull()
     }
 
 }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -44,8 +44,10 @@ class MessageMapper @Inject constructor(
                 message = message,
                 members = members
             )
-            if (message is Message.System && content == null) null // system messages doesn't have header so there is nothing to be displayed
-            else UIMessage(
+            if (message is Message.System && content == null)
+                null // system messages doesn't have header so without the content there is nothing to be displayed
+            else
+                UIMessage(
                 messageContent = messageContentMapper.fromMessage(
                     message = message,
                     members = members

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -97,13 +97,15 @@ class MessageContentMapperTest {
         val contentLeft = MessageContent.MemberChange.Removed(listOf(Member(userId1)))
         val contentRemoved = MessageContent.MemberChange.Removed(listOf(Member(userId2)))
         val contentAdded = MessageContent.MemberChange.Added(listOf(Member(userId2), Member(userId3)))
+        val contentAddedSelf = MessageContent.MemberChange.Added(listOf(Member(userId1)))
         val member1 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId1))
         val member2 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId2))
         val member3 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId3))
         // When
-        val resultContentLeft = mapper.toServer(contentLeft, userId1, listOf(member1))
-        val resultContentRemoved = mapper.toServer(contentRemoved, userId1, listOf(member1, member2))
-        val resultContentAdded = mapper.toServer(contentAdded, userId1, listOf(member1, member2, member3))
+        val resultContentLeft = mapper.mapMemberChangeMessage(contentLeft, userId1, listOf(member1))
+        val resultContentRemoved = mapper.mapMemberChangeMessage(contentRemoved, userId1, listOf(member1, member2))
+        val resultContentAdded = mapper.mapMemberChangeMessage(contentAdded, userId1, listOf(member1, member2, member3))
+        val resultContentAddedSelf = mapper.mapMemberChangeMessage(contentAddedSelf, userId1, listOf(member1))
         // Then
         assert(
             resultContentLeft is SystemMessage.MemberLeft &&
@@ -123,6 +125,7 @@ class MessageContentMapperTest {
                 resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.otherUser.name &&
                 resultContentAdded.memberNames[1].asString(arrangement.resources) == member3.otherUser.name
         )
+        assert(resultContentAddedSelf == null)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1143" title="AR-1143" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1143</a>   Conversation setting messages (system) 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

System messages still needed some polishing in order to pass the design review. There were some [comments](https://wearezeta.atlassian.net/browse/AR-1143?focusedCommentId=102200) from Wolfgang needed to be addressed.

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
