### PR TITLE
feat: dysplay sync status on the home screen

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -37,6 +37,7 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.UploadUserAvatarUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
+import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -138,6 +139,11 @@ class UseCaseModule {
     @Provides
     fun getLoginSessionUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, authServerConfigProvider: AuthServerConfigProvider) =
         coreLogic.getAuthenticationScope(authServerConfigProvider.authServer.value).ssoLoginScope.getLoginSessionGet
+
+    @ViewModelScoped
+    @Provides
+    fun observeSyncStateProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): ObserveSyncStateUseCase =
+        coreLogic.getSessionScope(currentAccount).observeSyncState
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -135,7 +135,7 @@ enum class NavigationItem(
 
     Home(
         primaryRoute = HOME,
-        content = { HomeScreen(it.navBackStackEntry.arguments?.getString(EXTRA_HOME_TAB_ITEM), hiltViewModel()) },
+        content = { HomeScreen(it.navBackStackEntry.arguments?.getString(EXTRA_HOME_TAB_ITEM), hiltViewModel(), hiltViewModel()) },
         animationConfig = NavigationAnimationConfig.DelegatedAnimation
     ),
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/WireLinearProgressIndicator.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireLinearProgressIndicator.kt
@@ -1,0 +1,14 @@
+package com.wire.android.ui.common
+
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun WireLinearProgressIndicator(modifier: Modifier = Modifier, progressColor: Color) {
+    LinearProgressIndicator(
+        color = progressColor,
+        modifier = modifier
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -21,6 +22,7 @@ import com.wire.android.navigation.HomeNavigationGraph
 import com.wire.android.navigation.HomeNavigationItem
 import com.wire.android.ui.common.bottomsheet.WireModalSheetLayout
 import com.wire.android.ui.common.topappbar.search.AppTopBarWithSearchBar
+import com.wire.android.ui.home.sync.SyncStateViewModel
 
 @OptIn(
     ExperimentalAnimationApi::class,
@@ -28,7 +30,7 @@ import com.wire.android.ui.common.topappbar.search.AppTopBarWithSearchBar
     ExperimentalMaterial3Api::class
 )
 @Composable
-fun HomeScreen(startScreen: String?, viewModel: HomeViewModel) {
+fun HomeScreen(startScreen: String?, viewModel: HomeViewModel, syncViewModel: SyncStateViewModel) {
     viewModel.checkRequirements()
     val homeState = rememberHomeState()
 
@@ -59,6 +61,7 @@ fun HomeScreen(startScreen: String?, viewModel: HomeViewModel) {
                         avatarAsset = viewModel.userAvatar.avatarAsset,
                         status = viewModel.userAvatar.status,
                         currentNavigationItem = homeState.currentNavigationItem,
+                        syncState = syncViewModel.syncState,
                         onOpenDrawerClicked = ::openDrawer,
                         onNavigateToUserProfile = viewModel::navigateToUserProfile,
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeTopBar.kt
@@ -1,19 +1,25 @@
 package com.wire.android.ui.home
 
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.wire.android.model.ImageAsset.UserAvatarAsset
-import com.wire.kalium.logic.data.user.UserAvailabilityStatus
-import com.wire.android.navigation.HomeNavigationItem
 import com.wire.android.model.UserAvatarData
+import com.wire.android.navigation.HomeNavigationItem
 import com.wire.android.ui.common.UserProfileAvatar
+import com.wire.android.ui.common.WireLinearProgressIndicator
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.topappbar.NavigationIconType
 import com.wire.android.ui.common.topappbar.WireCenterAlignedTopAppBar
+import com.wire.android.ui.home.sync.SyncViewState
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
@@ -21,6 +27,7 @@ fun HomeTopBar(
     avatarAsset: UserAvatarAsset?,
     status: UserAvailabilityStatus,
     currentNavigationItem: HomeNavigationItem,
+    syncState: SyncViewState,
     onOpenDrawerClicked: () -> Unit,
     onNavigateToUserProfile: () -> Unit
 ) {
@@ -37,5 +44,32 @@ fun HomeTopBar(
             }
         },
         elevation = if (currentNavigationItem.isSearchable) 0.dp else dimensions().topBarElevationHeight,
+    ) {
+        val shouldShowState = syncState !in setOf(SyncViewState.WAITING, SyncViewState.LIVE)
+
+        if (shouldShowState) {
+            WireLinearProgressIndicator(
+                modifier = Modifier.fillMaxWidth(),
+                progressColor = syncState.color
+            )
+        }
+    }
+}
+
+private val SyncViewState.color: Color
+    get() = when (this) {
+        SyncViewState.WAITING, SyncViewState.LIVE -> Color.White
+        SyncViewState.SLOW_SYNC -> Color.Blue
+        SyncViewState.GATHERING_EVENTS -> Color.Green
+        SyncViewState.LACK_OF_CONNECTION -> Color.Yellow
+        SyncViewState.UNKNOWN_FAILURE -> Color.Red
+    }
+
+@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class, ExperimentalAnimationApi::class)
+@Preview
+@Composable
+fun topBar() {
+    HomeTopBar(
+        null, UserAvailabilityStatus.AVAILABLE, HomeNavigationItem.Archive, SyncViewState.SLOW_SYNC, {}, {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/SyncStateViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/SyncStateViewModel.kt
@@ -1,0 +1,45 @@
+package com.wire.android.ui.home.sync
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.wire.kalium.logic.NetworkFailure
+import com.wire.kalium.logic.data.sync.SyncState
+import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SyncStateViewModel @Inject constructor(
+    private val observeSyncState: ObserveSyncStateUseCase
+) : ViewModel() {
+
+    var syncState by mutableStateOf(SyncViewState.WAITING)
+
+    init {
+        viewModelScope.launch {
+            launch { loadSync() }
+        }
+    }
+
+    private suspend fun loadSync() {
+        observeSyncState().collect { newState ->
+            syncState = when (newState) {
+                is SyncState.Failed -> {
+                    if (newState.cause is NetworkFailure.NoNetworkConnection) {
+                        SyncViewState.LACK_OF_CONNECTION
+                    } else {
+                        SyncViewState.UNKNOWN_FAILURE
+                    }
+                }
+                SyncState.GatheringPendingEvents -> SyncViewState.GATHERING_EVENTS
+                SyncState.Live -> SyncViewState.LIVE
+                SyncState.SlowSync -> SyncViewState.SLOW_SYNC
+                SyncState.Waiting -> SyncViewState.WAITING
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/sync/SyncViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/sync/SyncViewState.kt
@@ -1,0 +1,5 @@
+package com.wire.android.ui.home.sync
+
+enum class SyncViewState {
+    WAITING, SLOW_SYNC, GATHERING_EVENTS, LIVE, LACK_OF_CONNECTION, UNKNOWN_FAILURE
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Users have no way to know what is going on with the app, if the connection is established or not.
It also sucks for us, because it gets harder to understand what is going on without getting logs.

### Solutions

Add a progress indication on the HomeView to display SyncState

- Nothing: Live or Waiting
- 🔵 Slow Sync
- 🟢 Quick Sync / Pending Events
- 🟡 No internet connection
- 🔴 Unknown failure


### Testing

As this was done mainly with debugging in mind and as a placeholder for an actual designed feature, I've only tested it manually.

#### How to Test

Log in and open the main screen.

### Attachments

https://user-images.githubusercontent.com/9389043/175065826-66d350a8-c60b-41af-b780-cb7de6d1c608.mp4


----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
