### PR TITLE
fix: some Users can't register new client on RegisterDeviceScreen [AR-2029]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/devices/register/RegisterDeviceViewModel.kt
@@ -14,7 +14,6 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.kalium.logic.data.conversation.ClientId
-import com.wire.kalium.logic.feature.auth.ValidatePasswordUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.client.RegisterClientUseCase
 import com.wire.kalium.logic.feature.session.RegisterTokenResult
@@ -26,7 +25,6 @@ import javax.inject.Inject
 @HiltViewModel
 class RegisterDeviceViewModel @Inject constructor(
     private val navigationManager: NavigationManager,
-    private val validatePasswordUseCase: ValidatePasswordUseCase,
     private val registerClientUseCase: RegisterClientUseCase,
     private val pushTokenUseCase: RegisterTokenUseCase
 ) : ViewModel() {
@@ -46,21 +44,21 @@ class RegisterDeviceViewModel @Inject constructor(
     fun onContinue() {
         state = state.copy(loading = true, continueEnabled = false)
         viewModelScope.launch {
-            if (!validatePasswordUseCase(state.password.text))
-                state = state.copy(loading = false, continueEnabled = true, error = RegisterDeviceError.InvalidCredentialsError)
-            else when (val registerDeviceResult = registerClientUseCase(
+            when (val registerDeviceResult = registerClientUseCase(
                 RegisterClientUseCase.RegisterClientParam(
                     password = state.password.text,
                     capabilities = null,
-                ))) {
+                )
+            )) {
                 is RegisterClientResult.Failure.TooManyClients -> navigateToRemoveDevicesScreen()
                 is RegisterClientResult.Success -> {
                     registerPushToken(registerDeviceResult.client.id)
-                    navigateToHomeScreen()}
+                    navigateToHomeScreen()
+                }
                 is RegisterClientResult.Failure.Generic -> state = state.copy(
-                        loading = false,
-                        continueEnabled = true,
-                        error = RegisterDeviceError.GenericError(registerDeviceResult.genericFailure)
+                    loading = false,
+                    continueEnabled = true,
+                    error = RegisterDeviceError.GenericError(registerDeviceResult.genericFailure)
                 )
                 RegisterClientResult.Failure.InvalidCredentials -> state = state.copy(
                     loading = false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2029" title="AR-2029" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2029</a>  At login, I can't remove the additional devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

AR-2029

### Causes (Optional)

unnecessary password validation

### Solutions

remove any password validation when the user enter their passwords 

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
