### PR TITLE
feat: add group info tab on other profile screen [AR-1567]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -168,15 +168,16 @@ enum class NavigationItem(
 
     OtherUserProfile(
         primaryRoute = OTHER_USER_PROFILE,
-        canonicalRoute = "$OTHER_USER_PROFILE/{$EXTRA_USER_DOMAIN}/{$EXTRA_USER_ID}",
+        canonicalRoute = "$OTHER_USER_PROFILE/{$EXTRA_USER_DOMAIN}/{$EXTRA_USER_ID}?$EXTRA_CONVERSATION_ID={$EXTRA_CONVERSATION_ID}",
         content = { OtherUserProfileScreen() },
         animationConfig = NavigationAnimationConfig.NoAnimation
     ) {
         override fun getRouteWithArgs(arguments: List<Any>): String {
             val userDomain: String = arguments.filterIsInstance<String>()[0]
             val userProfileId: String = arguments.filterIsInstance<String>()[1]
-
-            return "$primaryRoute/$userDomain/$userProfileId"
+            val conversationId: ConversationId? = arguments.filterIsInstance<ConversationId>().firstOrNull()
+            val baseRoute = "$primaryRoute/$userDomain/$userProfileId"
+            return conversationId?.let { "$baseRoute?$EXTRA_CONVERSATION_ID=$it" } ?: baseRoute
         }
     },
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/CollapsingTopBarScaffold.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/CollapsingTopBarScaffold.kt
@@ -1,0 +1,120 @@
+package com.wire.android.ui.common
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.rememberSwipeableState
+import androidx.compose.material.swipeable
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.Velocity
+import com.wire.android.ui.theme.wireDimensions
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+@Composable
+fun CollapsingTopBarScaffold(
+    maxBarElevation: Dp = MaterialTheme.wireDimensions.topBarShadowElevation,
+    topBarHeader: @Composable (elevation: Dp) -> Unit,
+    topBarCollapsing: @Composable () -> Unit,
+    topBarFooter: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    content: @Composable () -> Unit,
+    contentFooter: @Composable () -> Unit = {}
+) {
+    val maxBarElevationPx = with(LocalDensity.current) { maxBarElevation.toPx() }
+    val swipeableState = rememberSwipeableState(initialValue = State.EXPANDED)
+    var collapsingHeight by remember { mutableStateOf(0) }
+    val topBarElevationState by remember {
+        derivedStateOf {
+            val value = -swipeableState.offset.value
+            listOf(value, collapsingHeight - value, maxBarElevationPx).minOrNull() ?: 0f
+        }
+    }
+
+    val nestedScrollConnection = object : NestedScrollConnection {
+
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset =
+            if (available.y < 0) swipeableState.performDrag(available.y).toOffset()
+            else Offset.Zero
+
+        override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset =
+            swipeableState.performDrag(available.y).toOffset()
+
+        override suspend fun onPreFling(available: Velocity): Velocity =
+            if (available.y < 0 && swipeableState.currentValue != State.COLLAPSED) {
+                swipeableState.performFling(available.y)
+                available
+            } else Velocity.Zero
+
+
+        override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+            swipeableState.performFling(velocity = available.y)
+            return super.onPostFling(consumed, available)
+        }
+
+        private fun Float.toOffset() = Offset(0f, this)
+    }
+
+    Scaffold(
+        topBar = { topBarHeader(with(LocalDensity.current) { topBarElevationState.toDp() }) },
+        snackbarHost = snackbarHost,
+        content = { internalPadding ->
+            Layout(
+                modifier = Modifier
+                    .padding(internalPadding)
+                    .swipeable(
+                        state = swipeableState,
+                        orientation = Orientation.Vertical,
+                        anchors = mapOf(0f to State.EXPANDED).let {
+                            if (collapsingHeight > 0) it.plus(-collapsingHeight.toFloat() to State.COLLAPSED)
+                            else it
+                        }
+                    )
+                    .nestedScroll(nestedScrollConnection),
+                content = {
+                    Box(modifier = Modifier.layoutId("topBarCollapsing")) { topBarCollapsing() }
+                    Box(modifier = Modifier.layoutId("topBarFooter")) { topBarFooter() }
+                    Box(modifier = Modifier.layoutId("content")) { content() }
+                    Box(modifier = Modifier.layoutId("contentFooter")) { contentFooter() }
+                },
+                measurePolicy = { measurables, constraints ->
+                    val measureConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+                    val collapsingPlaceable = measurables.first { it.layoutId == "topBarCollapsing" }.measure(measureConstraints)
+                    val footerPlaceable = measurables.first { it.layoutId == "topBarFooter" }.measure(measureConstraints)
+                    val contentFooterPlaceable = measurables.first { it.layoutId == "contentFooter" }.measure(measureConstraints)
+                    val contentPlaceable = measurables.first { it.layoutId == "content" }.measure(measureConstraints.copy(
+                        maxHeight = constraints.maxHeight - footerPlaceable.height - contentFooterPlaceable.height)
+                    )
+                    collapsingHeight = collapsingPlaceable.height
+                    layout(constraints.maxWidth, constraints.maxHeight) {
+                        val swipeOffset = swipeableState.offset.value.roundToInt()
+                        contentPlaceable.placeRelative(0, collapsingPlaceable.height + footerPlaceable.height + swipeOffset)
+                        footerPlaceable.placeRelative(0, collapsingPlaceable.height + swipeOffset)
+                        collapsingPlaceable.placeRelative(0, swipeOffset)
+                        contentFooterPlaceable.placeRelative(0, constraints.maxHeight - contentFooterPlaceable.height)
+                    }
+                }
+            )
+        }
+    )
+}
+
+private enum class State { EXPANDED, COLLAPSED }

--- a/app/src/main/kotlin/com/wire/android/ui/common/RowItemTemplate.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/RowItemTemplate.kt
@@ -16,7 +16,7 @@ import com.wire.android.ui.theme.DEFAULT_WEIGHT
 @Composable
 fun RowItemTemplate(
     leadingIcon: @Composable () -> Unit = {},
-    title: @Composable () -> Unit,
+    title: @Composable () -> Unit = {},
     subtitle: @Composable () -> Unit = {},
     actions: @Composable () -> Unit = {},
     clickable: Clickable = Clickable(false) {},

--- a/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
@@ -37,6 +37,7 @@ fun UserProfileAvatar(
     size: Dp = MaterialTheme.wireDimensions.userAvatarDefaultSize,
     modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
+
 ) {
     val painter = painter(avatarData.asset)
 

--- a/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/topappbar/WireCenterAlignedTopAppBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import com.wire.android.ui.theme.wireDimensions
@@ -23,9 +24,11 @@ fun WireCenterAlignedTopAppBar(
     elevation: Dp = MaterialTheme.wireDimensions.topBarShadowElevation,
     actions: @Composable RowScope.() -> Unit = {},
     colors: TopAppBarColors = wireTopAppBarColors(),
+    modifier: Modifier = Modifier,
     bottomContent: @Composable ColumnScope.() -> Unit = {}
 ) {
     Surface(
+        modifier = modifier,
         shadowElevation = elevation,
         color = colors.containerColor(scrollFraction = 0f).value
     ) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsViewModel.kt
@@ -48,7 +48,9 @@ open class GroupConversationParticipantsViewModel @Inject constructor(
         navigationManager.navigate(NavigationCommand(NavigationItem.SelfUserProfile.getRouteWithArgs()))
 
     private suspend fun navigateToOtherProfile(id: UserId) =
-        navigationManager.navigate(NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(id.domain, id.value))))
+        navigationManager.navigate(
+            NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(id, conversationId)))
+        )
 
     private fun observeConversationMembers() {
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveConversationRoleForUserUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveConversationRoleForUserUseCase.kt
@@ -25,11 +25,11 @@ class ObserveConversationRoleForUserUseCase  @Inject constructor(
             observeConversationMembers(conversationId)
         ) { selfUser: SelfUser, conversationDetails: ConversationDetails, memberDetailsList: List<MemberDetails> ->
             ConversationRoleData(
-                conversationDetails,
+                conversationDetails.conversation.name.orEmpty(),
                 memberDetailsList.firstOrNull { it.user.id == userId }?.role,
                 memberDetailsList.firstOrNull { it.user.id == selfUser.id }?.role
             )
         }
 }
 
-data class ConversationRoleData(val conversationDetails: ConversationDetails, val userRole: Member.Role?, val selfRole: Member.Role?)
+data class ConversationRoleData(val conversationName: String, val userRole: Member.Role?, val selfRole: Member.Role?)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveConversationRoleForUserUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/participants/usecase/ObserveConversationRoleForUserUseCase.kt
@@ -1,0 +1,35 @@
+package com.wire.android.ui.home.conversations.details.participants.usecase
+
+import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.conversation.Member
+import com.wire.kalium.logic.data.conversation.MemberDetails
+import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.user.SelfUser
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.conversation.ObserveConversationMembersUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import javax.inject.Inject
+
+class ObserveConversationRoleForUserUseCase  @Inject constructor(
+    private val observeConversationMembers: ObserveConversationMembersUseCase,
+    private val observeConversationDetails: ObserveConversationDetailsUseCase,
+    private val getSelfUserUseCase: GetSelfUserUseCase
+) {
+    suspend operator fun invoke(conversationId: ConversationId, userId: UserId): Flow<ConversationRoleData> =
+        combine(
+            getSelfUserUseCase(),
+            observeConversationDetails(conversationId),
+            observeConversationMembers(conversationId)
+        ) { selfUser: SelfUser, conversationDetails: ConversationDetails, memberDetailsList: List<MemberDetails> ->
+            ConversationRoleData(
+                conversationDetails,
+                memberDetailsList.firstOrNull { it.user.id == userId }?.role,
+                memberDetailsList.firstOrNull { it.user.id == selfUser.id }?.role
+            )
+        }
+}
+
+data class ConversationRoleData(val conversationDetails: ConversationDetails, val userRole: Member.Role?, val selfRole: Member.Role?)

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/RowItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/RowItem.kt
@@ -24,10 +24,10 @@ fun RowItem(
     modifier: Modifier = Modifier,
     content: @Composable (RowScope.() -> Unit),
 ) {
-    SurfaceBackgroundWrapper(modifier = modifier.padding(MaterialTheme.wireDimensions.conversationItemPadding)) {
+    SurfaceBackgroundWrapper(modifier = Modifier.padding(vertical = MaterialTheme.wireDimensions.conversationItemPadding)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
+            modifier = modifier
                 .height(MaterialTheme.wireDimensions.conversationItemRowHeight)
                 .fillMaxWidth()
                 .clickable(clickable)

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -74,76 +74,76 @@ fun UserProfileInfo(
                 )
             }
         }
-    }
-    ConstraintLayout(
-        Modifier
-            .fillMaxWidth()
-            .wrapContentHeight()
-    ) {
-        val (userDescription, editButton, teamDescription) = createRefs()
-
-        Column(
-            horizontalAlignment = CenterHorizontally,
-            modifier = Modifier
-                .padding(horizontal = dimensions().spacing64x)
-                .wrapContentSize()
-                .constrainAs(userDescription) {
-                    top.linkTo(parent.top)
-                    bottom.linkTo(parent.bottom)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
+        ConstraintLayout(
+            Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
         ) {
-            Text(
-                text = fullName,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-                style = MaterialTheme.wireTypography.title02,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
-            Text(
-                text = "@$userName",
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.wireTypography.body02,
-                maxLines = 1,
-                color = MaterialTheme.wireColorScheme.labelText,
-            )
-            if (membership != Membership.None) {
-                Spacer(Modifier.height(dimensions().spacing8x))
-                MembershipQualifierLabel(membership)
-            }
-        }
+            val (userDescription, editButton, teamDescription) = createRefs()
 
-        if (editableState is EditableState.IsEditable) {
-            IconButton(
+            Column(
+                horizontalAlignment = CenterHorizontally,
                 modifier = Modifier
-                    .padding(start = dimensions().spacing16x)
-                    .constrainAs(editButton) {
-                        top.linkTo(userDescription.top)
-                        bottom.linkTo(userDescription.bottom)
-                        end.linkTo(userDescription.end)
-                    },
-                onClick = editableState.onEditClick,
-                content = Icons.Filled.Edit.Icon()
-            )
-        }
-
-        if (teamName != null) {
-            Text(
-                modifier = Modifier
-                    .padding(top = dimensions().spacing8x)
-                    .padding(horizontal = dimensions().spacing16x)
-                    .constrainAs(teamDescription) {
-                        top.linkTo(userDescription.bottom)
+                    .padding(horizontal = dimensions().spacing64x)
+                    .wrapContentSize()
+                    .constrainAs(userDescription) {
+                        top.linkTo(parent.top)
+                        bottom.linkTo(parent.bottom)
                         start.linkTo(parent.start)
                         end.linkTo(parent.end)
-                    },
-                text = teamName,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                style = MaterialTheme.wireTypography.label01,
-                color = MaterialTheme.colorScheme.onBackground,
-            )
+                    }
+            ) {
+                Text(
+                    text = fullName,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    style = MaterialTheme.wireTypography.title02,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+                Text(
+                    text = "@$userName",
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.wireTypography.body02,
+                    maxLines = 1,
+                    color = MaterialTheme.wireColorScheme.labelText,
+                )
+                if (membership != Membership.None) {
+                    Spacer(Modifier.height(dimensions().spacing8x))
+                    MembershipQualifierLabel(membership)
+                }
+            }
+
+            if (editableState is EditableState.IsEditable) {
+                IconButton(
+                    modifier = Modifier
+                        .padding(start = dimensions().spacing16x)
+                        .constrainAs(editButton) {
+                            top.linkTo(userDescription.top)
+                            bottom.linkTo(userDescription.bottom)
+                            end.linkTo(userDescription.end)
+                        },
+                    onClick = editableState.onEditClick,
+                    content = Icons.Filled.Edit.Icon()
+                )
+            }
+
+            if (teamName != null) {
+                Text(
+                    modifier = Modifier
+                        .padding(top = dimensions().spacing8x)
+                        .padding(horizontal = dimensions().spacing16x)
+                        .constrainAs(teamDescription) {
+                            top.linkTo(userDescription.bottom)
+                            start.linkTo(parent.start)
+                            end.linkTo(parent.end)
+                        },
+                    text = teamName,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.wireTypography.label01,
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionActionButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionActionButton.kt
@@ -1,0 +1,81 @@
+package com.wire.android.ui.userprofile.other
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.ui.common.button.WireButtonState
+import com.wire.android.ui.common.button.WireSecondaryButton
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.common.textfield.WirePrimaryButton
+
+@Composable
+fun OtherUserConnectionActionButton(
+    connectionStatus: ConnectionStatus,
+    onSendConnectionRequest: () -> Unit,
+    onOpenConversation: () -> Unit,
+    onCancelConnectionRequest: () -> Unit,
+    acceptConnectionRequest: () -> Unit,
+    ignoreConnectionRequest: () -> Unit,
+) {
+    when (connectionStatus) {
+        is ConnectionStatus.Sent -> WireSecondaryButton(
+            text = stringResource(R.string.connection_label_cancel_request),
+            onClick = onCancelConnectionRequest
+        )
+        is ConnectionStatus.Connected -> WirePrimaryButton(
+            text = stringResource(R.string.label_open_conversation),
+            onClick = onOpenConversation,
+        )
+        is ConnectionStatus.Pending -> Column {
+            WirePrimaryButton(
+                text = stringResource(R.string.connection_label_accept),
+                onClick = acceptConnectionRequest,
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_check_tick),
+                        contentDescription = stringResource(R.string.content_description_right_arrow),
+                        modifier = Modifier.padding(dimensions().spacing8x)
+                    )
+                }
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            WirePrimaryButton(
+                text = stringResource(R.string.connection_label_ignore),
+                state = WireButtonState.Error,
+                onClick = ignoreConnectionRequest,
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_close),
+                        contentDescription = stringResource(R.string.content_description_right_arrow),
+                    )
+                }
+            )
+        }
+        else -> WirePrimaryButton(
+            text = stringResource(R.string.connection_label_connect),
+            onClick = onSendConnectionRequest,
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_add_contact),
+                    contentDescription = stringResource(R.string.content_description_right_arrow),
+                    modifier = Modifier.padding(dimensions().spacing8x)
+                )
+            }
+        )
+    }
+}
+
+@Composable
+@Preview
+fun OtherUserConnectionActionButtonPreview() {
+    OtherUserConnectionActionButton(ConnectionStatus.Connected, {}, {}, {}, {}, {})
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionStatusInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserConnectionStatusInfo.kt
@@ -1,0 +1,63 @@
+package com.wire.android.ui.userprofile.other
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+
+@Composable
+fun OtherUserConnectionStatusInfo(connectionStatus: ConnectionStatus, membership: Membership) {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(dimensions().spacing32x)
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            if (connectionStatus is ConnectionStatus.Pending)
+                Text(
+                    text = stringResource(R.string.connection_label_user_wants_to_conect),
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.wireColorScheme.onSurface,
+                    style = MaterialTheme.wireTypography.title02
+                )
+            Spacer(modifier = Modifier.height(24.dp))
+            val descriptionResource = when (connectionStatus) {
+                ConnectionStatus.Pending -> R.string.connection_label_accepting_request_description
+                ConnectionStatus.Connected -> throw IllegalStateException("Unhandled Connected ConnectionStatus")
+                else -> if (membership == Membership.None)
+                    R.string.connection_label_member_not_conneted
+                else R.string.connection_label_member_not_belongs_to_team
+            }
+            Text(
+                text = stringResource(descriptionResource),
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.wireColorScheme.labelText,
+                style = MaterialTheme.wireTypography.body01
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+fun OtherUserConnectionStatusInfoPreview() {
+    OtherUserConnectionStatusInfo(ConnectionStatus.NotConnected, Membership.Guest)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileDetails.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileDetails.kt
@@ -1,0 +1,100 @@
+package com.wire.android.ui.userprofile.other
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.model.Clickable
+import com.wire.android.ui.common.CopyButton
+import com.wire.android.ui.common.RowItemTemplate
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+
+@Composable
+fun OtherUserProfileDetails(
+    state: OtherUserProfileState,
+    otherUserProfileScreenState: OtherUserProfileScreenState = rememberOtherUserProfileScreenState(remember { SnackbarHostState() }),
+    lazyListState: LazyListState = rememberLazyListState()
+) {
+    LazyColumn(
+        state = lazyListState,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        if (state.email.isNotEmpty())
+            item(key = "user_details_email") {
+                UserDetailInformation(
+                    title = stringResource(R.string.email_label),
+                    value = state.email,
+                    onCopy = { otherUserProfileScreenState.copy(it) }
+                )
+            }
+        if (state.phone.isNotEmpty())
+            item(key = "user_details_phone") {
+                UserDetailInformation(
+                    title = stringResource(R.string.phone_label),
+                    value = state.phone,
+                    onCopy = { otherUserProfileScreenState.copy(it) }
+                )
+            }
+        repeat(20) {
+            item(key = "user_details_email$it") {
+                UserDetailInformation(
+                    title = stringResource(R.string.email_label),
+                    value = state.email + it,
+                    onCopy = { otherUserProfileScreenState.copy(it) }
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+private fun UserDetailInformation(
+    title: String,
+    value: String,
+    onCopy: (String) -> Unit
+) {
+    RowItemTemplate(
+        modifier = Modifier.padding(horizontal = dimensions().spacing8x),
+        title = {
+            Text(
+                style = MaterialTheme.wireTypography.subline01,
+                color = MaterialTheme.wireColorScheme.labelText,
+                text = title.uppercase()
+            )
+        },
+        subtitle = {
+            Text(
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.onBackground,
+                text = value
+            )
+        },
+        actions = { CopyButton(onCopyClicked = { onCopy("$value copied") }) },
+        clickable = Clickable(enabled = false) {}
+    )
+}
+
+@Composable
+@Preview
+fun OtherUserProfileDetailsPreview() {
+    OtherUserProfileDetails(OtherUserProfileState.PREVIEW)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileGroup.kt
@@ -1,0 +1,95 @@
+package com.wire.android.ui.userprofile.other
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.tooling.preview.Preview
+import com.wire.android.R
+import com.wire.android.model.Clickable
+import com.wire.android.ui.common.RowItemTemplate
+import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
+import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.ui.UIText
+import com.wire.android.util.ui.stringWithStyledArgs
+import com.wire.kalium.logic.data.conversation.Member
+
+@Composable
+fun OtherUserProfileGroup(
+    state: OtherUserProfileGroupState,
+    lazyListState: LazyListState = rememberLazyListState()
+) {
+    val context = LocalContext.current
+    LazyColumn(
+        state = lazyListState,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        item(key = "user_group_name") {
+            UserGroupInformation(
+                value = context.resources.stringWithStyledArgs(
+                    R.string.user_profile_group_member,
+                    MaterialTheme.wireTypography.body01,
+                    MaterialTheme.wireTypography.body02,
+                    MaterialTheme.wireColorScheme.onBackground,
+                    MaterialTheme.wireColorScheme.onBackground,
+                    state.groupName
+                )
+            )
+        }
+        item(key = "user_group_role") {
+            UserGroupInformation(
+                title = stringResource(id = R.string.user_profile_group_role),
+                value = AnnotatedString(state.role.name.asString()),
+            )
+        }
+    }
+}
+
+@Composable
+private fun UserGroupInformation(
+    title: String? = null,
+    value: AnnotatedString,
+    clickable: Clickable = Clickable(enabled = false) {}
+) {
+    RowItemTemplate(
+        modifier = Modifier.padding(horizontal = dimensions().spacing8x),
+        title = title?.let {
+            {
+                Text(
+                    style = MaterialTheme.wireTypography.subline01,
+                    color = MaterialTheme.wireColorScheme.labelText,
+                    text = title.uppercase()
+                )
+            }
+        } ?: {},
+        subtitle = {
+            Text(
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.onBackground,
+                text = value
+            )
+        },
+        clickable = clickable
+    )
+}
+
+val Member.Role.name get() = when(this) {
+    Member.Role.Admin -> UIText.StringResource(R.string.group_role_admin)
+    Member.Role.Member -> UIText.StringResource(R.string.group_role_member)
+    is Member.Role.Unknown -> UIText.DynamicString(name)
+}
+
+@Composable
+@Preview
+fun OtherUserProfileGroupPreview() {
+    OtherUserProfileGroup(OtherUserProfileState.PREVIEW.groupState!!)
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -103,7 +103,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             membership = userTypeMapper.toMembership(otherUser.userType),
             groupState = conversationRoleData?.userRole?.let { userRole ->
                 OtherUserProfileGroupState(
-                    groupName = conversationRoleData.conversationDetails.conversation.name ?: "",
+                    groupName = conversationRoleData.conversationName,
                     role = userRole,
                     isSelfAnAdmin = conversationRoleData.selfRole is Member.Role.Admin
                 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileState.kt
@@ -2,6 +2,7 @@ package com.wire.android.ui.userprofile.other
 
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.user.ConnectionState
 
 data class OtherUserProfileState(
@@ -14,7 +15,24 @@ data class OtherUserProfileState(
     val email: String = "",
     val phone: String = "",
     val connectionStatus: ConnectionStatus = ConnectionStatus.Unknown,
-    val membership : Membership = Membership.None
+    val membership : Membership = Membership.None,
+    val groupState: OtherUserProfileGroupState? = null
+) {
+    companion object {
+        val PREVIEW = OtherUserProfileState(
+            fullName = "name",
+            userName = "username",
+            teamName = "team",
+            email = "email",
+            groupState = OtherUserProfileGroupState("group name", Member.Role.Member, false)
+        )
+    }
+}
+
+data class OtherUserProfileGroupState(
+    val groupName: String,
+    val role: Member.Role,
+    val isSelfAnAdmin: Boolean
 )
 
 sealed class ConnectionStatus {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,13 @@
     <string name="user_profile_status_away">Away</string>
     <string name="user_profile_status_none">None</string>
     <string name="user_profile_new_account_text">New Team or Account</string>
+    <string name="user_profile_details_tab">DETAILS</string>
+    <string name="user_profile_group_tab">GROUP</string>
+    <string name="user_profile_group_member">Member of the group ”%s”</string>
+    <string name="user_profile_group_role">ROLE</string>
+
+    <string name="group_role_admin">Admin</string>
+    <string name="group_role_member">Member</string>
 
     <!-- User Profile status dialog-->
     <string name="user_profile_change_status_dialog_available_title">Set yourself to Available</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/participants/GroupConversationParticipantsViewModelTest.kt
@@ -12,6 +12,7 @@ import com.wire.android.ui.home.conversations.details.GroupConversationDetailsVi
 import com.wire.android.ui.home.conversations.details.participants.model.ConversationParticipantsData
 import com.wire.android.ui.home.conversations.details.participants.model.UIParticipant
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveParticipantsForConversationUseCase
+import com.wire.kalium.logic.data.id.parseIntoQualifiedID
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -62,7 +63,11 @@ class GroupConversationParticipantsViewModelTest {
         // Then
         coVerify {
             arrangement.navigationManager.navigate(
-                NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(member.id.domain, member.id.value)))
+                NavigationCommand(
+                    NavigationItem.OtherUserProfile.getRouteWithArgs(
+                        listOf(member.id.domain, member.id.value, arrangement.conversationId.parseIntoQualifiedID())
+                    )
+                )
             )
         }
     }
@@ -85,21 +90,23 @@ internal class GroupConversationParticipantsViewModelArrangement {
 
     @MockK
     private lateinit var savedStateHandle: SavedStateHandle
+
     @MockK
     lateinit var navigationManager: NavigationManager
+
     @MockK
     lateinit var observeParticipantsForConversationUseCase: ObserveParticipantsForConversationUseCase
     private val conversationMembersChannel = Channel<ConversationParticipantsData>(capacity = Channel.UNLIMITED)
     private val viewModel by lazy {
         GroupConversationParticipantsViewModel(savedStateHandle, navigationManager, observeParticipantsForConversationUseCase)
     }
+    val conversationId = "some-dummy-value@some.dummy.domain"
 
     init {
         // Tests setup
-        val dummyConversationId = "some-dummy-value@some.dummy.domain"
         MockKAnnotations.init(this, relaxUnitFun = true)
         mockUri()
-        every { savedStateHandle.get<String>(EXTRA_CONVERSATION_ID) } returns dummyConversationId
+        every { savedStateHandle.get<String>(EXTRA_CONVERSATION_ID) } returns conversationId
         // Default empty values
         coEvery { observeParticipantsForConversationUseCase(any(), any()) } returns flowOf()
     }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -99,6 +99,8 @@ class OtherUserProfileScreenViewModelTest {
         mockUri()
         every { savedStateHandle.get<String>(eq(EXTRA_USER_ID)) } returns USER_ID.value
         every { savedStateHandle.get<String>(eq(EXTRA_USER_DOMAIN)) } returns USER_ID.domain
+        every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns CONVERSATION_ID.toString()
+        coEvery { observeConversationRoleForUserUseCase.invoke(any(), any()) } returns flowOf(CONVERSATION_ROLE_DATA)
         coEvery { getUserInfo(any()) } returns GetUserInfoResult.Success(OTHER_USER, TEAM)
         every { userTypeMapper.toMembership(any()) } returns Membership.None
 
@@ -240,16 +242,13 @@ class OtherUserProfileScreenViewModelTest {
     }
 
     @Test
-    fun `given a group conversationId, when loading the data, then check conversation role`() =
+    fun `given a group conversationId, when loading the data, then return group state`() =
         runTest {
             // given
-            val conversationRoleData = ConversationRoleData("name", Member.Role.Member, Member.Role.Member)
-            val expected =  OtherUserProfileGroupState("name", Member.Role.Member, false)
-            coEvery { observeConversationRoleForUserUseCase.invoke(any(), any()) } returns flowOf(conversationRoleData)
-            every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns CONVERSATION_ID.toString()
-
-            // when - then
+            val expected =  OtherUserProfileGroupState("some_name", Member.Role.Member, false)
+            // when
             val groupState = otherUserProfileScreenViewModel.state.groupState
+            // then
             coVerify {
                 observeConversationRoleForUserUseCase(CONVERSATION_ID, USER_ID)
                 navigationManager wasNot Called
@@ -289,5 +288,6 @@ class OtherUserProfileScreenViewModelTest {
             access = listOf(Conversation.Access.INVITE),
             accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER)
         )
+        val CONVERSATION_ROLE_DATA = ConversationRoleData("some_name", Member.Role.Member, Member.Role.Member)
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -4,9 +4,11 @@ import androidx.lifecycle.SavedStateHandle
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.mockUri
 import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.navigation.EXTRA_CONVERSATION_ID
 import com.wire.android.navigation.EXTRA_USER_DOMAIN
 import com.wire.android.navigation.EXTRA_USER_ID
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveConversationRoleForUserUseCase
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.CoreFailure.Unknown
@@ -34,6 +36,7 @@ import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversatio
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
 import io.mockk.Called
+import io.mockk.InternalPlatformDsl.toStr
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -81,6 +84,9 @@ class OtherUserProfileScreenViewModelTest {
     private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
     @MockK
+    private lateinit var observeConversationRoleForUserUseCase: ObserveConversationRoleForUserUseCase
+
+    @MockK
     private lateinit var userTypeMapper: UserTypeMapper
 
     @BeforeEach
@@ -89,6 +95,7 @@ class OtherUserProfileScreenViewModelTest {
         mockUri()
         every { savedStateHandle.get<String>(eq(EXTRA_USER_ID)) } returns CONVERSATION_ID.value
         every { savedStateHandle.get<String>(eq(EXTRA_USER_DOMAIN)) } returns CONVERSATION_ID.domain
+        every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns CONVERSATION_ID.toString()
         coEvery { getUserInfo(any()) } returns GetUserInfoResult.Success(OTHER_USER, TEAM)
         every { userTypeMapper.toMembership(any()) } returns Membership.None
 
@@ -102,7 +109,8 @@ class OtherUserProfileScreenViewModelTest {
             acceptConnectionRequest,
             ignoreConnectionRequest,
             userTypeMapper,
-            wireSessionImageLoader
+            wireSessionImageLoader,
+            observeConversationRoleForUserUseCase
         )
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When navigating from group conversation participants list to the specific user profile, there should be an additional tab on user profile with group information - group name and user's role in that group. The header of this screen (the part with avatar, name, team, etc.) should collapse when scrolling, tabs row should be pinned to the top.

### Solutions

Created Scaffold with collapsing part of the top bar with the behavior similar to the `CollapsingToolbarLayout`.
`OtherUserProfile` compose elements broken down into several files for better code readability.
Added and handled new parameter - `conversationId` to the `NavigationItem.OtherUserProfile`.
Implemented logic of getting and showing info about the group name and role of the user in that group.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open group conversation details and click on a participant to open the profile.

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/179568646-15cefca6-4dd4-4924-b318-d9b3fab384a6.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
