### PR TITLE
fix: displayed received images with null width and height as asset messages [AR-1685]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -4,7 +4,6 @@ import androidx.annotation.StringRes
 import com.wire.android.R
 import com.wire.android.ui.home.conversations.findUser
 import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.MessageContent as UIMessageContent
 import com.wire.android.ui.home.conversations.name
 import com.wire.android.util.time.ISOFormatter
 import com.wire.android.util.ui.UIText
@@ -17,12 +16,12 @@ import com.wire.kalium.logic.data.message.MessageContent.Asset
 import com.wire.kalium.logic.data.message.MessageContent.MemberChange
 import com.wire.kalium.logic.data.message.MessageContent.MemberChange.Added
 import com.wire.kalium.logic.data.message.MessageContent.MemberChange.Removed
-import com.wire.kalium.logic.data.message.MessageContent.System
 import com.wire.kalium.logic.data.user.AssetId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import javax.inject.Inject
+import com.wire.android.ui.home.conversations.model.MessageContent as UIMessageContent
 
 // TODO: splits mapping into more classes
 class MessageContentMapper @Inject constructor(
@@ -57,7 +56,7 @@ class MessageContentMapper @Inject constructor(
         content: MessageContent.MemberChange,
         senderUserId: UserId,
         members: List<MemberDetails>
-    ) : UIMessageContent.SystemMessage? {
+    ): UIMessageContent.SystemMessage? {
         val sender = members.findUser(userId = senderUserId)
         val isAuthorSelfAction = content.members.size == 1 && senderUserId == content.members.first().id
         val authorName = toSystemMessageMemberName(
@@ -141,16 +140,19 @@ class MessageContentMapper @Inject constructor(
         }
         if (remoteData.assetId.isNotEmpty()) {
             when {
-                // If it's an image, we download it right away
-                isImage(mimeType) -> UIMessageContent.ImageMessage(
-                    assetId = AssetId(remoteData.assetId, remoteData.assetDomain.orEmpty()),
-                    rawImgData = getRawAssetData(
+                // If it's an image and has valid width and height, we download it right away
+                isImage(mimeType) && imgWidth > 0 && imgHeight > 0 -> {
+                    val rawData = getRawAssetData(
                         conversationId = conversationId,
                         messageId = messageId
-                    ),
-                    width = imgWidth,
-                    height = imgHeight
-                )
+                    )
+                    UIMessageContent.ImageMessage(
+                        assetId = AssetId(remoteData.assetId, remoteData.assetDomain.orEmpty()),
+                        rawImgData = rawData,
+                        width = imgWidth,
+                        height = imgHeight
+                    )
+                }
 
                 // It's a generic Asset Message so let's not download it yet
                 else -> {

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -48,22 +48,20 @@ class MessageMapper @Inject constructor(
                 null // system messages doesn't have header so without the content there is nothing to be displayed
             else
                 UIMessage(
-                messageContent = messageContentMapper.fromMessage(
-                    message = message,
-                    members = members
-                ),
-                messageSource = if (sender is MemberDetails.Self) MessageSource.Self else MessageSource.OtherUser,
-                messageHeader = MessageHeader(
-                    // TODO: Designs for deleted users?
-                    username = sender?.name?.let { UIText.DynamicString(it) } ?: UIText.StringResource(R.string.member_name_deleted_label),
-                    membership = if (sender is MemberDetails.Other) userTypeMapper.toMembership(sender.userType) else Membership.None,
-                    isLegalHold = false,
-                    time = message.date.uiMessageDateTime() ?: "",
-                    messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
-                    messageId = message.id
-                ),
-                userAvatarData = UserAvatarData(asset = sender?.previewAsset)
-            )
+                    messageContent = content,
+                    messageSource = if (sender is MemberDetails.Self) MessageSource.Self else MessageSource.OtherUser,
+                    messageHeader = MessageHeader(
+                        // TODO: Designs for deleted users?
+                        username = sender?.name?.let { UIText.DynamicString(it) }
+                            ?: UIText.StringResource(R.string.member_name_deleted_label),
+                        membership = if (sender is MemberDetails.Other) userTypeMapper.toMembership(sender.userType) else Membership.None,
+                        isLegalHold = false,
+                        time = message.date.uiMessageDateTime() ?: "",
+                        messageStatus = if (message.status == Message.Status.FAILED) MessageStatus.SendFailure else MessageStatus.Untouched,
+                        messageId = message.id
+                    ),
+                    userAvatarData = UserAvatarData(asset = sender?.previewAsset)
+                )
         }.filterNotNull()
     }
 }

--- a/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestMessage.kt
@@ -1,12 +1,8 @@
 package com.wire.android.framework
 
-import com.wire.android.ui.home.conversations.model.MessageBody
-import com.wire.android.ui.home.conversations.model.MessageContent.TextMessage
-import com.wire.android.ui.home.conversations.model.MessageHeader
-import com.wire.android.ui.home.conversations.model.MessageSource
-import com.wire.android.ui.home.conversations.model.MessageStatus
-import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.model.UserAvatarData
+import com.wire.android.ui.home.conversations.model.*
+import com.wire.android.ui.home.conversations.model.MessageContent.TextMessage
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.ClientId
@@ -30,7 +26,7 @@ object TestMessage {
         status = Message.Status.SENT,
         editStatus = Message.EditStatus.NotEdited
     )
-    val ASSET_REMOTE_DATA = AssetContent.RemoteData(
+    val DUMMY_ASSET_REMOTE_DATA = AssetContent.RemoteData(
         otrKey = ByteArray(0),
         sha256 = ByteArray(16),
         assetId = "asset-id",
@@ -39,7 +35,7 @@ object TestMessage {
         encryptionAlgorithm = MessageEncryptionAlgorithm.AES_GCM
     )
     val ASSET_IMAGE_CONTENT = AssetContent(
-        0L, "name", "image/jpg", null, ASSET_REMOTE_DATA, Message.DownloadStatus.NOT_DOWNLOADED
+        0L, "name", "image/jpg", AssetContent.AssetMetadata.Image(100, 100), DUMMY_ASSET_REMOTE_DATA, Message.DownloadStatus.NOT_DOWNLOADED
     )
     val MEMBER_REMOVED_MESSAGE = Message.System(
         id = "messageID",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1685" title="AR-1685" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1685</a>  When receiving an image as attachment from web, android does not show the file
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Images received from web client shared as files come with their asset metadata `width` and `height` set to 0. This was causing the image not to render at all.


### Solutions

If an image message comes with any of these metadata values set to 0, we will treat it as a Generic Asset Message instead.


### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Attachments (Optional)



----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
