### PR TITLE
chore: add retry automation login when session is blocked on staging accounts

### DIFF
--- a/app/src/androidTest/java/com/wire/android/di/TestModule.kt
+++ b/app/src/androidTest/java/com/wire/android/di/TestModule.kt
@@ -1,7 +1,9 @@
 package com.wire.android.di
 
 import com.wire.android.utils.EMAIL
+import com.wire.android.utils.EMAIL_2
 import com.wire.android.utils.PASSWORD
+import com.wire.android.utils.PASSWORD_2
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.user.UserId
@@ -46,7 +48,14 @@ class TestModule {
                     coreLogic.sessionRepository.storeSession(authResult.userSession)
                     authResult.userSession.tokens.userId
                 } else {
-                    throw RuntimeException("Failed to setup testing custom injection")
+                    val authResultRetry = coreLogic.getAuthenticationScope(ServerConfig.STAGING)
+                        .login(EMAIL_2, PASSWORD_2, false)
+                    if (authResultRetry is AuthenticationResult.Success) {
+                        coreLogic.sessionRepository.storeSession(authResultRetry.userSession)
+                        authResultRetry.userSession.tokens.userId
+                    } else {
+                        throw RuntimeException("Failed to setup testing custom injection")
+                    }
                 }
             }
         }

--- a/app/src/androidTest/java/com/wire/android/utils/Extensions.kt
+++ b/app/src/androidTest/java/com/wire/android/utils/Extensions.kt
@@ -34,6 +34,9 @@ fun ComposeTestRule.waitForExecution(timeoutMillis: Long = WAIT_TIMEOUT, block: 
 }
 
 const val WAIT_TIMEOUT = 9000L
-const val PASSWORD = "Mustafastaging1!"
 const val EMAIL = "mustafa+1@wire.com"
+const val PASSWORD = "Mustafastaging1!"
 const val USER_NAME = "Mustafastaging1"
+const val EMAIL_2 = "mustafa+7@wire.com"
+const val PASSWORD_2 = "mustafa+7@wire.com"
+const val USER_NAME_2 = "doga7"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Attempt to be able to "retry" for limit logins on staging accounts (workaround)

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
