### PR TITLE
fix: back navigation with arguments

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -135,12 +135,7 @@ enum class NavigationItem(
         content = {
             HomeScreen(
                 it.navBackStackEntry.arguments?.getString(EXTRA_HOME_TAB_ITEM),
-                hiltViewModel<com.wire.android.ui.home.HomeViewModel>().apply {
-                    it.navBackStackEntry.savedStateHandle.keys().forEach { key ->
-                        savedStateHandle[key] = it.navBackStackEntry.savedStateHandle.get<Any?>(key)
-                    }
-                    it.navBackStackEntry.arguments?.clear() //TODO this doesn't work
-                }
+                hiltSavedStateViewModel(it.navBackStackEntry)
             ) },
         animationConfig = NavigationAnimationConfig.DelegatedAnimation
     ),
@@ -189,13 +184,7 @@ enum class NavigationItem(
     Conversation(
         primaryRoute = CONVERSATION,
         canonicalRoute = "$CONVERSATION/{$EXTRA_CONVERSATION_ID}",
-        content = {
-            ConversationScreen(hiltViewModel<ConversationViewModel>().apply {
-                it.navBackStackEntry.savedStateHandle.keys().forEach { key ->
-                    savedStateHandle[key] = it.navBackStackEntry.savedStateHandle.get<Any?>(key)
-                }
-            })
-        },
+        content = { ConversationScreen(hiltSavedStateViewModel()) },
     ) {
         override fun getRouteWithArgs(arguments: List<Any>): String {
             val conversationId: ConversationId? = arguments.filterIsInstance<ConversationId>().firstOrNull()
@@ -311,6 +300,8 @@ const val EXTRA_MESSAGE_TO_DELETE_ID = "extra_message_to_delete"
 const val EXTRA_MESSAGE_TO_DELETE_IS_SELF = "extra_message_to_delete_is_self"
 
 const val EXTRA_CONNECTION_IGNORED_USER_NAME = "extra_connection_ignored_user_name"
+
+const val EXTRA_BACK_NAVIGATION_ARGUMENTS = "extra_back_navigation_arguments"
 
 fun NavigationItem.isExternalRoute() = this.getRouteWithArgs().startsWith("http")
 

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -184,7 +184,7 @@ enum class NavigationItem(
     Conversation(
         primaryRoute = CONVERSATION,
         canonicalRoute = "$CONVERSATION/{$EXTRA_CONVERSATION_ID}",
-        content = { ConversationScreen(hiltSavedStateViewModel()) },
+        content = { ConversationScreen(hiltSavedStateViewModel(it.navBackStackEntry)) },
     ) {
         override fun getRouteWithArgs(arguments: List<Any>): String {
             val conversationId: ConversationId? = arguments.filterIsInstance<ConversationId>().firstOrNull()

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -32,9 +32,10 @@ internal fun navigateToItem(
 
 internal fun NavController.popWithArguments(arguments: Map<String, Any>?) {
     previousBackStackEntry?.let {
-        arguments?.forEach { (key, value) ->
+        it.savedStateHandle.remove<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
+        arguments?.let { arguments ->
             appLogger.d("Destination is ${it.destination}")
-            it.savedStateHandle[key] = value
+            it.savedStateHandle[EXTRA_BACK_NAVIGATION_ARGUMENTS] = arguments
         }
     }
     popBackStack()

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationUtils.kt
@@ -8,19 +8,15 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.wire.android.appLogger
 
 @ExperimentalMaterial3Api
-internal fun navigateToItem(
-    navController: NavController,
-    command: NavigationCommand
-) {
-    navController.navigate(command.destination) {
+internal fun NavController.navigateToItem(command: NavigationCommand) {
+    currentBackStackEntry?.savedStateHandle?.remove<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
+    navigate(command.destination) {
         when (command.backStackMode) {
             BackStackMode.CLEAR_WHOLE, BackStackMode.CLEAR_TILL_START -> {
-                navController.run {
-                    backQueue.firstOrNull { it.destination.route != null }?.let { entry ->
-                        val inclusive = command.backStackMode == BackStackMode.CLEAR_WHOLE
-                        val startId = entry.destination.id
-                        popBackStack(startId, inclusive)
-                    }
+                backQueue.firstOrNull { it.destination.route != null }?.let { entry ->
+                    val inclusive = command.backStackMode == BackStackMode.CLEAR_WHOLE
+                    val startId = entry.destination.id
+                    popBackStack(startId, inclusive)
                 }
             }
             BackStackMode.NONE -> {}

--- a/app/src/main/kotlin/com/wire/android/navigation/SavedStateViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/SavedStateViewModel.kt
@@ -15,3 +15,8 @@ inline fun <reified T : SavedStateViewModel> hiltSavedStateViewModel(navBackStac
             savedStateHandle[EXTRA_BACK_NAVIGATION_ARGUMENTS] = it.savedStateHandle.get<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
         }
     }
+
+fun <V: Any> SavedStateHandle.getBackNavArgs() = get<Map<String, V>>(EXTRA_BACK_NAVIGATION_ARGUMENTS) ?: mapOf()
+
+@Suppress("UNCHECKED_CAST")
+fun <V: Any> SavedStateHandle.getBackNavArg(key: String): V? = getBackNavArgs<Any>()[key] as? V

--- a/app/src/main/kotlin/com/wire/android/navigation/SavedStateViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/SavedStateViewModel.kt
@@ -1,0 +1,17 @@
+package com.wire.android.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavBackStackEntry
+
+open class SavedStateViewModel(open val savedStateHandle: SavedStateHandle) : ViewModel()
+
+@Composable
+inline fun <reified T : SavedStateViewModel> hiltSavedStateViewModel(navBackStackEntry: NavBackStackEntry? = null) =
+    hiltViewModel<T>().apply {
+        navBackStackEntry?.let {
+            savedStateHandle[EXTRA_BACK_NAVIGATION_ARGUMENTS] = it.savedStateHandle.get<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
+        }
+    }

--- a/app/src/main/kotlin/com/wire/android/navigation/SavedStateViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/SavedStateViewModel.kt
@@ -6,17 +6,21 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavBackStackEntry
 
+/*
+ * ViewModel extension which already has SavedStateHandle field.
+ * It is recommended to use it for NavigationItem together with the hiltSavedStateViewModel method which requires a NavBackStackEntry
+ * in order to be able to receive arguments when navigating back using popWithArguments.
+ */
 open class SavedStateViewModel(open val savedStateHandle: SavedStateHandle) : ViewModel()
 
 @Composable
-inline fun <reified T : SavedStateViewModel> hiltSavedStateViewModel(navBackStackEntry: NavBackStackEntry? = null) =
+inline fun <reified T : SavedStateViewModel> hiltSavedStateViewModel(navBackStackEntry: NavBackStackEntry) =
     hiltViewModel<T>().apply {
-        navBackStackEntry?.let {
-            savedStateHandle[EXTRA_BACK_NAVIGATION_ARGUMENTS] = it.savedStateHandle.get<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
-        }
+        savedStateHandle[EXTRA_BACK_NAVIGATION_ARGUMENTS] =
+            navBackStackEntry.savedStateHandle.get<Map<String, Any>>(EXTRA_BACK_NAVIGATION_ARGUMENTS)
     }
 
-fun <V: Any> SavedStateHandle.getBackNavArgs() = get<Map<String, V>>(EXTRA_BACK_NAVIGATION_ARGUMENTS) ?: mapOf()
+fun <V : Any> SavedStateHandle.getBackNavArgs() = get<Map<String, V>>(EXTRA_BACK_NAVIGATION_ARGUMENTS) ?: mapOf()
 
 @Suppress("UNCHECKED_CAST")
-fun <V: Any> SavedStateHandle.getBackNavArg(key: String): V? = getBackNavArgs<Any>()[key] as? V
+fun <V : Any> SavedStateHandle.getBackNavArg(key: String): V? = getBackNavArgs<Any>()[key] as? V

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -84,7 +84,7 @@ class WireActivity : AppCompatActivity() {
                 .onEach { command ->
                     if (command == null) return@onEach
                     keyboardController?.hide()
-                    navigateToItem(navController, command)
+                    navController.navigateToItem(command)
                 }
                 .launchIn(scope)
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -15,6 +15,8 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.navigation.SavedStateViewModel
+import com.wire.android.navigation.getBackNavArg
+import com.wire.android.navigation.getBackNavArgs
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
@@ -54,8 +56,7 @@ class HomeViewModel @Inject constructor(
     }
 
     internal fun showPendingToast() {
-        val backNavArgs = savedStateHandle.get<Map<String, Any?>>(EXTRA_BACK_NAVIGATION_ARGUMENTS) ?: mapOf()
-        val connectionIgnoredUserName = backNavArgs[EXTRA_CONNECTION_IGNORED_USER_NAME] as? String
+        val connectionIgnoredUserName = savedStateHandle.getBackNavArg<String>(EXTRA_CONNECTION_IGNORED_USER_NAME)
         snackBarMessageState = connectionIgnoredUserName?.let { HomeSnackBarState.SuccessConnectionIgnoreRequest(it) }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/HomeViewModel.kt
@@ -9,10 +9,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.navigation.BackStackMode
+import com.wire.android.navigation.EXTRA_BACK_NAVIGATION_ARGUMENTS
 import com.wire.android.navigation.EXTRA_CONNECTION_IGNORED_USER_NAME
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.navigation.SavedStateViewModel
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.call.usecase.GetIncomingCallsUseCase
@@ -28,13 +30,13 @@ import javax.inject.Inject
 @ExperimentalMaterial3Api
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    val savedStateHandle: SavedStateHandle,
+    override val savedStateHandle: SavedStateHandle,
     private val navigationManager: NavigationManager,
     private val listenToEvents: ListenToEventsUseCase,
     private val incomingCalls: GetIncomingCallsUseCase,
     private val getSelf: GetSelfUserUseCase,
     private val needsToRegisterClient: NeedsToRegisterClientUseCase
-) : ViewModel() {
+) : SavedStateViewModel(savedStateHandle) {
 
     var snackBarMessageState by mutableStateOf<HomeSnackBarState?>(null)
 
@@ -52,11 +54,9 @@ class HomeViewModel @Inject constructor(
     }
 
     internal fun showPendingToast() {
-        val connectionIgnoredUserName = savedStateHandle
-            .get<String?>(EXTRA_CONNECTION_IGNORED_USER_NAME)
-        if (connectionIgnoredUserName != null) {
-            snackBarMessageState = HomeSnackBarState.SuccessConnectionIgnoreRequest(connectionIgnoredUserName)
-        }
+        val backNavArgs = savedStateHandle.get<Map<String, Any?>>(EXTRA_BACK_NAVIGATION_ARGUMENTS) ?: mapOf()
+        val connectionIgnoredUserName = backNavArgs[EXTRA_CONNECTION_IGNORED_USER_NAME] as? String
+        snackBarMessageState = connectionIgnoredUserName?.let { HomeSnackBarState.SuccessConnectionIgnoreRequest(it) }
     }
 
     fun checkRequirements() {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -17,6 +17,8 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.navigation.SavedStateViewModel
+import com.wire.android.navigation.getBackNavArg
+import com.wire.android.navigation.getBackNavArgs
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxAssetSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxImageSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorOpeningAssetFile
@@ -138,9 +140,9 @@ class ConversationViewModel @Inject constructor(
     internal fun checkPendingActions() {
         // Check if there are messages to delete
         val messageToDeleteId = savedStateHandle
-            .get<String>(EXTRA_MESSAGE_TO_DELETE_ID)
+            .getBackNavArg<String>(EXTRA_MESSAGE_TO_DELETE_ID)
         val messageToDeleteIsSelf = savedStateHandle
-            .get<Boolean>(EXTRA_MESSAGE_TO_DELETE_IS_SELF)
+            .getBackNavArg<Boolean>(EXTRA_MESSAGE_TO_DELETE_IS_SELF)
 
         if (messageToDeleteId != null && messageToDeleteIsSelf != null) {
             showDeleteMessageDialog(messageToDeleteId, messageToDeleteIsSelf)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -16,6 +16,7 @@ import com.wire.android.navigation.EXTRA_MESSAGE_TO_DELETE_IS_SELF
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.navigation.SavedStateViewModel
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxAssetSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorMaxImageSize
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.ErrorOpeningAssetFile
@@ -59,7 +60,7 @@ import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
 class ConversationViewModel @Inject constructor(
-    val savedStateHandle: SavedStateHandle,
+    override val savedStateHandle: SavedStateHandle,
     private val navigationManager: NavigationManager,
     private val observeConversationDetails: ObserveConversationDetailsUseCase,
     private val sendImageMessage: SendImageMessageUseCase,
@@ -73,7 +74,7 @@ class ConversationViewModel @Inject constructor(
     private val getSelfUserTeam: GetSelfTeamUseCase,
     private val getMessageForConversation: GetMessagesForConversationUseCase,
     private val fileManager: FileManager
-) : ViewModel() {
+) : SavedStateViewModel(savedStateHandle) {
 
     var conversationViewState by mutableStateOf(ConversationViewState())
         private set


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

There is an issue with navigating back with arguments, passing such arguments to the ViewModel and clearing them when not needed anymore.

### Solutions

Created SavedStateViewModel - ViewModel which already has SavedStateHandle parameter by default. Implemented hiltSavedStateViewModel method which takes NavBackStackEntry as an argument to pass the arguments to the ViewModel's SavedStateHandle. Every navigation (back and forward) updates the back navigation arguments of the current or previous entry. Added external functions for easier getting navigation arguments from SavedStateHandle.

### Testing

#### How to Test

Currently it's used in two situations:
- removing image from media gallery screen, it should remove message after going back to conversation screen
- ignoring connection, it should show snackbar after going back to home screen

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
