### PR TITLE
feat: delete conversations events navigation to home on deleted (AR-2041)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -37,6 +37,7 @@ import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.conversation.ConversationDetails
+import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
@@ -61,13 +62,12 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.functional.onFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
 import okio.buffer
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
-import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -134,15 +134,13 @@ class ConversationViewModel @Inject constructor(
     }
 
     private fun listenConversationDetails() = viewModelScope.launch {
-        withContext(dispatchers.io()) {
-            observeConversationDetails(conversationId)
-                .collect { result ->
-                    when (result) {
-                        is Failure -> handleConversationDetailsFailure(result.storageFailure)
-                        is Success -> handleConversationDetails(result.conversationDetails)
-                    }
+        observeConversationDetails(conversationId)
+            .collect { result ->
+                when (result) {
+                    is Failure -> handleConversationDetailsFailure(result.storageFailure)
+                    is Success -> handleConversationDetails(result.conversationDetails)
                 }
-        }
+            }
     }
 
     private suspend fun handleConversationDetailsFailure(failure: StorageFailure) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -37,7 +37,6 @@ import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.conversation.ConversationDetails
-import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.FAILED
 import com.wire.kalium.logic.data.message.Message.DownloadStatus.IN_PROGRESS
@@ -62,12 +61,13 @@ import com.wire.kalium.logic.feature.team.GetSelfTeamUseCase
 import com.wire.kalium.logic.feature.user.IsFileSharingEnabledUseCase
 import com.wire.kalium.logic.functional.onFailure
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
 import okio.buffer
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -143,6 +143,10 @@ class ConversationViewModel @Inject constructor(
             }
     }
 
+    /**
+     * TODO: This right now handles only the case when a conversation details doesn't exists.
+     * Later we'll have to expand the error cases to different behaviors
+     */
     private suspend fun handleConversationDetailsFailure(failure: StorageFailure) {
         when (failure) {
             is StorageFailure.DataNotFound -> navigateToHome()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -131,13 +131,15 @@ class ConversationViewModel @Inject constructor(
     }
 
     private fun listenConversationDetails() = viewModelScope.launch {
-        observeConversationDetails(conversationId)
-            .collect { result ->
-                when (result) {
-                    is Failure -> navigateToHome()
-                    is Success -> emitConversationDetails(result.conversationDetails)
+        withContext(dispatchers.io()) {
+            observeConversationDetails(conversationId)
+                .collect { result ->
+                    when (result) {
+                        is Failure -> navigateToHome()
+                        is Success -> emitConversationDetails(result.conversationDetails)
+                    }
                 }
-            }
+        }
     }
 
     private fun emitConversationDetails(conversationDetails: ConversationDetails) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2041" title="AR-2041" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-2041</a>  (ui) Navigation from conversation detail delete
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Given that we receive a conversation deleted event, we need to react (remove it from the conversations list) and if we are on the details view, we need to navigate back to the conversations lists, because this conversation is not available anymore.

### Attachments (Optional)

https://user-images.githubusercontent.com/5806454/182393652-66ca6967-81ff-4d20-a7bc-ec18a7b42a1a.mov

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
