### PR TITLE
fix: map username/label for federated users (AR-2036)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -1,7 +1,6 @@
 package com.wire.android
 
 import android.app.Application
-import android.util.Log
 import androidx.work.Configuration
 import co.touchlab.kermit.platformLogWriter
 import com.datadog.android.Datadog
@@ -108,7 +107,6 @@ class WireApplication : Application(), Configuration.Provider {
         Datadog.initialize(this, credentials, configuration, TrackingConsent.GRANTED)
         Datadog.setUserInfo(id = getDeviceId(this))
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
-        Datadog.setVerbosity(Log.VERBOSE)
     }
 
     override fun onLowMemory() {

--- a/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/ContactMapper.kt
@@ -3,6 +3,7 @@ package com.wire.android.mapper
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.home.newconversation.model.Contact
+import com.wire.android.ui.userprofile.common.UsernameMapper.mapUserLabel
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.user.OtherUser
 import javax.inject.Inject
@@ -18,8 +19,8 @@ class ContactMapper
             return Contact(
                 id = id.value,
                 domain = id.domain,
-                name = name ?: "",
-                label = handle ?: "",
+                name = name.orEmpty(),
+                label = mapUserLabel(otherUser),
                 avatarData = UserAvatarData(completePicture?.let { ImageAsset.UserAvatarAsset(wireSessionImageLoader, it) }),
                 membership = userTypeMapper.toMembership(userType),
                 connectionState = otherUser.connectionStatus

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UsernameMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UsernameMapper.kt
@@ -1,0 +1,15 @@
+package com.wire.android.ui.userprofile.common
+
+import com.wire.kalium.logic.data.user.OtherUser
+import com.wire.kalium.logic.data.user.type.UserType
+
+object UsernameMapper {
+
+    fun mapUserLabel(otherUser: OtherUser): String = with(otherUser) {
+        val userId = otherUser.id
+        return when (otherUser.userType) {
+            UserType.FEDERATED -> if (handle != null) "$handle@${userId.domain}" else ""
+            else -> handle.orEmpty()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -18,6 +18,7 @@ import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.home.conversations.details.participants.usecase.ConversationRoleData
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveConversationRoleForUserUseCase
+import com.wire.android.ui.userprofile.common.UsernameMapper.mapUserLabel
 import com.wire.android.util.EMPTY
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.Member
@@ -38,10 +39,10 @@ import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversatio
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 
 @Suppress("LongParameterList")
 @HiltViewModel
@@ -74,9 +75,10 @@ class OtherUserProfileScreenViewModel @Inject constructor(
                     appLogger.d("Couldn't not find the user with provided id:$userId.id and domain:$userId.domain")
                     connectionOperationState = ConnectionOperationState.LoadUserInformationError()
                 }
-                is GetUserInfoResult.Success -> conversationId
-                    .let { if (it != null) observeConversationRoleForUser(it, userId) else flowOf(it) }
-                    .collect { loadViewState(result.otherUser, result.team, it) }
+                is GetUserInfoResult.Success ->
+                    conversationId
+                        .let { if (it != null) observeConversationRoleForUser(it, userId) else flowOf(it) }
+                        .collect { loadViewState(result.otherUser, result.team, it) }
             }
         }
     }
@@ -86,7 +88,7 @@ class OtherUserProfileScreenViewModel @Inject constructor(
             isDataLoading = false,
             userAvatarAsset = otherUser.completePicture?.let { pic -> ImageAsset.UserAvatarAsset(wireSessionImageLoader, pic) },
             fullName = otherUser.name ?: String.EMPTY,
-            userName = otherUser.handle ?: String.EMPTY,
+            userName = mapUserLabel(otherUser),
             teamName = team?.name ?: String.EMPTY,
             email = otherUser.email ?: String.EMPTY,
             phone = otherUser.phone ?: String.EMPTY,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2036" title="AR-2036" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2036</a>  No domain is displayed in search result for users from another backend
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR enables showing information about the domain for federated users

### Attachments (Optional)

![Screenshot_1658848129](https://user-images.githubusercontent.com/5806454/181042880-5fb71f4e-8a03-4f65-b829-0ad18689c3dd.png)

![Screenshot_1658848125](https://user-images.githubusercontent.com/5806454/181042899-6e799829-58e5-4eb8-bbc3-ba2d6e9d8258.png)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
