### PR TITLE
feat: display error when failing to delete message (AR-1271)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -30,10 +30,12 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.conversationColor
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.snackbar.SwipeDismissSnackbarHost
+import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorDeletingMessage
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorDownloadingAsset
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxAssetSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxImageSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorOpeningAssetFile
+import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorPickingAttachment
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingAsset
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorSendingImage
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnFileDownloaded
@@ -240,7 +242,8 @@ private fun getSnackbarMessage(messageCode: ConversationSnackbarMessages): Pair<
         ErrorSendingAsset -> stringResource(R.string.error_conversation_sending_asset)
         ErrorDownloadingAsset -> stringResource(R.string.error_conversation_downloading_asset)
         ErrorOpeningAssetFile -> stringResource(R.string.error_conversation_opening_asset_file)
-        ConversationSnackbarMessages.ErrorPickingAttachment -> stringResource(R.string.error_conversation_generic)
+        ErrorDeletingMessage -> stringResource(R.string.error_conversation_deleting_message)
+        ErrorPickingAttachment -> stringResource(R.string.error_conversation_generic)
     }
     val actionLabel = when (messageCode) {
         is OnFileDownloaded -> stringResource(R.string.label_show)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SnackbarMessages.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SnackbarMessages.kt
@@ -7,6 +7,7 @@ sealed class ConversationSnackbarMessages {
     object ErrorSendingImage : ConversationSnackbarMessages()
     object ErrorDownloadingAsset : ConversationSnackbarMessages()
     object ErrorOpeningAssetFile : ConversationSnackbarMessages()
+    object ErrorDeletingMessage: ConversationSnackbarMessages()
     class ErrorMaxAssetSize(val maxLimitInMB: Int) : ConversationSnackbarMessages()
     class OnFileDownloaded(val assetName: String?) : ConversationSnackbarMessages()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -319,6 +319,7 @@
     <string name="error_conversation_sending_asset">There was an error trying to send that file. Please check your Internet connection and try again</string>
     <string name="error_conversation_downloading_asset">There was an error trying to download that file. Please try again</string>
     <string name="error_conversation_opening_asset_file">No app was found to open the selected file</string>
+    <string name="error_conversation_deleting_message">There was an error deleting the message. Please verify your connection and try again</string>
     <string name="error_conversation_max_image_size_limit">The image you chose is too large. Please choose an image smaller than 15MB</string>
     <string name="error_conversation_max_asset_size_limit">The file you chose is too large. Please choose a file smaller than %sMB</string>
     <string name="error_conversation_generic">There was an unknown error when trying to send the message</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -12,6 +12,7 @@ import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversationUseCase
 import com.wire.android.util.FileManager
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
@@ -33,6 +34,7 @@ import com.wire.kalium.logic.feature.message.MarkMessagesAsNotifiedUseCase
 import com.wire.kalium.logic.feature.message.Result
 import com.wire.kalium.logic.feature.message.SendTextMessageUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
+import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -138,10 +140,14 @@ internal class ConversationsViewModelArrangement {
         return this
     }
 
-
     fun withSuccessfulSendAttachmentMessage(): ConversationsViewModelArrangement {
         coEvery { sendAssetMessage(any(), any(), any(), any()) } returns SendAssetMessageResult.Success
         coEvery { sendImageMessage(any(), any(), any(), any(), any()) } returns SendImageMessageResult.Success
+        return this
+    }
+
+    fun withFailureOnDeletingMessages(): ConversationsViewModelArrangement {
+        coEvery { deleteMessage(any(), any(), any()) } returns Either.Left(CoreFailure.Unknown(null))
         return this
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -82,6 +82,36 @@ class ConversationsViewModelTest {
     }
 
     @Test
+    fun `given a failure, when deleting messages, then the error state is updated`() = runTest {
+        // Given
+        val (_, viewModel) = ConversationsViewModelArrangement().withFailureOnDeletingMessages().arrange()
+
+        viewModel.conversationViewState
+        // When
+        viewModel.deleteMessage("messageId", true)
+
+        // Then
+        assert(viewModel.conversationViewState.onSnackbarMessage is ConversationSnackbarMessages.ErrorDeletingMessage)
+    }
+
+    @Test
+    fun `given a failure, when deleting messages, then the delete dialog state is closed`() = runTest {
+        // Given
+        val (_, viewModel) = ConversationsViewModelArrangement().withFailureOnDeletingMessages().arrange()
+
+        viewModel.conversationViewState
+        // When
+        viewModel.deleteMessage("messageId", true)
+
+        // Then
+        val expectedState = DeleteMessageDialogsState.States(
+            DeleteMessageDialogActiveState.Hidden,
+            DeleteMessageDialogActiveState.Hidden
+        )
+        assertEquals(expectedState, viewModel.deleteMessageDialogsState)
+    }
+
+    @Test
     fun `given a 1 on 1 conversation, when solving the conversation name, then the name of the other user is used`() = runTest {
         // Given
         val oneToOneConversationDetails = withMockConversationDetailsOneOnOne("Other User Name Goes Here")
@@ -321,4 +351,5 @@ class ConversationsViewModelTest {
             verify(exactly = 1) { arrangement.fileManager.openWithExternalApp(any(), any(), any()) }
             assert(viewModel.conversationViewState.downloadedAssetDialogState == DownloadedAssetDialogVisibilityState.Hidden)
         }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1271" title="AR-1271" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-1271</a>  Toast for deletion error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There's no feedback to the user when there's a failure when deleting messages.

### Solutions

Handle the error and display a snackbar.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

1. Turn off your internet connection;
2. Attempt to delete a message.

### Attachments

https://user-images.githubusercontent.com/9389043/174299377-009a6b83-1db1-4cb8-968b-a301697e62eb.mov

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
