### PR TITLE
fix: remember the Clickable so that we do not Recompose the image content (AR-1865)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -78,21 +79,36 @@ fun MessageItem(
             Column {
                 Spacer(modifier = Modifier.height(dimensions().userAvatarClickablePadding))
                 MessageHeader(messageHeader)
+
                 if (!isDeleted) {
-                    MessageContent(messageContent,
-                        onAssetClick = Clickable(enabled = !isDeleted) { onAssetMessageClicked(message.messageHeader.messageId) },
-                        onImageClick = Clickable(enabled = !isDeleted) {
+                    val currentOnAssetClicked =
+                    remember {
+                        Clickable(enabled = true) {
+                            onAssetMessageClicked(message.messageHeader.messageId)
+                        }
+                    }
+
+                    val currentOnImageClick =
+                    remember {
+                        Clickable(enabled = true) {
                             onImageMessageClicked(
                                 message.messageHeader.messageId,
                                 message.messageSource == MessageSource.Self
                             )
                         }
+                    }
+
+                    MessageContent(
+                        messageContent = messageContent,
+                        onAssetClick = currentOnAssetClicked,
+                        onImageClick = currentOnImageClick
                     )
                 }
             }
         }
     }
 }
+
 
 @Composable
 private fun MessageHeader(messageHeader: MessageHeader) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -84,7 +85,8 @@ fun MessageImage(
             .clickable(onImageClick)
     ) {
         val imageData: Bitmap? =
-            if (rawImgData != null && rawImgData.size < ConversationViewModel.IMAGE_SIZE_LIMIT_BYTES) rawImgData.toBitmap() else null
+            remember { if (rawImgData != null && rawImgData.size < ConversationViewModel.IMAGE_SIZE_LIMIT_BYTES) rawImgData.toBitmap() else null }
+
         Image(
             painter = rememberAsyncImagePainter(imageData ?: getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
             alignment = Alignment.CenterStart,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -85,7 +85,7 @@ fun MessageImage(
             .clickable(onImageClick)
     ) {
         val imageData: Bitmap? =
-            remember { if (rawImgData != null && rawImgData.size < ConversationViewModel.IMAGE_SIZE_LIMIT_BYTES) rawImgData.toBitmap() else null }
+            if (rawImgData != null && rawImgData.size < ConversationViewModel.IMAGE_SIZE_LIMIT_BYTES) rawImgData.toBitmap() else null
 
         Image(
             painter = rememberAsyncImagePainter(imageData ?: getUriFromDrawable(LocalContext.current, R.drawable.ic_gallery)),
@@ -244,7 +244,7 @@ private fun AnnotatedString.Builder.appendBody(messageBody: MessageBody) {
     append(messageBody.message.asString())
 }
 
-class ImageMessageParams(private val realImgWidth: Int, private val realImgHeight: Int) {
+data class ImageMessageParams(private val realImgWidth: Int, private val realImgHeight: Int) {
     // Image size normalizations to keep the ratio of the inline message image
     val normalizedWidth: Dp
         @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/UIMessage.kt
@@ -29,7 +29,6 @@ data class MessageHeader(
     val messageId: String
 )
 
-
 sealed class MessageStatus(val text: UIText) {
     object Untouched : MessageStatus(UIText.DynamicString(""))
     object Deleted : MessageStatus(UIText.StringResource(R.string.deleted_message_text))


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1865" title="AR-1865" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1865</a>  Images are flickering while typing message on a conversation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The images inside the MessageComposer were recomposed.

### Causes (Optional)

-Once again our well beloved Lambda creation.

### Solutions

- remember the Clickable object so that it does not get recreated.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
