### PR TITLE
fix: QualifiedIdMapper crashes [AR-2137]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -85,6 +85,11 @@ class CoreLogicModule {
             kaliumConfigs = kaliumConfigs
         )
     }
+
+    @NoSession
+    @Singleton
+    @Provides
+    fun provideNoSessionQualifiedIdMapper(): QualifiedIdMapper = QualifiedIdMapperImpl(null)
 }
 
 @Module
@@ -584,11 +589,6 @@ class UseCaseModule {
         @CurrentAccount currentAccount: UserId
     ): FederatedIdMapper =
         coreLogic.getSessionScope(currentAccount).federatedIdMapper
-
-    @NoSession
-    @ViewModelScoped
-    @Provides
-    fun provideNoSessionQualifiedIdMapper(): QualifiedIdMapper = QualifiedIdMapperImpl(null)
 
     @ViewModelScoped
     @Provides

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/CallNotificationDismissReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/CallNotificationDismissReceiver.kt
@@ -5,11 +5,13 @@ import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.di.NoSession
 import com.wire.android.notification.CallNotificationManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.GlobalScope
@@ -17,9 +19,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class CallNotificationDismissReceiver(
-    private val qualifiedIdMapper: QualifiedIdMapper
-) : BroadcastReceiver() {
+class CallNotificationDismissReceiver : BroadcastReceiver() {  // requires zero argument constructor
 
     @Inject
     @KaliumCoreLogic
@@ -28,13 +28,15 @@ class CallNotificationDismissReceiver(
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    @NoSession
+    lateinit var qualifiedIdMapper: QualifiedIdMapper
+
     override fun onReceive(context: Context, intent: Intent) {
         val conversationId: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: return
         appLogger.i("CallNotificationDismissReceiver: onReceive, conversationId: $conversationId")
 
-        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.let {
-            qualifiedIdMapper.fromStringToQualifiedID(it)
-        } ?: run { null }
+        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
 
         GlobalScope.launch(dispatcherProvider.io()) {
             val sessionScope =

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/ConnectionRequestNotificationDismissReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/ConnectionRequestNotificationDismissReceiver.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.di.NoSession
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.GlobalScope
@@ -16,9 +18,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ConnectionRequestNotificationDismissReceiver(
-    private val qualifiedIdMapper: QualifiedIdMapper
-) : BroadcastReceiver() {
+class ConnectionRequestNotificationDismissReceiver : BroadcastReceiver() { // requires zero argument constructor
 
     @Inject
     @KaliumCoreLogic
@@ -27,13 +27,15 @@ class ConnectionRequestNotificationDismissReceiver(
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    @NoSession
+    lateinit var qualifiedIdMapper: QualifiedIdMapper
+
     override fun onReceive(context: Context, intent: Intent) {
         val requesterUserId: String? = intent.getStringExtra(EXTRA_CONNECTION_REQUESTER_USER_ID)
         appLogger.i("ConnectionRequestNotificationDismissReceiver: onReceive, requesterUserId: $requesterUserId")
 
-        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.let {
-            qualifiedIdMapper.fromStringToQualifiedID(it)
-        } ?: run { null }
+        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
 
         GlobalScope.launch(dispatcherProvider.io()) {
             val sessionScope =
@@ -49,14 +51,7 @@ class ConnectionRequestNotificationDismissReceiver(
                 }
 
             sessionScope?.let { scope ->
-                requesterUserId?.let { userId ->
-                    qualifiedIdMapper.fromStringToQualifiedID(userId).let {
-                        scope.conversations.markConnectionRequestAsNotified(it)
-                    }
-                }
-                requesterUserId?.run {
-                    qualifiedIdMapper.fromStringToQualifiedID(this)
-                }?.let {
+                requesterUserId?.toQualifiedID(qualifiedIdMapper)?.let {
                     scope.conversations.markConnectionRequestAsNotified(it)
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/MessageNotificationDismissReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/MessageNotificationDismissReceiver.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.di.NoSession
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.util.toStringDate
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,9 +19,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MessageNotificationDismissReceiver(
-    private val qualifiedIdMapper: QualifiedIdMapper
-) : BroadcastReceiver() {
+class MessageNotificationDismissReceiver : BroadcastReceiver() { // requires zero argument constructor
 
     @Inject
     @KaliumCoreLogic
@@ -28,13 +28,15 @@ class MessageNotificationDismissReceiver(
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    @NoSession
+    lateinit var qualifiedIdMapper: QualifiedIdMapper
+
     override fun onReceive(context: Context, intent: Intent) {
         val conversationId: String? = intent.getStringExtra(EXTRA_CONVERSATION_ID)
         appLogger.i("MessageNotificationDismissReceiver: onReceive, conversationId: $conversationId")
 
-        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.let {
-            qualifiedIdMapper.fromStringToQualifiedID(it)
-        } ?: run { null }
+        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
 
 
         GlobalScope.launch(dispatcherProvider.io()) {

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.RemoteInput
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.di.NoSession
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
@@ -15,9 +16,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class NotificationReplyReceiver(
-    private val qualifiedIdMapper: QualifiedIdMapper
-) : BroadcastReceiver() {
+class NotificationReplyReceiver : BroadcastReceiver() { // requires zero argument constructor
 
     @Inject
     @KaliumCoreLogic
@@ -25,6 +24,10 @@ class NotificationReplyReceiver(
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    @NoSession
+    lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     override fun onReceive(context: Context, intent: Intent) {
         val remoteInput = RemoteInput.getResultsFromIntent(intent)

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/SummaryNotificationDismissReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/SummaryNotificationDismissReceiver.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.di.NoSession
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.util.toStringDate
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,9 +19,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class SummaryNotificationDismissReceiver(
-    private val qualifiedIdMapper: QualifiedIdMapper
-) : BroadcastReceiver() {
+class SummaryNotificationDismissReceiver : BroadcastReceiver() { // requires zero argument constructor
 
     @Inject
     @KaliumCoreLogic
@@ -28,12 +28,14 @@ class SummaryNotificationDismissReceiver(
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    @NoSession
+    lateinit var qualifiedIdMapper: QualifiedIdMapper
+
     override fun onReceive(context: Context, intent: Intent) {
         appLogger.i("SummaryNotificationDismissReceiver: onReceive")
 
-        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.let {
-            qualifiedIdMapper.fromStringToQualifiedID(it)
-        } ?: run { null }
+        val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
 
         GlobalScope.launch(dispatcherProvider.io()) {
             val sessionScope =

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -24,6 +24,7 @@ import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCase
@@ -64,13 +65,8 @@ class OtherUserProfileScreenViewModel @Inject constructor(
     var state: OtherUserProfileState by mutableStateOf(OtherUserProfileState())
     var connectionOperationState: ConnectionOperationState? by mutableStateOf(null)
 
-    private val userId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
-        savedStateHandle.get<String>(EXTRA_USER_ID)!!
-    )
-
-    private val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
-        savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)!!
-    )
+    private val userId: QualifiedID = savedStateHandle.get<String>(EXTRA_USER_ID)!!.toQualifiedID(qualifiedIdMapper)
+    private val conversationId: QualifiedID? = savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)?.toQualifiedID(qualifiedIdMapper)
 
     init {
         state = state.copy(isDataLoading = true)

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -12,6 +12,7 @@ import com.wire.android.navigation.getCurrentNavigationItem
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
+import com.wire.kalium.logic.data.id.toQualifiedID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -64,10 +65,13 @@ sealed class CurrentScreen {
 
     // Some Conversation is opened
     data class Conversation(val id: ConversationId) : CurrentScreen()
+
     // Another User Profile Screen is opened
     data class OtherUserProfile(val id: QualifiedID) : CurrentScreen()
+
     // Some other screen is opened, kinda "do nothing screen"
     object SomeOther : CurrentScreen()
+
     // App is in background (screen is turned off, or covered by another app), non of the screens is visible
     object InBackground : CurrentScreen()
 
@@ -78,13 +82,13 @@ sealed class CurrentScreen {
             when (currentItem) {
                 NavigationItem.Conversation -> {
                     arguments?.getString(EXTRA_CONVERSATION_ID)
-                        ?.run{ qualifiedIdMapper.fromStringToQualifiedID(this) }
+                        ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { Conversation(it) }
                         ?: SomeOther
                 }
                 NavigationItem.OtherUserProfile -> {
                     arguments?.getString(EXTRA_USER_ID)
-                        ?.run{ qualifiedIdMapper.fromStringToQualifiedID(this) }
+                        ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { OtherUserProfile(it) }
                         ?: SomeOther
                 }

--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -5,6 +5,7 @@ import androidx.annotation.VisibleForTesting
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapperImpl
+import com.wire.kalium.logic.data.id.toQualifiedID
 
 sealed class DeepLinkResult {
     object Unknown : DeepLinkResult()
@@ -32,12 +33,12 @@ class DeepLinkProcessor {
     }
 
     private fun getOpenConversationDeepLinkResult(uri: Uri): DeepLinkResult =
-        uri.lastPathSegment?.run { qualifiedIdMapper.fromStringToQualifiedID(this) }?.let {
+        uri.lastPathSegment?.toQualifiedID(qualifiedIdMapper)?.let {
             DeepLinkResult.OpenConversation(it)
         } ?: DeepLinkResult.Unknown
 
     private fun getOpenOtherUserProfileDeepLinkResult(uri: Uri): DeepLinkResult =
-        uri.lastPathSegment?.run { qualifiedIdMapper.fromStringToQualifiedID(this) }?.let {
+        uri.lastPathSegment?.toQualifiedID(qualifiedIdMapper)?.let {
             DeepLinkResult.OpenOtherUserProfile(it)
         } ?: DeepLinkResult.Unknown
 
@@ -46,7 +47,7 @@ class DeepLinkProcessor {
     } ?: DeepLinkResult.Unknown
 
     private fun getIncomingCallDeepLinkResult(uri: Uri) =
-        uri.lastPathSegment?.run { qualifiedIdMapper.fromStringToQualifiedID(this) }?.let {
+        uri.lastPathSegment?.toQualifiedID(qualifiedIdMapper)?.let {
             DeepLinkResult.IncomingCall(it)
         } ?: DeepLinkResult.Unknown
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelArrangement.kt
@@ -253,21 +253,27 @@ internal fun withMockConversationDetailsOneOnOne(
     senderAvatar: UserAssetId? = null,
     senderId: UserId = UserId("user-id", "user-domain")
 ) = ConversationDetails.OneOne(
-    mockk(),
-    mockk<OtherUser>().apply {
+    conversation = mockk(),
+    otherUser = mockk<OtherUser>().apply {
         every { id } returns senderId
         every { name } returns senderName
         every { previewPicture } returns senderAvatar
     },
-    ConnectionState.PENDING,
-    LegalHoldStatus.DISABLED,
-    UserType.INTERNAL
+    connectionState = ConnectionState.PENDING,
+    legalHoldStatus = LegalHoldStatus.DISABLED,
+    userType = UserType.INTERNAL,
+    unreadMessagesCount = 0L
 )
 
-internal fun mockConversationDetailsGroup(conversationName: String) = ConversationDetails.Group(mockk<Conversation>().apply {
+internal fun mockConversationDetailsGroup(conversationName: String) = ConversationDetails.Group(
+    conversation = mockk<Conversation>().apply {
     every { name } returns conversationName
     every { id } returns ConversationId("someId", "someDomain")
-}, mockk())
+},
+    legalHoldStatus = mockk(),
+    hasOngoingCall = false,
+    unreadMessagesCount = 0
+)
 
 internal fun mockUITextMessage(userName: String = "mockUserName"): UIMessage {
     return mockk<UIMessage>().also {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -297,18 +297,21 @@ class GroupConversationDetailsViewModelTest {
     companion object {
         val testGroup = ConversationDetails.Group(
             Conversation(
-                ConversationId("conv_id", "domain"),
-                "Conv Name",
-                Conversation.Type.ONE_ON_ONE,
-                TeamId("team_id"),
-                Conversation.ProtocolInfo.Proteus,
-                MutedConversationStatus.AllAllowed,
-                null,
-                null,
+                id = ConversationId("conv_id", "domain"),
+                name = "Conv Name",
+                type = Conversation.Type.ONE_ON_ONE,
+                teamId = TeamId("team_id"),
+                protocol = Conversation.ProtocolInfo.Proteus,
+                mutedStatus = MutedConversationStatus.AllAllowed,
+                lastNotificationDate = null,
+                lastModifiedDate = null,
                 access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),
-                accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST)
+                accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER, Conversation.AccessRole.GUEST),
+                lastReadDate = null
             ),
-            legalHoldStatus = LegalHoldStatus.DISABLED
+            legalHoldStatus = LegalHoldStatus.DISABLED,
+            hasOngoingCall = false,
+            unreadMessagesCount = 0L
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -226,27 +226,30 @@ class MediaGalleryViewModelTest {
         dummyConversationId: QualifiedID = QualifiedID("a-value", "a-domain")
     ): ConversationDetails =
         OneOne(
-            Conversation(
-                dummyConversationId,
-                mockedConversationTitle,
-                Conversation.Type.ONE_ON_ONE,
-                null,
+            conversation = Conversation(
+                id = dummyConversationId,
+                name = mockedConversationTitle,
+                type = Conversation.Type.ONE_ON_ONE,
+                teamId = null,
                 protocol = Conversation.ProtocolInfo.Proteus,
-                AllAllowed,
-                null, null,
+                mutedStatus = AllAllowed,
+                lastNotificationDate = null,
+                lastModifiedDate = null,
+                lastReadDate = null,
                 access = listOf(Conversation.Access.INVITE),
                 accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER)
             ),
-            OtherUser(
+            otherUser = OtherUser(
                 QualifiedID("other-user-id", "domain-id"),
                 null, null, null, null,
                 1, null, ConnectionState.ACCEPTED, null, null,
                 UserType.INTERNAL,
                 UserAvailabilityStatus.AVAILABLE
             ),
-            ConnectionState.ACCEPTED,
-            LegalHoldStatus.DISABLED,
-            UserType.INTERNAL
+            connectionState = ConnectionState.ACCEPTED,
+            legalHoldStatus = LegalHoldStatus.DISABLED,
+            userType = UserType.INTERNAL,
+            unreadMessagesCount = 0L
         )
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -99,9 +99,10 @@ internal class NewConversationViewModelArrangement {
             type = Conversation.Type.ONE_ON_ONE,
             teamId = null,
             protocol = Conversation.ProtocolInfo.Proteus,
-            MutedConversationStatus.AllAllowed,
-            null,
-            null,
+            mutedStatus = MutedConversationStatus.AllAllowed,
+            lastNotificationDate = null,
+            lastModifiedDate = null,
+            lastReadDate = null,
             access = listOf(Conversation.Access.INVITE),
             accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER)
         )

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -106,7 +106,10 @@ class OtherUserProfileScreenViewModelTest {
         coEvery {
             qualifiedIdMapper.fromStringToQualifiedID("some_value@some_domain")
         } returns QualifiedID("some_value", "some_domain")
+        initViewModel()
+    }
 
+    private fun initViewModel() {
         otherUserProfileScreenViewModel = OtherUserProfileScreenViewModel(
             savedStateHandle,
             navigationManager,
@@ -250,6 +253,8 @@ class OtherUserProfileScreenViewModelTest {
         runTest {
             // given
             val expected =  OtherUserProfileGroupState("some_name", Member.Role.Member, false)
+            every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns CONVERSATION_ID.toString()
+            initViewModel()
             // when
             val groupState = otherUserProfileScreenViewModel.state.groupState
             // then
@@ -258,6 +263,22 @@ class OtherUserProfileScreenViewModelTest {
                 navigationManager wasNot Called
             }
             assertEquals(groupState, expected)
+        }
+
+    @Test
+    fun `given no conversationId, when loading the data, then return null group state`() =
+        runTest {
+            // given
+            every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns null
+            initViewModel()
+            // when
+            val groupState = otherUserProfileScreenViewModel.state.groupState
+            // then
+            coVerify {
+                observeConversationRoleForUserUseCase(any(), any()) wasNot Called
+                navigationManager wasNot Called
+            }
+            assertEquals(groupState, null)
         }
 
     // todo: add tests for cancel request
@@ -281,14 +302,15 @@ class OtherUserProfileScreenViewModelTest {
         )
         val TEAM = Team("some_id", null)
         val CONVERSATION = Conversation(
-            CONVERSATION_ID,
-            "some_name",
-            Conversation.Type.ONE_ON_ONE,
-            null,
+            id = CONVERSATION_ID,
+            name = "some_name",
+            type = Conversation.Type.ONE_ON_ONE,
+            teamId = null,
             protocol = Conversation.ProtocolInfo.Proteus,
-            MutedConversationStatus.AllAllowed,
-            null,
-            null,
+            mutedStatus = MutedConversationStatus.AllAllowed,
+            lastNotificationDate = null,
+            lastModifiedDate = null,
+            lastReadDate = null,
             access = listOf(Conversation.Access.INVITE),
             accessRole = listOf(Conversation.AccessRole.NON_TEAM_MEMBER)
         )


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2137" title="AR-2137" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2137</a>  App is crashing when tapping on "New Conversation" Button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

QualifiedIdMapper is only provided in a ViewModel scope and requires user session. It's wrongly injected into BroadcastReceivers - they must have zero arguments constructor to work so everything needs to be injected as `lateinit var`. 

### Solutions

Provided another QualifiedIdMapper with @NoSession annotation in a SingletonComponent and injected with this annotation into @AndroidEntryPoint BroadcastReceivers (they doesn't have its own component so they use SingletonComponent) using `lateinit var`  to bring back empty constructors.
Restore conversationId to be nullable again in OtherUserProfileScreenViewModel.

### Dependencies (Optional)

https://github.com/wireapp/kalium/pull/753

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Previously it crashed when opening login screen, add conversation screen, other user profile screen (from any other place than group conversation) or when swiping out notifications - it shouldn't now.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
