### PR TITLE
fix: fixed crash when sending/receiving svg images

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/AssetsUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/AssetsUtil.kt
@@ -1,0 +1,9 @@
+package com.wire.android.mapper
+
+internal fun isImage(mimeType: String): Boolean = when (mimeType) {
+    // We only support the following inline image types
+    "image/jpeg" -> true
+    "image/jpg" -> true
+    "image/png" -> true
+    else -> false
+}

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -142,7 +142,7 @@ class MessageContentMapper @Inject constructor(
         if (remoteData.assetId.isNotEmpty()) {
             when {
                 // If it's an image, we download it right away
-                mimeType.contains("image") -> UIMessageContent.ImageMessage(
+                isImage(mimeType) -> UIMessageContent.ImageMessage(
                     assetId = AssetId(remoteData.assetId, remoteData.assetDomain.orEmpty()),
                     rawImgData = getRawAssetData(
                         conversationId = conversationId,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -2,22 +2,15 @@ package com.wire.android.ui.home.messagecomposer
 
 import android.content.Context
 import android.net.Uri
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Dp
 import com.wire.android.appLogger
+import com.wire.android.mapper.isImage
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
-import com.wire.android.util.DEFAULT_FILE_MIME_TYPE
-import com.wire.android.util.getFileName
-import com.wire.android.util.getMimeType
-import com.wire.android.util.orDefault
-import com.wire.android.util.toByteArray
+import com.wire.android.util.*
 import java.io.IOException
 
 @Composable
@@ -118,7 +111,7 @@ class AttachmentInnerState(val context: Context) {
             val mimeType = attachmentUri.getMimeType(context).orDefault(DEFAULT_FILE_MIME_TYPE)
             val assetRawData = attachmentUri.toByteArray(context)
             val assetFileName = context.getFileName(attachmentUri)
-            val attachmentType = if (mimeType.contains("image/")) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
+            val attachmentType = if (isImage(mimeType)) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
             val attachment = AttachmentBundle(mimeType, assetRawData, assetFileName, attachmentType)
             AttachmentState.Picked(attachment)
         } catch (e: IOException) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -2,7 +2,11 @@ package com.wire.android.ui.home.messagecomposer
 
 import android.content.Context
 import android.net.Uri
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Dp
@@ -10,7 +14,11 @@ import com.wire.android.appLogger
 import com.wire.android.mapper.isImage
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
-import com.wire.android.util.*
+import com.wire.android.util.DEFAULT_FILE_MIME_TYPE
+import com.wire.android.util.getFileName
+import com.wire.android.util.getMimeType
+import com.wire.android.util.orDefault
+import com.wire.android.util.toByteArray
 import java.io.IOException
 
 @Composable

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -39,7 +39,7 @@ object TestMessage {
         encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
     )
     val ASSET_IMAGE_CONTENT = AssetContent(
-        0L, "name", "image", null, ASSET_REMOTE_DATA, Message.DownloadStatus.NOT_DOWNLOADED
+        0L, "name", "image/jpg", null, ASSET_REMOTE_DATA, Message.DownloadStatus.NOT_DOWNLOADED
     )
     val MEMBER_REMOVED_MESSAGE = Message.System(
         id = "messageID",

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -132,8 +132,7 @@ class MessageContentMapperTest {
     fun givenAssetContent_whenMappingToUIMessageContent_thenCorrectValuesShouldBeReturned() = runTest {
         // Given
         val (arrangement, mapper) = Arrangement().arrange()
-        val userId = UserId("user-id1", "user-domain")
-        val contentOther = TestMessage.ASSET_IMAGE_CONTENT.copy(
+        val unknownImageFormatMessage = TestMessage.ASSET_IMAGE_CONTENT.copy(
             mimeType = "other",
             remoteData = TestMessage.ASSET_REMOTE_DATA.copy(assetId = "id")
         )
@@ -141,9 +140,9 @@ class MessageContentMapperTest {
             remoteData = TestMessage.ASSET_REMOTE_DATA.copy(assetId = "image-id")
         )
         // When - Then
-        val resultContentOther = mapper.toAsset(QualifiedID("id", "domain"), "message-id", contentOther)
+        val resultContentOther = mapper.toAsset(QualifiedID("id", "domain"), "message-id", unknownImageFormatMessage)
         coVerify(exactly = 0) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
-        assert(resultContentOther is AssetMessage && resultContentOther.assetId.value == contentOther.remoteData.assetId)
+        assert(resultContentOther is AssetMessage && resultContentOther.assetId.value == unknownImageFormatMessage.remoteData.assetId)
         // When - Then
         val resultContentImage = mapper.toAsset(QualifiedID("id", "domain"), "message-id", contentImage)
         coVerify(exactly = 1) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -151,6 +151,22 @@ class MessageContentMapperTest {
     }
 
     @Test
+    fun givenSVGImageAssetContent_whenMappingToUIMessageContent_thenIsMappedToAssetMessage() = runTest {
+        // Given
+        val (arrangement, mapper) = Arrangement().arrange()
+        val contentImage = TestMessage.ASSET_IMAGE_CONTENT.copy(
+            mimeType = "image/svg",
+        )
+
+        // When
+        val resultContentImage = mapper.toAsset(QualifiedID("id", "domain"), "message-id", contentImage)
+
+        // Then
+        coVerify(inverse = true) { arrangement.getMessageAssetUseCase.invoke(any(), any()) }
+        assert(resultContentImage is AssetMessage)
+    }
+
+    @Test
     fun givenMessage_whenMappingToUIMessageContent_thenCorrectValuesShouldBeReturned() = runTest {
         // Given
         val (_, mapper) = Arrangement().arrange()


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sharing SVG files as images was causing some app crashes. Because even though their mime type is "image/svg", our app can't interpret this format in order to render it inlined in the chat.

### Solutions

To add a utils method to whitelist only "jpeg", "jpg" and "png" as _valid_ image types. If we plan on support or display other image types, we will need to add this mime type to the list.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Just share an svg file as image !

### Attachments (Optional)

https://user-images.githubusercontent.com/2468164/174822903-fb01c145-cb37-4703-ab77-2e1f77632460.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
