### PR TITLE
fix: handle user SAML settings when registering account

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -40,6 +40,7 @@ import com.wire.kalium.logic.feature.session.RegisterTokenUseCase
 import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoUseCase
+import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import com.wire.kalium.logic.featureFlags.KaliumConfigs
 import dagger.Module
 import dagger.Provides
@@ -569,4 +570,12 @@ class UseCaseModule {
         @CurrentAccount currentAccount: UserId
     ): UpdateConversationAccessRoleUseCase =
         coreLogic.getSessionScope(currentAccount).conversations.updateConversationAccess
+
+
+    @ViewModelScoped
+    @Provides
+    fun provideIsPasswordRequiredUseCase(
+        @KaliumCoreLogic coreLogic: CoreLogic,
+        @CurrentAccount currentAccount: UserId
+    ): IsPasswordRequiredUseCase = coreLogic.getSessionScope(currentAccount).users.isPasswordRequired
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/CreateAccountBaseViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/common/CreateAccountBaseViewModel.kt
@@ -1,7 +1,5 @@
 package com.wire.android.ui.authentication.create.common
 
-import android.net.Uri
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -226,16 +224,16 @@ abstract class CreateAccountBaseViewModel(
                     )
             }
 
-            val (userInfo, session) = registerAccountUseCase(registerParam).let {
+            val (ssoId, session) = registerAccountUseCase(registerParam).let {
                 when (it) {
                     is RegisterResult.Failure -> {
                         updateCodeErrorState(it.toCodeError())
                         return@launch
                     }
-                    is RegisterResult.Success -> it.value
+                    is RegisterResult.Success -> it.ssoId to it.userSession
                 }
             }
-            val storedUserId = addAuthenticatedUser(session, false).let {
+            val storedUserId = addAuthenticatedUser(session, ssoId, false).let {
                 when (it) {
                     is AddAuthenticatedUserUseCase.Result.Failure -> {
                         updateCodeErrorState(it.toCodeError())

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceState.kt
@@ -7,6 +7,7 @@ data class RegisterDeviceState(
     val password: TextFieldValue = TextFieldValue(""),
     val continueEnabled: Boolean = false,
     val loading: Boolean = false,
+    val isPasswordRequired: Boolean = false,
     val error: RegisterDeviceError = RegisterDeviceError.None
 )
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -13,61 +13,102 @@ import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
 import com.wire.kalium.logic.feature.session.RegisterTokenResult
 import com.wire.kalium.logic.feature.session.RegisterTokenUseCase
+import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import okhttp3.internal.wait
 import javax.inject.Inject
 
 @HiltViewModel
 class RegisterDeviceViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
-    private val validatePasswordUseCase: ValidatePasswordUseCase,
     private val registerClientUseCase: RegisterClientUseCase,
-    private val pushTokenUseCase: RegisterTokenUseCase
+    private val pushTokenUseCase: RegisterTokenUseCase,
+    private val isPasswordRequired: IsPasswordRequiredUseCase,
+    private val dispatcher: DispatcherProvider
 ) : ViewModel() {
 
     var state: RegisterDeviceState by mutableStateOf(RegisterDeviceState())
         private set
 
+    init {
+        viewModelScope.launch(dispatcher.io()) {
+            updateState(state.copy(loading = true))
+            isPasswordRequired().let {
+                updateState(state.copy(loading = false))
+                when (it) {
+                    is IsPasswordRequiredUseCase.Result.Failure -> {
+                        updateErrorState(RegisterDeviceError.GenericError(it.cause))
+                    }
+                    is IsPasswordRequiredUseCase.Result.Success -> {
+                        updateState(state.copy(isPasswordRequired = it.value))
+                    }
+                }
+            }
+        }.wait()
+
+        viewModelScope.launch {
+            when (state.isPasswordRequired) {
+                true -> {}
+                false -> registerClient(null)
+            }
+        }.wait()
+    }
+
     fun onPasswordChange(newText: TextFieldValue) {
         if (state.password != newText)
-            state = state.copy(password = newText, error = RegisterDeviceError.None, continueEnabled = newText.text.isNotEmpty())
+            updateState(state.copy(password = newText, error = RegisterDeviceError.None, continueEnabled = newText.text.isNotEmpty()))
     }
 
     fun onErrorDismiss() {
-        state = state.copy(error = RegisterDeviceError.None)
+        updateErrorState(RegisterDeviceError.None)
+    }
+
+    private suspend fun registerClient(password: String?) {
+        updateState(state.copy(loading = true, continueEnabled = false))
+        when (val registerDeviceResult = registerClientUseCase(
+            RegisterClientUseCase.RegisterClientParam(
+                password = password,
+                capabilities = null,
+            )
+        )) {
+            is RegisterClientResult.Failure.TooManyClients -> navigateToRemoveDevicesScreen()
+            is RegisterClientResult.Success -> {
+                registerPushToken(registerDeviceResult.client.id)
+                navigateToHomeScreen()
+            }
+            is RegisterClientResult.Failure.Generic -> state = state.copy(
+                loading = false,
+                continueEnabled = true,
+                error = RegisterDeviceError.GenericError(registerDeviceResult.genericFailure)
+            )
+            RegisterClientResult.Failure.InvalidCredentials -> state = state.copy(
+                loading = false,
+                continueEnabled = true,
+                error = RegisterDeviceError.InvalidCredentialsError
+            )
+        }
     }
 
     fun onContinue() {
-        state = state.copy(loading = true, continueEnabled = false)
         viewModelScope.launch {
-            if (!validatePasswordUseCase(state.password.text))
-                state = state.copy(loading = false, continueEnabled = true, error = RegisterDeviceError.InvalidCredentialsError)
-            else when (val registerDeviceResult = registerClientUseCase(
-                RegisterClientUseCase.RegisterClientParam(
-                    password = state.password.text,
-                    capabilities = null,
-                ))) {
-                is RegisterClientResult.Failure.TooManyClients -> navigateToRemoveDevicesScreen()
-                is RegisterClientResult.Success -> {
-                    registerPushToken(registerDeviceResult.client.id)
-                    navigateToHomeScreen()}
-                is RegisterClientResult.Failure.Generic -> state = state.copy(
-                        loading = false,
-                        continueEnabled = true,
-                        error = RegisterDeviceError.GenericError(registerDeviceResult.genericFailure)
-                )
-                RegisterClientResult.Failure.InvalidCredentials -> state = state.copy(
-                    loading = false,
-                    continueEnabled = true,
-                    error = RegisterDeviceError.InvalidCredentialsError
-                )
-            }
+            registerClient(state.password.text)
+        }
+    }
+
+    fun updateErrorState(error: RegisterDeviceError) {
+        updateState(state.copy(error = error))
+    }
+
+    fun updateState(newState: RegisterDeviceState) {
+        viewModelScope.launch(dispatcher.main()) {
+            state = newState
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -36,7 +36,7 @@ class LoginEmailViewModel @Inject constructor(
     fun login() {
         loginState = loginState.copy(emailLoginLoading = true, loginError = LoginError.None).updateEmailLoginEnabled()
         viewModelScope.launch {
-            val authSession = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true)
+            val (authSession, ssoId) = loginUseCase(loginState.userIdentifier.text, loginState.password.text, true)
                 .let {
                     when (it) {
                         is AuthenticationResult.Failure -> {
@@ -44,10 +44,10 @@ class LoginEmailViewModel @Inject constructor(
                             return@launch
                         }
 
-                        is AuthenticationResult.Success -> it.userSession
+                        is AuthenticationResult.Success -> it.userSession to it.ssoId
                     }
                 }
-            val storedUserId = addAuthenticatedUser(authSession, false).let {
+            val storedUserId = addAuthenticatedUser(authSession, ssoId, false).let {
                 when (it) {
                     is AddAuthenticatedUserUseCase.Result.Failure -> {
                         updateEmailLoginError(it.toLoginError())

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModel.kt
@@ -58,16 +58,16 @@ class LoginSSOViewModel @Inject constructor(
     fun establishSSOSession(cookie: String) {
         loginState = loginState.copy(ssoLoginLoading = true, loginError = LoginError.None).updateSSOLoginEnabled()
         viewModelScope.launch {
-            val authSession = getSSOLoginSessionUseCase(cookie).let {
+            val (authSession, ssoId) = getSSOLoginSessionUseCase(cookie).let {
                 when (it) {
                     is SSOLoginSessionResult.Failure -> {
                         updateSSOLoginError(it.toLoginError())
                         return@launch
                     }
-                    is SSOLoginSessionResult.Success -> it.userSession
+                    is SSOLoginSessionResult.Success -> it.userSession to it.ssoId
                 }
             }
-            val storedUserId = addAuthenticatedUser(authSession, false).let {
+            val storedUserId = addAuthenticatedUser(authSession, ssoId, false).let {
                 when (it) {
                     is AddAuthenticatedUserUseCase.Result.Failure -> {
                         updateSSOLoginError(it.toLoginError())

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -2,7 +2,6 @@ package com.wire.android.ui.authentication.devices.register
 
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.config.CoroutineTestExtension
-import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -65,8 +64,7 @@ class RegisterDeviceViewModelTest {
                 navigationManager,
                 registerClientUseCase,
                 registerTokenUseCase,
-                isPasswordRequiredUseCase,
-                TestDispatcherProvider()
+                isPasswordRequiredUseCase
             )
     }
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModelTest.kt
@@ -2,6 +2,7 @@ package com.wire.android.ui.authentication.devices.register
 
 import androidx.compose.ui.text.input.TextFieldValue
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
@@ -13,11 +14,11 @@ import com.wire.kalium.logic.NetworkFailure
 import com.wire.kalium.logic.data.client.Client
 import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
 import com.wire.kalium.logic.feature.session.RegisterTokenResult
 import com.wire.kalium.logic.feature.session.RegisterTokenUseCase
+import com.wire.kalium.logic.feature.user.IsPasswordRequiredUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -44,13 +45,13 @@ class RegisterDeviceViewModelTest {
     private lateinit var navigationManager: NavigationManager
 
     @MockK
-    private lateinit var validatePasswordUseCase: ValidatePasswordUseCase
-
-    @MockK
     private lateinit var registerClientUseCase: RegisterClientUseCase
 
     @MockK
     private lateinit var registerTokenUseCase: RegisterTokenUseCase
+
+    @MockK
+    private lateinit var isPasswordRequiredUseCase: IsPasswordRequiredUseCase
 
     private lateinit var registerDeviceViewModel: RegisterDeviceViewModel
 
@@ -58,13 +59,19 @@ class RegisterDeviceViewModelTest {
     fun setup() {
         MockKAnnotations.init(this)
         mockUri()
+        coEvery { isPasswordRequiredUseCase() } returns IsPasswordRequiredUseCase.Result.Success(true)
         registerDeviceViewModel =
-            RegisterDeviceViewModel(navigationManager, validatePasswordUseCase, registerClientUseCase, registerTokenUseCase)
+            RegisterDeviceViewModel(
+                navigationManager,
+                registerClientUseCase,
+                registerTokenUseCase,
+                isPasswordRequiredUseCase,
+                TestDispatcherProvider()
+            )
     }
 
     @Test
     fun `given empty string, when entering the password to register, then button is disabled`() {
-        coEvery { validatePasswordUseCase(String.EMPTY) } returns false
         registerDeviceViewModel.onPasswordChange(TextFieldValue(String.EMPTY))
         registerDeviceViewModel.state.continueEnabled shouldBeEqualTo false
         registerDeviceViewModel.state.loading shouldBeEqualTo false
@@ -72,7 +79,6 @@ class RegisterDeviceViewModelTest {
 
     @Test
     fun `given non-empty string, when entering the password to register, then button is disabled`() {
-        coEvery { validatePasswordUseCase("abc") } returns true
         registerDeviceViewModel.onPasswordChange(TextFieldValue("abc"))
         registerDeviceViewModel.state.continueEnabled shouldBeEqualTo true
         registerDeviceViewModel.state.loading shouldBeEqualTo false
@@ -80,7 +86,6 @@ class RegisterDeviceViewModelTest {
 
     @Test
     fun `given button is clicked, when registering the client, then show loading`() {
-        coEvery { validatePasswordUseCase(any()) } returns true
         coEvery {
             registerClientUseCase(any())
         } returns RegisterClientResult.Success(CLIENT)
@@ -98,7 +103,6 @@ class RegisterDeviceViewModelTest {
         val scheduler = TestCoroutineScheduler()
         val password = "abc"
         Dispatchers.setMain(StandardTestDispatcher(scheduler))
-        coEvery { validatePasswordUseCase(any()) } returns true
         coEvery {
             registerClientUseCase(
                 any()
@@ -113,7 +117,6 @@ class RegisterDeviceViewModelTest {
 
         runTest { registerDeviceViewModel.onContinue() }
 
-        coVerify(exactly = 1) { validatePasswordUseCase(password) }
         coVerify(exactly = 1) {
             registerClientUseCase(any())
         }
@@ -128,7 +131,6 @@ class RegisterDeviceViewModelTest {
         val scheduler = TestCoroutineScheduler()
         val password = "abc"
         Dispatchers.setMain(StandardTestDispatcher(scheduler))
-        coEvery { validatePasswordUseCase(any()) } returns true
         coEvery {
             registerClientUseCase(any())
         } returns RegisterClientResult.Failure.TooManyClients
@@ -137,7 +139,6 @@ class RegisterDeviceViewModelTest {
 
         runTest { registerDeviceViewModel.onContinue() }
 
-        coVerify(exactly = 1) { validatePasswordUseCase(password) }
         coVerify(exactly = 1) {
             registerClientUseCase(any())
         }
@@ -148,7 +149,6 @@ class RegisterDeviceViewModelTest {
 
     @Test
     fun `given button is clicked, when password is invalid, then UsernameInvalidError is passed`() {
-        coEvery { validatePasswordUseCase(any()) } returns false
         coEvery {
             registerClientUseCase(any())
         } returns RegisterClientResult.Failure.InvalidCredentials
@@ -161,7 +161,6 @@ class RegisterDeviceViewModelTest {
     @Test
     fun `given button is clicked, when request returns Generic error, then GenericError is passed`() {
         val networkFailure = NetworkFailure.NoNetworkConnection(null)
-        coEvery { validatePasswordUseCase(any()) } returns true
         coEvery { registerClientUseCase(any()) } returns
                 RegisterClientResult.Failure.Generic(networkFailure)
 
@@ -175,7 +174,6 @@ class RegisterDeviceViewModelTest {
     @Test
     fun `given dialog is dismissed, when state error is DialogError, then hide error`() {
         val networkFailure = NetworkFailure.NoNetworkConnection(null)
-        coEvery { validatePasswordUseCase(any()) } returns true
         coEvery { registerClientUseCase(any()) } returns
                 RegisterClientResult.Failure.Generic(networkFailure)
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
@@ -84,9 +85,6 @@ class LoginEmailViewModelTest {
     private lateinit var authSession: AuthSession
 
     @MockK
-    private lateinit var client: Client
-
-    @MockK
     private lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     @MockK
@@ -94,7 +92,6 @@ class LoginEmailViewModelTest {
 
     private lateinit var loginViewModel: LoginEmailViewModel
 
-    private val apiBaseUrl: String = "apiBaseUrl"
     private val userId: QualifiedID = QualifiedID("userId", "domain")
 
     @BeforeEach
@@ -161,7 +158,7 @@ class LoginEmailViewModelTest {
         val scheduler = TestCoroutineScheduler()
         val password = "abc"
         Dispatchers.setMain(StandardTestDispatcher(scheduler))
-        coEvery { loginUseCase(any(), any(), any()) } returns AuthenticationResult.Success(authSession)
+        coEvery { loginUseCase(any(), any(), any()) } returns AuthenticationResult.Success(authSession, SSO_ID)
         coEvery { addAuthenticatedUserUseCase(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Success(userId)
         coEvery { navigationManager.navigate(any()) } returns Unit
         coEvery { registerClientUseCase(any()) } returns RegisterClientResult.Success(CLIENT)
@@ -226,7 +223,7 @@ class LoginEmailViewModelTest {
 
     @Test
     fun `given button is clicked, when addAuthenticatedUser returns UserAlreadyExists error, then UserAlreadyExists is passed`() {
-        coEvery { loginUseCase(any(), any(), any()) } returns AuthenticationResult.Success(authSession)
+        coEvery { loginUseCase(any(), any(), any()) } returns AuthenticationResult.Success(authSession, SSO_ID)
         coEvery { addAuthenticatedUserUseCase(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Failure.UserAlreadyExists
 
         runTest { loginViewModel.login() }
@@ -240,6 +237,7 @@ class LoginEmailViewModelTest {
             CLIENT_ID, ClientType.Permanent, "time", null,
             null, "label", "cookie", null, "model"
         )
+        val SSO_ID: SsoId = SsoId("scim_id", null, null)
     }
 }
 

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelTest.kt
@@ -21,6 +21,7 @@ import com.wire.kalium.logic.data.client.ClientType
 import com.wire.kalium.logic.data.conversation.ClientId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.SsoId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.auth.sso.GetSSOLoginSessionUseCase
@@ -108,6 +109,7 @@ class LoginSSOViewModelTest {
         every { clientScope.register } returns registerClientUseCase
         every { clientScope.registerPushToken } returns registerTokenUseCase
         every { authServerConfigProvider.authServer.value } returns newServerConfig(1).links
+
         loginViewModel = LoginSSOViewModel(
             savedStateHandle,
             qualifiedIdMapper,
@@ -216,7 +218,7 @@ class LoginSSOViewModelTest {
 
     @Test
     fun `given establishSSOSession is called, when SSOLogin Success, then SSOLoginResult is passed`() {
-        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession)
+        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession, SSO_ID)
         coEvery { addAuthenticatedUserUseCase(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Success(userId)
         coEvery {
             registerClientUseCase(any())
@@ -265,7 +267,7 @@ class LoginSSOViewModelTest {
 
     @Test
     fun `given HandleSSOResult is called, when SSOLoginResult is success, then establishSSOSession should be called once`() {
-        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession)
+        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession, SSO_ID)
         coEvery { addAuthenticatedUserUseCase(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Success(userId)
         coEvery { registerClientUseCase(any()) } returns RegisterClientResult.Success(CLIENT)
         coEvery { registerTokenUseCase(any(), CLIENT.id) } returns RegisterTokenResult.Success
@@ -276,7 +278,7 @@ class LoginSSOViewModelTest {
 
     @Test
     fun `given establishSSOSession called, when addAuthenticatedUser returns UserAlreadyExists error, then UserAlreadyExists is passed`() {
-        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession)
+        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession, SSO_ID)
         coEvery { addAuthenticatedUserUseCase(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Failure.UserAlreadyExists
 
         runTest { loginViewModel.establishSSOSession("") }
@@ -291,7 +293,7 @@ class LoginSSOViewModelTest {
 
     @Test
     fun `given establishSSOSession is called, when registerClientUseCase returns TooManyClients error, then TooManyClients is passed`() {
-        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession)
+        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession, SSO_ID)
         coEvery { addAuthenticatedUserUseCase(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Success(userId)
         coEvery {
             registerClientUseCase(any())
@@ -309,7 +311,7 @@ class LoginSSOViewModelTest {
 
     @Test
     fun `given establishSSOSession is called, when registerTokenUseCase returns PushTokenFailure error, then LoginError is None`() {
-        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession)
+        coEvery { getSSOLoginSessionUseCase(any()) } returns SSOLoginSessionResult.Success(authSession, SSO_ID)
         coEvery { addAuthenticatedUserUseCase(any(), any()) } returns AddAuthenticatedUserUseCase.Result.Success(userId)
         coEvery {
             registerClientUseCase(any())
@@ -337,5 +339,6 @@ class LoginSSOViewModelTest {
             CLIENT_ID, ClientType.Permanent, "time", null,
             null, "label", "cookie", null, "model"
         )
+        val SSO_ID: SsoId = SsoId("scim_id", null, null)
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

AR-1999

### Solutions

1. store the user SSOID from the user info response
2. user `IsPasswordRequiredUseCase` to know when to ask the user to enter their password.

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
