### PR TITLE
feat: group members roles [AR-1041]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -519,7 +519,7 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun getUserInfoUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): GetUserInfoUseCase =
+    fun provideGetUserInfoUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): GetUserInfoUseCase =
         coreLogic.getSessionScope(currentAccount).users.getUserInfo
 
     @ViewModelScoped

--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -36,6 +36,7 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.RegisterTokenUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
 import com.wire.kalium.logic.feature.user.UploadUserAvatarUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
@@ -518,7 +519,7 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
-    fun getUserInfoUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+    fun getUserInfoUseCaseProvider(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId): GetUserInfoUseCase =
         coreLogic.getSessionScope(currentAccount).users.getUserInfo
 
     @ViewModelScoped

--- a/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
@@ -4,7 +4,7 @@ import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.util.ui.WireSessionImageLoader
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.user.OtherUser
 import javax.inject.Inject
 
 class ContactMapper @Inject constructor(
@@ -25,5 +25,4 @@ class ContactMapper @Inject constructor(
             )
         }
     }
-
 }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -16,6 +16,8 @@ import com.wire.kalium.logic.data.message.MessageContent.MemberChange
 import com.wire.kalium.logic.data.message.MessageContent.MemberChange.Added
 import com.wire.kalium.logic.data.message.MessageContent.MemberChange.Removed
 import com.wire.kalium.logic.data.user.AssetId
+import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
@@ -61,7 +63,7 @@ class MessageContentMapper @Inject constructor(
             type = SelfNameType.ResourceTitleCase
         )
 
-        return if (sender is MemberDetails.Self) {
+        return if (sender?.user is SelfUser) {
             UIMessageContent.SystemMessage.MissedCall.youCalled(authorName)
         } else {
             UIMessageContent.SystemMessage.MissedCall.otherCalled(authorName)
@@ -179,10 +181,9 @@ class MessageContentMapper @Inject constructor(
         return UIMessageContent.RestrictedAsset(mimeType)
     }
 
-    fun toSystemMessageMemberName(member: MemberDetails?, type: SelfNameType = SelfNameType.NameOrDeleted): UIText = when (member) {
-        is MemberDetails.Other -> member.name?.let { UIText.DynamicString(it) }
-            ?: UIText.StringResource(messageResourceProvider.memberNameDeleted)
-        is MemberDetails.Self -> when (type) {
+    fun toSystemMessageMemberName(member: MemberDetails?, type: SelfNameType = SelfNameType.NameOrDeleted): UIText = when (member?.user) {
+        is OtherUser -> member.name?.let { UIText.DynamicString(it) } ?: UIText.StringResource(messageResourceProvider.memberNameDeleted)
+        is SelfUser -> when (type) {
             SelfNameType.ResourceLowercase -> UIText.StringResource(messageResourceProvider.memberNameYouLowercase)
             SelfNameType.ResourceTitleCase -> UIText.StringResource(messageResourceProvider.memberNameYouTitlecase)
             SelfNameType.NameOrDeleted -> member.name?.let { UIText.DynamicString(it) }

--- a/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageMapper.kt
@@ -9,6 +9,7 @@ import com.wire.android.ui.home.conversations.model.MessageStatus
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.name
 import com.wire.android.ui.home.conversations.previewAsset
+import com.wire.android.ui.home.conversations.userId
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.time.ISOFormatter
@@ -18,6 +19,9 @@ import com.wire.android.util.uiMessageDateTime
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -29,7 +33,7 @@ class MessageMapper @Inject constructor(
     private val wireSessionImageLoader: WireSessionImageLoader
 ) {
 
-    fun memberIdList(messages: List<Message>) = messages.flatMap { message ->
+    fun memberIdList(messages: List<Message>): List<UserId> = messages.flatMap { message ->
         listOf(message.senderUserId).plus(
             when (val content = message.content) {
                 is MessageContent.MemberChange -> content.members
@@ -53,13 +57,13 @@ class MessageMapper @Inject constructor(
             else
                 UIMessage(
                     messageContent = content,
-                    messageSource = if (sender is MemberDetails.Self) MessageSource.Self else MessageSource.OtherUser,
+                    messageSource = if (sender?.user is SelfUser) MessageSource.Self else MessageSource.OtherUser,
                     messageHeader = MessageHeader(
                         // TODO: Designs for deleted users?
                         username = sender?.name?.let { UIText.DynamicString(it) }
                             ?: UIText.StringResource(R.string.member_name_deleted_label),
-                        membership = if (sender is MemberDetails.Other) {
-                            userTypeMapper.toMembership(sender.otherUser.userType)
+                        membership = if (sender?.user is OtherUser) {
+                            userTypeMapper.toMembership((sender.user as OtherUser).userType)
                         } else {
                             Membership.None
                         },

--- a/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UIParticipantMapper.kt
@@ -8,6 +8,7 @@ import com.wire.android.ui.home.conversations.userId
 import com.wire.android.ui.home.conversations.userType
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.user.SelfUser
 import javax.inject.Inject
 
 class UIParticipantMapper @Inject constructor(
@@ -19,7 +20,7 @@ class UIParticipantMapper @Inject constructor(
         name = memberDetails.name.orEmpty(),
         handle = memberDetails.handle.orEmpty(),
         avatarData = memberDetails.avatar(wireSessionImageLoader),
-        isSelf = memberDetails is MemberDetails.Self,
+        isSelf = memberDetails.user is SelfUser,
         membership = userTypeMapper.toMembership(memberDetails.userType)
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationMemberExt.kt
@@ -4,52 +4,39 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.MemberDetails
-import com.wire.kalium.logic.data.user.UserAssetId
+import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 
-fun List<MemberDetails>.findUser(userId: UserId): MemberDetails? = firstOrNull { member ->
-    when (member) {
-        is MemberDetails.Other -> member.otherUser.id == userId
-        is MemberDetails.Self -> member.selfUser.id == userId
-    }
-}
+fun List<MemberDetails>.findUser(userId: UserId): MemberDetails? = firstOrNull { it.user.id == userId }
 
 val MemberDetails.name
-    get() = when (this) {
-        is MemberDetails.Other -> this.otherUser.name
-        is MemberDetails.Self -> this.selfUser.name
-    }
+    get() = this.user.name
 
 val MemberDetails.handle
-    get() = when (this) {
-        is MemberDetails.Other -> this.otherUser.handle
-        is MemberDetails.Self -> this.selfUser.handle
-    }
+    get() = this.user.handle
 
 val MemberDetails.userId
-    get() = when (this) {
-        is MemberDetails.Other -> this.otherUser.id
-        is MemberDetails.Self -> this.selfUser.id
-    }
+    get() = this.user.id
 
 val MemberDetails.availabilityStatus: UserAvailabilityStatus
-    get() = when (this) {
-        is MemberDetails.Other -> this.otherUser.availabilityStatus
-        is MemberDetails.Self -> this.selfUser.availabilityStatus
+    get() = when (this.user) {
+        is OtherUser -> (user as OtherUser).availabilityStatus
+        is SelfUser -> (user as SelfUser).availabilityStatus
     }
 
-fun MemberDetails.previewAsset(wireSessionImageLoader: WireSessionImageLoader): UserAvatarAsset? = when (this) {
-    is MemberDetails.Other -> this.otherUser.previewPicture
-    is MemberDetails.Self -> this.selfUser.previewPicture
+fun MemberDetails.previewAsset(wireSessionImageLoader: WireSessionImageLoader): UserAvatarAsset? = when (this.user) {
+    is OtherUser -> user.previewPicture
+    is SelfUser -> user.previewPicture
 }?.let { UserAvatarAsset(wireSessionImageLoader, it) }
 
 fun MemberDetails.avatar(wireSessionImageLoader: WireSessionImageLoader): UserAvatarData =
     UserAvatarData(asset = this.previewAsset(wireSessionImageLoader), availabilityStatus = this.availabilityStatus)
 
 val MemberDetails.userType: UserType
-    get() = when (this) {
-        is MemberDetails.Other -> this.otherUser.userType
-        is MemberDetails.Self -> UserType.INTERNAL
+    get() = when (this.user) {
+        is OtherUser -> (user as OtherUser).userType
+        is SelfUser -> UserType.INTERNAL
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCase.kt
@@ -4,6 +4,7 @@ import com.wire.android.mapper.UIParticipantMapper
 import com.wire.android.ui.home.conversations.details.participants.model.ConversationParticipantsData
 import com.wire.android.ui.home.conversations.name
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
 import kotlinx.coroutines.flow.Flow
@@ -18,10 +19,10 @@ class ObserveParticipantsForConversationUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(conversationId: ConversationId, limit: Int = -1): Flow<ConversationParticipantsData> =
         observeConversationMembers(conversationId)
-            .map { it.sortedBy { it.name } }
-            .map {
-                val allAdmins = it.filter { false } // TODO count { it is Admin }
-                val allParticipants = it.filter { true } // TODO count { it !is Admin }
+            .map { memberDetailList -> memberDetailList.sortedBy { it.name } }
+            .map { sortedMemberList ->
+                val allAdmins = sortedMemberList.filter { it.role == Member.Role.Admin }
+                val allParticipants = sortedMemberList.filter { it.role != Member.Role.Admin }
 
                 ConversationParticipantsData(
                     admins = allAdmins.limit(limit).map { uiParticipantMapper.toUIParticipant(it) },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
@@ -4,7 +4,7 @@ import com.wire.android.mapper.MessageMapper
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.feature.conversation.ObserveMemberDetailsByIdsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
 import com.wire.kalium.logic.feature.message.GetRecentMessagesUseCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -16,7 +16,7 @@ import javax.inject.Inject
 class GetMessagesForConversationUseCase
 @Inject constructor(
     private val getMessages: GetRecentMessagesUseCase,
-    private val observeMemberDetailsByIds: ObserveMemberDetailsByIdsUseCase,
+    private val observeConversationMembers: ObserveConversationMembersUseCase,
     private val messageMapper: MessageMapper,
     private val dispatchers: DispatcherProvider,
 ) {
@@ -25,8 +25,8 @@ class GetMessagesForConversationUseCase
     suspend operator fun invoke(conversationId: ConversationId): Flow<List<UIMessage>> =
         getMessages(conversationId)
             .flatMapLatest { messages ->
-                observeMemberDetailsByIds(messageMapper.memberIdList(messages))
+                // TODO: this logic is faulty since if search for the message sender only in the members list which is not correct
+                observeConversationMembers(conversationId)
                     .map { members -> messageMapper.toUIMessages(members, messages) }
             }.flowOn(dispatchers.io())
-
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/usecase/GetMessagesForConversationUseCase.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
+// TODO: move to kalium (is there a reason for this usecase to be in AR)
 class GetMessagesForConversationUseCase
 @Inject constructor(
     private val getMessages: GetRecentMessagesUseCase,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -18,8 +18,8 @@ import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.util.EMPTY
 import com.wire.android.util.ui.WireSessionImageLoader
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.team.Team
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCaseResult

--- a/app/src/test/kotlin/com/wire/android/framework/TestUser.kt
+++ b/app/src/test/kotlin/com/wire/android/framework/TestUser.kt
@@ -1,8 +1,10 @@
 package com.wire.android.framework
 
+import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MemberDetails
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -18,7 +20,7 @@ object TestUser {
         email = "email",
         phone = "phone",
         accentId = 0,
-        teamId = "teamId",
+        teamId = TeamId("teamId"),
         connectionStatus = ConnectionState.ACCEPTED,
         previewPicture = UserAssetId("value", "domain"),
         completePicture = UserAssetId("value", "domain"),
@@ -31,13 +33,13 @@ object TestUser {
         email = "otherEmail",
         phone = "otherPhone",
         accentId = 0,
-        team = "otherTeamId",
+        teamId = TeamId("otherTeamId"),
         connectionStatus = ConnectionState.ACCEPTED,
         previewPicture = UserAssetId("value", "domain"),
         completePicture = UserAssetId("value", "domain"),
         availabilityStatus = UserAvailabilityStatus.AVAILABLE,
         userType = UserType.INTERNAL
     )
-    val MEMBER_SELF = MemberDetails.Self(SELF_USER)
-    val MEMBER_OTHER = MemberDetails.Other(OTHER_USER)
+    val MEMBER_SELF = MemberDetails(SELF_USER, Member.Role.Admin)
+    val MEMBER_OTHER = MemberDetails(OTHER_USER, Member.Role.Member)
 }

--- a/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/MessageContentMapperTest.kt
@@ -7,6 +7,7 @@ import com.wire.android.framework.TestUser
 import com.wire.android.ui.home.conversations.model.MessageContent.AssetMessage
 import com.wire.android.ui.home.conversations.model.MessageContent.ImageMessage
 import com.wire.android.ui.home.conversations.model.MessageContent.SystemMessage
+import com.wire.android.ui.home.conversations.name
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MemberDetails
@@ -15,6 +16,7 @@ import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.AssetContent.AssetMetadata
 import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
@@ -46,11 +48,11 @@ class MessageContentMapperTest {
         val deleted = mapper.toSystemMessageMemberName(deletedMemberDetails, MessageContentMapper.SelfNameType.NameOrDeleted)
         val otherName = mapper.toSystemMessageMemberName(otherMemberDetails, MessageContentMapper.SelfNameType.NameOrDeleted)
         // Then
-        assert(selfName is UIText.DynamicString && selfName.value == selfMemberDetails.selfUser.name)
+        assert(selfName is UIText.DynamicString && selfName.value == selfMemberDetails.name)
         assert(selfResLower is UIText.StringResource && selfResLower.resId == arrangement.messageResourceProvider.memberNameYouLowercase)
         assert(selfResTitle is UIText.StringResource && selfResTitle.resId == arrangement.messageResourceProvider.memberNameYouTitlecase)
         assert(deleted is UIText.StringResource && deleted.resId == arrangement.messageResourceProvider.memberNameDeleted)
-        assert(otherName is UIText.DynamicString && otherName.value == otherMemberDetails.otherUser.name)
+        assert(otherName is UIText.DynamicString && otherName.value == otherMemberDetails.name)
     }
 
     @Test
@@ -91,8 +93,9 @@ class MessageContentMapperTest {
         val member2 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId2))
         val member3 = TestUser.MEMBER_OTHER.copy(TestUser.OTHER_USER.copy(id = userId3))
         val missedCallMessage = TestMessage.MISSED_CALL_MESSAGE
-        val selfCaller = MemberDetails.Self(TestUser.SELF_USER.copy(id = missedCallMessage.senderUserId))
-        val otherCaller = member1.copy(otherUser = member1.otherUser.copy(id = missedCallMessage.senderUserId))
+        val selfCaller = MemberDetails(TestUser.SELF_USER.copy(id = missedCallMessage.senderUserId), Member.Role.Admin)
+        val otherCallerInfo = (member1.user as OtherUser).copy(id = missedCallMessage.senderUserId)
+        val otherCaller = member1.copy(user = otherCallerInfo)
         // When
         val resultContentLeft = mapper.mapMemberChangeMessage(contentLeft, userId1, listOf(member1))
         val resultContentRemoved = mapper.mapMemberChangeMessage(contentRemoved, userId1, listOf(member1, member2))
@@ -103,21 +106,21 @@ class MessageContentMapperTest {
         // Then
         assert(
             resultContentLeft is SystemMessage.MemberLeft &&
-                    resultContentLeft.author.asString(arrangement.resources) == member1.otherUser.name
+                    resultContentLeft.author.asString(arrangement.resources) == member1.name
         )
         assert(
             resultContentRemoved is SystemMessage.MemberRemoved &&
-                    resultContentRemoved.author.asString(arrangement.resources) == member1.otherUser.name &&
+                    resultContentRemoved.author.asString(arrangement.resources) == member1.name &&
                     resultContentRemoved.memberNames.size == 1 &&
-                    resultContentRemoved.memberNames[0].asString(arrangement.resources) == member2.otherUser.name
+                    resultContentRemoved.memberNames[0].asString(arrangement.resources) == member2.name
 
         )
         assert(
             resultContentAdded is SystemMessage.MemberAdded &&
-                    resultContentAdded.author.asString(arrangement.resources) == member1.otherUser.name &&
+                    resultContentAdded.author.asString(arrangement.resources) == member1.name &&
                     resultContentAdded.memberNames.size == 2 &&
-                    resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.otherUser.name &&
-                    resultContentAdded.memberNames[1].asString(arrangement.resources) == member3.otherUser.name
+                    resultContentAdded.memberNames[0].asString(arrangement.resources) == member2.name &&
+                    resultContentAdded.memberNames[1].asString(arrangement.resources) == member3.name
         )
         assert(resultContentAddedSelf == null)
         assert(

--- a/app/src/test/kotlin/com/wire/android/mapper/UIParticipantMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/UIParticipantMapperTest.kt
@@ -7,9 +7,11 @@ import com.wire.android.ui.home.conversations.name
 import com.wire.android.ui.home.conversations.userId
 import com.wire.android.ui.home.conversations.userType
 import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MemberDetails
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
@@ -25,12 +27,12 @@ class UIParticipantMapperTest {
     fun givenMemberDetails_whenMappingToContacts_thenCorrectValuesShouldBeReturned() = runTest {
         val (arrangement, mapper) = Arrangement().arrange()
         // Given
-        val data = listOf(
-            MemberDetails.Self(testSelfUser(0)),
-            MemberDetails.Other(testOtherUser(1).copy(userType = UserType.INTERNAL)),
-            MemberDetails.Other(testOtherUser(2).copy(userType = UserType.EXTERNAL)),
-            MemberDetails.Other(testOtherUser(3).copy(userType = UserType.FEDERATED)),
-            MemberDetails.Other(testOtherUser(4).copy(userType = UserType.GUEST))
+        val data: List<MemberDetails> = listOf(
+            MemberDetails(testSelfUser(0), Member.Role.Admin),
+            MemberDetails(testOtherUser(1).copy(userType = UserType.INTERNAL), Member.Role.Admin),
+            MemberDetails(testOtherUser(2).copy(userType = UserType.EXTERNAL), Member.Role.Member),
+            MemberDetails(testOtherUser(3).copy(userType = UserType.FEDERATED), Member.Role.Member),
+            MemberDetails(testOtherUser(4).copy(userType = UserType.GUEST), Member.Role.Member)
         )
         // When
         val results = data.map { mapper.toUIParticipant(it) }
@@ -51,7 +53,7 @@ class UIParticipantMapperTest {
                 && memberDetails.handle == uiParticipant.handle
                 && memberDetails.avatar(wireSessionImageLoader) == uiParticipant.avatarData
                 && userTypeMapper.toMembership(memberDetails.userType) == uiParticipant.membership
-                && memberDetails is MemberDetails.Self == uiParticipant.isSelf
+                && memberDetails.user is SelfUser == uiParticipant.isSelf
 
     private class Arrangement {
 
@@ -79,7 +81,7 @@ fun testSelfUser(i: Int): SelfUser = SelfUser(
     email = "email$i",
     phone = "phone$i",
     accentId = i,
-    teamId = "team$i",
+    teamId = TeamId("team$i"),
     connectionStatus = ConnectionState.NOT_CONNECTED,
     previewPicture = null,
     completePicture = null,
@@ -93,7 +95,7 @@ fun testOtherUser(i: Int): OtherUser = OtherUser(
     email = "email$i",
     phone = "phone$i",
     accentId = i,
-    team = "team$i",
+    teamId = TeamId("team$i"),
     connectionStatus = ConnectionState.NOT_CONNECTED,
     previewPicture = null,
     completePicture = null,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -18,9 +18,9 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveParticipantsForConversationUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.wire.android.mapper.UIParticipantMapper
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.mapper.testOtherUser
 import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MemberDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.type.UserType
@@ -13,12 +14,14 @@ import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseC
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ObserveParticipantsForConversationUseCaseTest {
 
     @Test
@@ -27,7 +30,7 @@ class ObserveParticipantsForConversationUseCaseTest {
         val limit = 4
         val members = buildList {
             for (i in 1..(limit + 1)) {
-                add(MemberDetails.Other(testOtherUser(i).copy(userType = UserType.INTERNAL)))
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
             }
         }
         val (_, useCase) = ObserveParticipantsForConversationUseCaseArrangement()
@@ -44,9 +47,9 @@ class ObserveParticipantsForConversationUseCaseTest {
     @Test
     fun `given a group members, when solving the participants list without limit, then all lists are passed`() = runTest {
         // Given
-        val members = buildList {
+        val members: List<MemberDetails> = buildList {
             for (i in 1..20) {
-                add(MemberDetails.Other(testOtherUser(i).copy(userType = UserType.INTERNAL)))
+                add(MemberDetails(testOtherUser(i).copy(userType = UserType.INTERNAL), Member.Role.Member))
             }
         }
         val (_, useCase) = ObserveParticipantsForConversationUseCaseArrangement()

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -16,8 +16,8 @@ import com.wire.kalium.logic.data.conversation.LegalHoldStatus
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus.AllAllowed
 import com.wire.kalium.logic.data.conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
@@ -219,9 +219,9 @@ class MediaGalleryViewModelTest {
                 QualifiedID("other-user-id", "domain-id"),
                 null, null, null, null,
                 1, null, ConnectionState.ACCEPTED, null, null,
-                UserAvailabilityStatus.AVAILABLE,
-                UserType.INTERNAL
-            ),
+                UserType.INTERNAL,
+                UserAvailabilityStatus.AVAILABLE
+                ),
             ConnectionState.ACCEPTED,
             LegalHoldStatus.DISABLED,
             UserType.INTERNAL

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -13,9 +13,10 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.publicuser.model.UserSearchResult
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.type.UserType
@@ -111,7 +112,7 @@ internal class NewConversationViewModelArrangement {
             email = "publicEmail",
             phone = "publicPhone",
             accentId = 0,
-            team = "publicTeamId",
+            teamId = TeamId("publicTeamId"),
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = UserAssetId("value", "domain"),
             completePicture = UserAssetId("value", "domain"),
@@ -126,7 +127,7 @@ internal class NewConversationViewModelArrangement {
             email = "knownEmail",
             phone = "knownPhone",
             accentId = 0,
-            team = "knownTeamId",
+            teamId = TeamId("knownTeamId"),
             connectionStatus = ConnectionState.ACCEPTED,
             previewPicture = UserAssetId("value", "domain"),
             completePicture = UserAssetId("value", "domain"),

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -14,9 +14,10 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.conversation.ProtocolInfo
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.kalium.logic.data.publicuser.model.OtherUser
+import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
@@ -80,7 +81,7 @@ class OtherUserProfileScreenViewModelTest {
     private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
     @MockK
-    private lateinit var userTypeMapper : UserTypeMapper
+    private lateinit var userTypeMapper: UserTypeMapper
 
     @BeforeEach
     fun setUp() {
@@ -239,12 +240,12 @@ class OtherUserProfileScreenViewModelTest {
             "some_email",
             "some_phone",
             1,
-            "some_team",
+            TeamId("some_team"),
             ConnectionState.NOT_CONNECTED,
             null,
             null,
-            UserAvailabilityStatus.AVAILABLE,
-            UserType.INTERNAL
+            UserType.INTERNAL,
+            UserAvailabilityStatus.AVAILABLE
         )
         val TEAM = Team("some_id", null)
         val CONVERSATION = Conversation(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1041" title="AR-1041" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1041</a>  Group Admins
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

[AR-1041]

### Solutions

expose the member role from the Kalium and show the new info on the conversation member screen

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[AR-1041]: https://wearezeta.atlassian.net/browse/AR-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ