### PR TITLE
feat: hide the protocol selection when MLS is disabled 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/CoreLogicModule.kt
@@ -548,6 +548,11 @@ class UseCaseModule {
 
     @ViewModelScoped
     @Provides
+    fun provideIsMLSEnabledUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
+        coreLogic.getSessionScope(currentAccount).isMLSEnabled
+
+    @ViewModelScoped
+    @Provides
     fun provideIsFileSharingEnabledUseCase(@KaliumCoreLogic coreLogic: CoreLogic, @CurrentAccount currentAccount: UserId) =
         coreLogic.getSessionScope(currentAccount).isFileSharingEnabled
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -28,6 +28,7 @@ import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.search.Result
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersUseCase
+import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.functional.Either
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -41,6 +42,7 @@ class NewConversationViewModel @Inject constructor(
     private val searchPublicUsers: SearchUsersUseCase,
     private val createGroupConversation: CreateGroupConversationUseCase,
     private val contactMapper: ContactMapper,
+    isMLSEnabled: IsMLSEnabledUseCase,
     dispatchers: DispatcherProvider,
     sendConnectionRequest: SendConnectionRequestUseCase,
     navigationManager: NavigationManager
@@ -49,7 +51,7 @@ class NewConversationViewModel @Inject constructor(
         const val GROUP_NAME_MAX_COUNT = 64
     }
 
-    var groupNameState: NewGroupState by mutableStateOf(NewGroupState())
+    var groupNameState: NewGroupState by mutableStateOf(NewGroupState(mlsEnabled = isMLSEnabled()))
 
     var groupOptionsState: GroupOptionState by mutableStateOf(GroupOptionState())
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupScreen.kt
@@ -120,17 +120,18 @@ fun NewGroupScreenContent(
                     }
 
                 }
-
-                WireDropDown(
-                    items =
-                    ConversationOptions.Protocol.values().map { it.name },
-                    defaultItemIndex = 0,
-                    stringResource(R.string.protocol),
-                    modifier = Modifier.constrainAs(protocol) {
-                        top.linkTo(textField.bottom)
-                    }.padding(MaterialTheme.wireDimensions.spacing16x)
-                ) { selectedIndex ->
-                    groupProtocol = ConversationOptions.Protocol.values()[selectedIndex]
+                if (mlsEnabled) {
+                    WireDropDown(
+                        items =
+                        ConversationOptions.Protocol.values().map { it.name },
+                        defaultItemIndex = 0,
+                        stringResource(R.string.protocol),
+                        modifier = Modifier.constrainAs(protocol) {
+                            top.linkTo(textField.bottom)
+                        }.padding(MaterialTheme.wireDimensions.spacing16x)
+                    ) { selectedIndex ->
+                        groupProtocol = ConversationOptions.Protocol.values()[selectedIndex]
+                    }
                 }
                 WirePrimaryButton(
                     text = stringResource(R.string.label_continue),

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupState.kt
@@ -8,6 +8,7 @@ data class NewGroupState(
     var groupProtocol: ConversationOptions.Protocol = ConversationOptions.Protocol.PROTEUS,
     val animatedGroupNameError: Boolean = false,
     val continueEnabled: Boolean = false,
+    val mlsEnabled: Boolean = true,
     val isLoading : Boolean = false,
     val error: GroupNameError = GroupNameError.None
 ) {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -26,6 +26,7 @@ import com.wire.kalium.logic.feature.publicuser.GetAllContactsUseCase
 import com.wire.kalium.logic.feature.publicuser.search.Result
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersUseCase
+import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
 import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -36,6 +37,7 @@ internal class NewConversationViewModelArrangement {
         MockKAnnotations.init(this, relaxUnitFun = true)
 
         // Default empty values
+        coEvery { isMLSEnabledUseCase() } returns true
         coEvery { searchUsers(any()) } returns Result.Success(userSearchResult = UserSearchResult(listOf(PUBLIC_USER)))
         coEvery { searchKnownUsers(any()) } returns Result.Success(userSearchResult = UserSearchResult(listOf(KNOWN_USER)))
         coEvery { getAllContacts() } returns GetAllContactsResult.Success(listOf())
@@ -84,6 +86,9 @@ internal class NewConversationViewModelArrangement {
 
     @MockK
     lateinit var sendConnectionRequestUseCase: SendConnectionRequestUseCase
+
+    @MockK
+    lateinit var isMLSEnabledUseCase: IsMLSEnabledUseCase
 
     @MockK
     lateinit var contactMapper: ContactMapper
@@ -149,7 +154,8 @@ internal class NewConversationViewModelArrangement {
             createGroupConversation = createGroupConversation,
             contactMapper = contactMapper,
             sendConnectionRequest = sendConnectionRequestUseCase,
-            dispatchers = TestDispatcherProvider()
+            dispatchers = TestDispatcherProvider(),
+            isMLSEnabled = isMLSEnabledUseCase
         )
     }
 


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Don't show the protocol selection when creating a new conversation if MLS is disabled.

### Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/kalium/pull/757

### Testing

#### How to Test

1. Enable MLS for your user in team settings
2. Tap create new conversation 
3. protocol selection is visible/hidden

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
