### PR TITLE
fix: UI fix [AR-1884]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/WireSwitch.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/WireSwitch.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import com.wire.android.ui.theme.wireColorScheme
@@ -16,7 +17,7 @@ import com.wire.android.ui.theme.wireColorScheme
 fun WireSwitch(
     checked: Boolean,
     onCheckedChange: ((Boolean) -> Unit)?,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier.scale(scaleX = 1f, scaleY = 0.85f),
     thumbContent: @Composable () -> Unit = { },
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
@@ -61,16 +61,13 @@ fun GroupConversationOptionsItem(
                     end = MaterialTheme.wireDimensions.spacing12x
                 )
         ) {
-            // item label
-            label?.let { label ->
+            if (label != null)
                 Text(
                     text = label,
                     style = MaterialTheme.wireTypography.label01,
                     color = MaterialTheme.wireColorScheme.secondaryText,
                     modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.spacing4x)
                 )
-            }
-
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = title,
@@ -78,9 +75,8 @@ fun GroupConversationOptionsItem(
                     color = MaterialTheme.wireColorScheme.onBackground,
                     modifier = Modifier.weight(weight = 1f, fill = true)
                 )
-                titleTrailingItem?.let {
+                if (titleTrailingItem != null)
                     Box(modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)) { titleTrailingItem() }
-                }
                 if (switchState is SwitchState.Visible) {
                     if (switchState.isOnOffVisible) {
                         Text(
@@ -100,19 +96,15 @@ fun GroupConversationOptionsItem(
                 }
                 if (arrowType == ArrowType.TITLE_ALIGNED) ArrowRight()
             }
-
-            subtitle?.let { subtitle ->
+            if (subtitle != null)
                 Text(
                     text = subtitle,
                     style = MaterialTheme.wireTypography.body01,
                     color = MaterialTheme.wireColorScheme.secondaryText,
-                    modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing4x)
+                    modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing2x)
                 )
-            }
-
-            footer?.let {
+            if (footer != null)
                 Box(modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing8x)) { footer() }
-            }
         }
         if (arrowType == ArrowType.CENTER_ALIGNED) ArrowRight()
     }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
@@ -55,19 +55,22 @@ fun GroupConversationOptionsItem(
             modifier = Modifier
                 .weight(1f)
                 .padding(
-                    top = MaterialTheme.wireDimensions.spacing8x,
-                    bottom = MaterialTheme.wireDimensions.spacing8x,
+                    top = MaterialTheme.wireDimensions.spacing12x,
+                    bottom = MaterialTheme.wireDimensions.spacing12x,
                     start = MaterialTheme.wireDimensions.spacing16x,
-                    end = MaterialTheme.wireDimensions.spacing16x
+                    end = MaterialTheme.wireDimensions.spacing12x
                 )
         ) {
-            if (label != null)
+            // item label
+            label?.let { label ->
                 Text(
                     text = label,
                     style = MaterialTheme.wireTypography.label01,
                     color = MaterialTheme.wireColorScheme.secondaryText,
                     modifier = Modifier.padding(bottom = MaterialTheme.wireDimensions.spacing4x)
                 )
+            }
+
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = title,
@@ -75,8 +78,9 @@ fun GroupConversationOptionsItem(
                     color = MaterialTheme.wireColorScheme.onBackground,
                     modifier = Modifier.weight(weight = 1f, fill = true)
                 )
-                if (titleTrailingItem != null)
+                titleTrailingItem?.let {
                     Box(modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)) { titleTrailingItem() }
+                }
                 if (switchState is SwitchState.Visible) {
                     if (switchState.isOnOffVisible) {
                         Text(
@@ -96,15 +100,19 @@ fun GroupConversationOptionsItem(
                 }
                 if (arrowType == ArrowType.TITLE_ALIGNED) ArrowRight()
             }
-            if (subtitle != null)
+
+            subtitle?.let { subtitle ->
                 Text(
                     text = subtitle,
                     style = MaterialTheme.wireTypography.body01,
                     color = MaterialTheme.wireColorScheme.secondaryText,
-                    modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing8x)
+                    modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing4x)
                 )
-            if (footer != null)
+            }
+
+            footer?.let {
                 Box(modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing8x)) { footer() }
+            }
         }
         if (arrowType == ArrowType.CENTER_ALIGNED) ArrowRight()
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1884" title="AR-1884" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1884</a>  Separate guests and services + make admin control them
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

conversation options screen doesn't match design

### Solutions

change padding to match design and use scale to make the switch a bit smaller


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
