### PR TITLE
feat: upload develop builds to separate S3 path from CI [SQPIT-1128]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -337,6 +337,11 @@ pipeline {
               sh "ls -la app/build/outputs/apk/${flavor.toLowerCase()}/${buildType.toLowerCase()}/"
               echo 'Uploading file to S3 Bucket'
               s3Upload(acl:'Private', workingDir: "app/build/outputs/apk/${flavor.toLowerCase()}/${buildType.toLowerCase()}/", includePathPattern:'com.wire.android-*.apk', bucket: 'z-lohika', path: "megazord/android/reloaded/${flavor.toLowerCase()}/${buildType.toLowerCase()}/")
+              script {
+                if (env.BRANCH_NAME.startsWith("PR-") || env.BRANCH_NAME == "develop") {
+                  s3Upload(acl:'Private', workingDir: "app/build/outputs/apk/${flavor.toLowerCase()}/${buildType.toLowerCase()}/", includePathPattern:'com.wire.android-*.apk', bucket: 'z-lohika', path: "megazord/android/reloaded/by-branch/${env.BRANCH_NAME}/")
+                }
+              }
             }
           }
           stage('Playstore') {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQPIT-1128" title="SQPIT-1128" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />SQPIT-1128</a>  Develop builds should be in a separate folder then PR builds on megazord for Android Reloaded Project
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The Jenkins configuration for `wire-android-reloaded` uploads *all* CI builds to the same path in S3, which makes it difficult to determine which branch a given build corresponds to. This makes it harder for QA to find the latest `develop` build in order to test for regressions.

### Solutions

This change adds a second upload step to the CI configuration so that builds on `develop` and on PR branches are also uploaded to paths which contain the branch name. This should make it much easier to e.g. grab the latest `develop` build in an automatic fashion.

### Testing

Check whether CI behaves correctly when building a client from this PR's branch.
