### PR TITLE
fix: truncate long names in search AR-1867

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.ui.common.ArrowRightIcon
@@ -93,6 +94,8 @@ private fun ContactItem(
             Text(
                 text = name,
                 style = MaterialTheme.wireTypography.title02,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         },
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/HighLightName.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/HighLightName.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
@@ -37,7 +38,6 @@ fun HighlightName(
             )
         }
     }
-
     if (highlightIndexes.isNotEmpty()) {
         Text(
             buildAnnotatedString {
@@ -60,12 +60,16 @@ fun HighlightName(
                             end = highLightIndexes.endIndex
                         )
                     }
-            }
+            },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     } else {
         Text(
             text = name,
-            style = MaterialTheme.wireTypography.title02
+            style = MaterialTheme.wireTypography.title02,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/HighLightSubtTitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/search/HighLightSubtTitle.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireTypography
@@ -65,13 +66,17 @@ fun HighlightSubtitle(
                             end = highLightIndexes.endIndex + 1
                         )
                     }
-            }
+            },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     } else {
         Text(
             text = "@$subTitle",
             style = MaterialTheme.wireTypography.subline01,
-            color = MaterialTheme.wireColorScheme.secondaryText
+            color = MaterialTheme.wireColorScheme.secondaryText,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1867" title="AR-1867" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1867</a>  Long name doesn't fit on New Conv. List Screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Long names in search extend passed 1 line, stretching the visuals vertically

### Solutions

Limit the text to 1 line and truncate the rest

### Testing

Manual

#### How to Test

Search for me or @dogaguclu 

### Attachments (Optional)

![Screenshot_20220622-130748_Android Reloaded 20 FINAL](https://user-images.githubusercontent.com/196761/175016712-95b821e1-91de-4c2a-8cd9-4691977550d0.jpg)

![Screenshot_20220622-130807_Android Reloaded 20 FINAL](https://user-images.githubusercontent.com/196761/175016737-d36b3510-2236-4b8a-aea5-3dcb5c80690d.jpg)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
