### PR TITLE
chore: adjust join button padding

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/JoinButton.kt
@@ -15,6 +15,7 @@ import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.textfield.WirePrimaryButton
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.ui.theme.wireTypography
 
 @Composable
 fun JoinButton(
@@ -28,6 +29,7 @@ fun JoinButton(
         fillMaxWidth = false,
         shape = RoundedCornerShape(size = MaterialTheme.wireDimensions.corner12x),
         text = stringResource(R.string.calling_label_join_call),
+        textStyle = MaterialTheme.wireTypography.button03,
         state = WireButtonState.Positive,
         minHeight = minHeight,
         minWidth = minWidth,
@@ -38,8 +40,8 @@ fun JoinButton(
                 end = dimensions().spacing8x
             ),
         contentPadding = PaddingValues(
-            horizontal = dimensions().spacing12x,
-            vertical = dimensions().spacing8x
+            horizontal = dimensions().spacing8x,
+            vertical = dimensions().spacing4x
         )
     )
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-1053](https://wearezeta.atlassian.net/browse/AR-1053)

### Issues

Design was a bit off for the Join Call Button

### Solutions

Adjust the button padding so it looks more like in design.

| OLD BUTTON  | NEW BUTTON |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/5890660/180241225-cc10cbd9-41ac-45d5-b858-8dd775249fd1.png" width="300" height="140" /> | <img src="https://user-images.githubusercontent.com/5890660/180241410-ba148f2c-4640-45e5-a576-9fcb2a0c9972.png" width="300" height="140" /> |