### PR TITLE
fix: long tap on message (AR-1992)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/MessageItem.kt
@@ -108,7 +108,8 @@ fun MessageItem(
                     MessageContent(
                         messageContent = messageContent,
                         onAssetClick = currentOnAssetClicked,
-                        onImageClick = currentOnImageClick
+                        onImageClick = currentOnImageClick,
+                        onLongClick = { onLongClicked(message)}
                     )
                 }
 
@@ -177,6 +178,7 @@ private fun MessageContent(
     messageContent: MessageContent?,
     onAssetClick: Clickable,
     onImageClick: Clickable,
+    onLongClick: (() -> Unit)? = null
 ) {
     when (messageContent) {
         is MessageContent.ImageMessage -> MessageImage(
@@ -185,7 +187,8 @@ private fun MessageContent(
             onImageClick = onImageClick
         )
         is MessageContent.TextMessage -> MessageBody(
-            messageBody = messageContent.messageBody
+            messageBody = messageContent.messageBody,
+            onLongClick = onLongClick
         )
         is MessageContent.AssetMessage -> MessageAsset(
             assetName = messageContent.assetName.split(".").dropLast(1).joinToString("."),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/MessageTypes.kt
@@ -61,11 +61,12 @@ import kotlin.math.roundToInt
 // TODO: Here we actually need to implement some logic that will distinguish MentionLabel with Body of the message,
 // waiting for the backend to implement mapping logic for the MessageBody
 @Composable
-internal fun MessageBody(messageBody: MessageBody) {
+internal fun MessageBody(messageBody: MessageBody, onLongClick: (() -> Unit)? = null) {
     LinkifyText(
         text = messageBody.message.asString(),
         mask = Linkify.WEB_URLS or Linkify.EMAIL_ADDRESSES,
-        color = MaterialTheme.colorScheme.onBackground
+        color = MaterialTheme.colorScheme.onBackground,
+        onLongClick = onLongClick
     )
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1992" title="AR-1992" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1992</a>  Long Tap on text messages doesn't bring up message option menu (i.e. delete, copy...)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- text in message didn't respond for long clicks 

### Causes (Optional)

### Solutions

- pass long click event from text 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
