### PR TITLE
ci: detect kalium rollback

### DIFF
--- a/.github/workflows/check-kalium-commitish.yml
+++ b/.github/workflows/check-kalium-commitish.yml
@@ -1,0 +1,33 @@
+name: "Validate Kalium References"
+
+on:
+  pull_request:
+    types: [ opened, synchronize ] # Don't rerun on `edited` to save time
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive # Needed in order to fetch Kalium sources for building
+          fetch-depth: 0
+
+      - name: Validate Kalium refs
+        id: validate_kalium
+        run: |
+          echo "::set-output name=is_kalium_rollback::$(
+            git diff kalium |
+            awk '/^i/{c=NR}NR>c+2&&/^[-+]/' |
+            awk '{split($0,words," "); print words[3];}' |
+            xargs git -C kalium merge-base --is-ancestor 
+          )"
+      
+      - name: Leave a comment
+        env: 
+          HEAD: ${{github.head_ref}}
+        if: steps.validate_kalium.is_kalium_rollback != 0
+        run: |
+          gh pr comment ${HEAD}" --body "@${{github.event.pull_request.user.login} Looks like you are rolling back kalium to a previous commitish. Is this intentional?"

--- a/.github/workflows/check-kalium-commitish.yml
+++ b/.github/workflows/check-kalium-commitish.yml
@@ -30,4 +30,4 @@ jobs:
           HEAD: ${{github.head_ref}}
         if: steps.validate_kalium.is_kalium_rollback != 0
         run: |
-          gh pr comment "${HEAD}" --body "@${{github.event.pull_request.user.login} looks like you are rolling back kalium to a previous commitish. Is this intentional?"
+          gh pr comment "${HEAD}" --body "@${{github.event.pull_request.user.login}} looks like you are rolling back kalium to a previous commitish. Is this intentional?"

--- a/.github/workflows/check-kalium-commitish.yml
+++ b/.github/workflows/check-kalium-commitish.yml
@@ -5,7 +5,7 @@ on:
     types: [ opened, synchronize ] # Don't rerun on `edited` to save time
 
 jobs:
-  unit-tests:
+  validate-kalium-ref:
     runs-on: ubuntu-20.04
 
     steps:
@@ -15,7 +15,7 @@ jobs:
           submodules: recursive # Needed in order to fetch Kalium sources for building
           fetch-depth: 0
 
-      - name: Validate Kalium refs
+      - name: Run git merge-base
         id: validate_kalium
         run: |
           echo "::set-output name=is_kalium_rollback::$(

--- a/.github/workflows/check-kalium-commitish.yml
+++ b/.github/workflows/check-kalium-commitish.yml
@@ -30,4 +30,4 @@ jobs:
           HEAD: ${{github.head_ref}}
         if: steps.validate_kalium.is_kalium_rollback != 0
         run: |
-          gh pr comment ${HEAD}" --body "@${{github.event.pull_request.user.login} Looks like you are rolling back kalium to a previous commitish. Is this intentional?"
+          gh pr comment "${HEAD}" --body "@${{github.event.pull_request.user.login} looks like you are rolling back kalium to a previous commitish. Is this intentional?"

--- a/.github/workflows/check-kalium-commitish.yml
+++ b/.github/workflows/check-kalium-commitish.yml
@@ -22,7 +22,7 @@ jobs:
             git diff kalium |
             awk '/^i/{c=NR}NR>c+2&&/^[-+]/' |
             awk '{split($0,words," "); print words[3];}' |
-            xargs git -C kalium merge-base --is-ancestor 
+            xargs echo 
           )"
       
       - name: Leave a comment


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes roll backs to `kalium`'s ref go unnoticed. Rolling back is in general undesirable.

### Solutions

Add a GitHub action to detect rollbacks and warn the creator of the PR


### Testing

#### How to Test

Notice there is a comment on this PR (which rollbacks kalium on purpose)

### Notes (Optional)

The rollback won't be committed in the final merge

----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
