### PR TITLE
fix: refactored way to resample avatar and images assets

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -124,7 +124,8 @@ class AttachmentInnerState(val context: Context) {
             val assetFileName = context.getFileName(attachmentUri) ?: throw IOException("The selected asset has an invalid name")
             val mimeType = attachmentUri.getMimeType(context).orDefault(DEFAULT_FILE_MIME_TYPE)
             val attachmentType = if (isValidImage(mimeType)) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
-            val assetSize = if (attachmentType == AttachmentType.IMAGE) attachmentUri.resampleImageAndCopyToTempPath(context, fullTempAssetPath)
+            val assetSize = if (attachmentType == AttachmentType.IMAGE)
+                attachmentUri.resampleImageAndCopyToTempPath(context, fullTempAssetPath)
             else attachmentUri.copyToTempPath(context, fullTempAssetPath)
             val attachment = AttachmentBundle(mimeType, fullTempAssetPath, assetSize, assetFileName, attachmentType)
             AttachmentState.Picked(attachment)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposerInnerState.kt
@@ -18,6 +18,7 @@ import com.wire.android.util.copyToTempPath
 import com.wire.android.util.getFileName
 import com.wire.android.util.getMimeType
 import com.wire.android.util.orDefault
+import com.wire.android.util.resampleImageAndCopyToTempPath
 import com.wire.kalium.logic.data.asset.isValidImage
 import okio.Path
 import okio.Path.Companion.toPath
@@ -117,13 +118,14 @@ class MessageComposerInnerState(
 class AttachmentInnerState(val context: Context) {
     var attachmentState by mutableStateOf<AttachmentState>(AttachmentState.NotPicked)
 
-    fun pickAttachment(attachmentUri: Uri, tempCachePath: Path) {
+    suspend fun pickAttachment(attachmentUri: Uri, tempCachePath: Path) {
         attachmentState = try {
             val fullTempAssetPath = "$tempCachePath/${UUID.randomUUID()}".toPath()
-            val mimeType = attachmentUri.getMimeType(context).orDefault(DEFAULT_FILE_MIME_TYPE)
             val assetFileName = context.getFileName(attachmentUri) ?: throw IOException("The selected asset has an invalid name")
-            val assetSize = attachmentUri.copyToTempPath(context, fullTempAssetPath)
+            val mimeType = attachmentUri.getMimeType(context).orDefault(DEFAULT_FILE_MIME_TYPE)
             val attachmentType = if (isValidImage(mimeType)) AttachmentType.IMAGE else AttachmentType.GENERIC_FILE
+            val assetSize = if (attachmentType == AttachmentType.IMAGE) attachmentUri.resampleImageAndCopyToTempPath(context, fullTempAssetPath)
+            else attachmentUri.copyToTempPath(context, fullTempAssetPath)
             val attachment = AttachmentBundle(mimeType, fullTempAssetPath, assetSize, assetFileName, attachmentType)
             AttachmentState.Picked(attachment)
         } catch (e: IOException) {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -42,7 +42,6 @@ import com.wire.android.ui.userprofile.avatarpicker.AvatarPickerViewModel.ErrorC
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun AvatarPickerScreen(viewModel: AvatarPickerViewModel) {
-    val context = LocalContext.current
     val targetAvatarUri = viewModel.getTemporaryAvatarUri()
     val state = rememberAvatarPickerState(
         onImageSelected = { viewModel.updatePickedAvatarUri(it) },
@@ -57,7 +56,7 @@ fun AvatarPickerScreen(viewModel: AvatarPickerViewModel) {
             viewModel.navigateBack()
         },
         onSaveClick = {
-            viewModel.uploadNewPickedAvatarAndBack(context)
+            viewModel.uploadNewPickedAvatarAndBack()
         }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPicker.kt
@@ -45,8 +45,8 @@ fun AvatarPickerScreen(viewModel: AvatarPickerViewModel) {
     val context = LocalContext.current
     val targetAvatarUri = viewModel.getTemporaryAvatarUri()
     val state = rememberAvatarPickerState(
-        onImageSelected = { viewModel.processAvatar(it) },
-        onPictureTaken = { viewModel.processAvatar(targetAvatarUri) },
+        onImageSelected = { viewModel.updatePickedAvatarUri(it) },
+        onPictureTaken = { viewModel.updatePickedAvatarUri(targetAvatarUri) },
         targetPictureFileUri = targetAvatarUri
     )
 
@@ -150,7 +150,6 @@ private fun AvatarPickerContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AvatarPickerActionButtons(
     isUploadingImage: Boolean,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/avatarpicker/AvatarPickerViewModel.kt
@@ -75,7 +75,7 @@ class AvatarPickerViewModel @Inject constructor(
         pictureState = PictureState.Uploading(imgUri)
         viewModelScope.launch {
             val avatarPath = kaliumFileSystem.selfUserAvatarPath()
-            val imageDataSize = imgUri.resampleImageAndCopyToTempPath(appContext, avatarPath, ImageUtil.ImageSizeClass.Small)
+            val imageDataSize = imgUri.resampleImageAndCopyToTempPath(appContext, avatarPath, ImageUtil.ImageSizeClass.Small, dispatchers)
             val result = uploadUserAvatar(avatarPath, imageDataSize)
             if (result is UploadAvatarResult.Success) {
                 dataStore.updateUserAvatarAssetId(result.userAssetId.toString())

--- a/app/src/main/kotlin/com/wire/android/util/AvatarImageManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/AvatarImageManager.kt
@@ -12,38 +12,6 @@ import okio.Path.Companion.toOkioPath
 
 class AvatarImageManager @Inject constructor(val context: Context) {
 
-    /**
-     * Given an image [uri] rotates the image to a [ExifInterface.ORIENTATION_NORMAL] and overwrite the original un-rotated image
-     * Also compress the data to have an efficient data management, without losing quality
-     *
-     * In case of failure, just use the same picture without post processing
-     *
-     * @param uri the image location on which the operation will be performed
-     * @param context
-     */
-    @Suppress("TooGenericExceptionCaught")
-    suspend fun postProcessAvatar(uri: Uri): Uri? {
-        try {
-            val avatarByteArray = uri.toByteArray(context)
-
-            // Compress image
-            val resampledByteArray = avatarByteArray.let { ImageUtil.resample(it, ImageUtil.ImageSizeClass.Small) }
-
-            // Save to fixed path
-            return getWritableTempAvatarUri(resampledByteArray)
-        } catch (exception: Exception) {
-            // NOOP: None post process op performed
-        }
-
-        return null
-    }
-
-    private fun getWritableTempAvatarUri(imageData: ByteArray): Uri {
-        val file = getTempAvatarFile(context)
-        file.writeBytes(imageData)
-        return file.toUri()
-    }
-
     fun getWritableAvatarUri(imageDataPath: Path): Uri {
         val file = imageDataPath.toFile()
         return file.toUri()
@@ -54,27 +22,16 @@ class AvatarImageManager @Inject constructor(val context: Context) {
     }
 
     companion object {
-        private const val TEMP_AVATAR_FILENAME = "temp_avatar_path.jpg"
         private const val AVATAR_FILENAME = "user_avatar_path.jpg"
 
-        fun getTempAvatarFile(context: Context): File {
-            val file = File(context.cacheDir, TEMP_AVATAR_FILENAME)
-            file.setWritable(true, false)
-            return file
-        }
-
-        fun getAvatarFile(context: Context): File {
+        private fun getAvatarFile(context: Context): File {
             val file = File(context.cacheDir, AVATAR_FILENAME)
             file.setWritable(true, false)
             return file
         }
 
-        fun getShareableAvatarUri(context: Context): Uri {
+        private fun getShareableAvatarUri(context: Context): Uri {
             return FileProvider.getUriForFile(context, context.getProviderAuthority(), getAvatarFile(context))
-        }
-
-        fun getSharableTempAvatarUri(context: Context): Uri {
-            return FileProvider.getUriForFile(context, context.getProviderAuthority(), getTempAvatarFile(context))
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues
After assets refactoring, image messages were not being resampled. 

### Solutions
I refactored a bit the flow for resampling avatars (small size) and asset messages (medium size) so that they use the same new util method called `Uri.resampleImageAndCopyToTempPath()`

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test
Update your avatar image with a new large image and check the final one uploaded is way smaller. Same with images in conversations.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
