### PR TITLE
fix: pass conversation to onConversationItemClick callback

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -127,7 +127,8 @@ class ConversationListViewModel @Inject constructor(
             viewModelScope.launch {
                 when (updateConversationMutedStatus(conversationId, mutedConversationStatus, Date().time)) {
                     ConversationUpdateStatusResult.Failure -> errorState = ConversationOperationErrorState.MutingOperationErrorState()
-                    ConversationUpdateStatusResult.Success -> appLogger.d("MutedStatus changed for conversation: $conversationId to $mutedConversationStatus")
+                    ConversationUpdateStatusResult.Success ->
+                        appLogger.d("MutedStatus changed for conversation: $conversationId to $mutedConversationStatus")
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -127,7 +127,7 @@ class ConversationListViewModel @Inject constructor(
             viewModelScope.launch {
                 when (updateConversationMutedStatus(conversationId, mutedConversationStatus, Date().time)) {
                     ConversationUpdateStatusResult.Failure -> errorState = ConversationOperationErrorState.MutingOperationErrorState()
-                    ConversationUpdateStatusResult.Success -> appLogger.d("MutedStatus changed for conversation: $conversationId")
+                    ConversationUpdateStatusResult.Success -> appLogger.d("MutedStatus changed for conversation: $conversationId to $mutedConversationStatus")
                 }
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationRouter.kt
@@ -53,7 +53,7 @@ fun ConversationRouterHomeBridge(
 
     fun openConversationBottomSheet(
         conversationItem: ConversationItem,
-        conversationOptionNavigation: ConversationOptionNavigation
+        conversationOptionNavigation: ConversationOptionNavigation = ConversationOptionNavigation.Home
     ) {
         onHomeBottomSheetContentChanged {
             val conversationState = rememberConversationSheetState(
@@ -99,8 +99,7 @@ fun ConversationRouterHomeBridge(
         openNewConversation = viewModel::openNewConversation,
         onEditConversationItem = { conversationItem ->
             openConversationBottomSheet(
-                conversationItem = conversationItem,
-                conversationOptionNavigation = ConversationOptionNavigation.Home
+                conversationItem = conversationItem
             )
         },
         onScrollPositionProviderChanged = onScrollPositionProviderChanged,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationItemFactory.kt
@@ -30,7 +30,7 @@ fun ConversationItemFactory(
     openNotificationsOptions: (ConversationItem) -> Unit,
     joinCall: (ConversationId) -> Unit,
 ) {
-    val onConversationItemClick = remember {
+    val onConversationItemClick = remember(conversation) {
         Clickable(
             enabled = true,
             onClick = {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?


 onClickListener was not recreated with a state of Conversation changed , so when we muted the conversation it was not reflected in the UI


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
