### PR TITLE
fix: New calls mute the ongoing call(AR-2025)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallState.kt
@@ -4,15 +4,14 @@ import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.ui.calling.model.UICallParticipant
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.kalium.logic.data.call.ConversationType
-import com.wire.kalium.logic.data.call.Participant
 
 data class CallState(
     val conversationName: ConversationName? = null,
     val callerName: String? = null,
     val avatarAssetId: UserAvatarAsset? = null,
     val participants: List<UICallParticipant> = listOf(),
-    val isMuted: Boolean = false,
-    val isCameraOn: Boolean = false,
+    val isMuted: Boolean? = null,
+    val isCameraOn: Boolean? = null,
     val isSpeakerOn: Boolean = false,
     val isCameraFlipped: Boolean = false,
     val conversationType: ConversationType = ConversationType.OneOnOne,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -68,7 +68,9 @@ class SharedCallingViewModel @Inject constructor(
     var callState by mutableStateOf(CallState())
 
     val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
-        savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)!!
+        checkNotNull(savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)) {
+            "No conversationId was provided via savedStateHandle to SharedCallingViewModel"
+        }
     )
 
     init {
@@ -135,10 +137,12 @@ class SharedCallingViewModel @Inject constructor(
 
     private suspend fun observeOnMute() {
         snapshotFlow { callState.isMuted }.collectLatest {
-            if (it) {
-                muteCall(conversationId)
-            } else {
-                unMuteCall(conversationId)
+            it?.let {
+                if (it) {
+                    muteCall(conversationId)
+                } else {
+                    unMuteCall(conversationId)
+                }
             }
         }
     }
@@ -146,7 +150,7 @@ class SharedCallingViewModel @Inject constructor(
     private suspend fun observeCallState() {
         allCalls().collect { calls ->
             calls.find { call ->
-                call.conversationId == conversationId && call.status == CallStatus.ESTABLISHED
+                call.conversationId == conversationId && call.status != CallStatus.CLOSED
             }?.let { call ->
                 callState = callState.copy(
                     callerName = call.callerName,
@@ -185,28 +189,32 @@ class SharedCallingViewModel @Inject constructor(
 
     fun toggleMute() {
         viewModelScope.launch {
-            callState = if (callState.isMuted) {
-                callState.copy(isMuted = false)
-            } else {
-                callState.copy(isMuted = true)
+            callState.isMuted?.let {
+                callState = if (it) {
+                    callState.copy(isMuted = false)
+                } else {
+                    callState.copy(isMuted = true)
+                }
             }
         }
     }
 
     fun toggleVideo() {
         viewModelScope.launch {
-            callState = if (callState.isCameraOn) {
-                turnLoudSpeakerOff()
-                callState.copy(
-                    isCameraOn = false,
-                    isSpeakerOn = false
-                )
-            } else {
-                turnLoudSpeakerOn()
-                callState.copy(
-                    isCameraOn = true,
-                    isSpeakerOn = true
-                )
+            callState.isCameraOn?.let {
+                callState = if (it) {
+                    turnLoudSpeakerOff()
+                    callState.copy(
+                        isCameraOn = false,
+                        isSpeakerOn = false
+                    )
+                } else {
+                    turnLoudSpeakerOn()
+                    callState.copy(
+                        isCameraOn = true,
+                        isSpeakerOn = true
+                    )
+                }
             }
         }
     }
@@ -228,9 +236,11 @@ class SharedCallingViewModel @Inject constructor(
 
     fun pauseVideo() {
         viewModelScope.launch {
-            if (callState.isCameraOn) {
-                updateVideoState(conversationId, VideoState.PAUSED)
-                setVideoPreview(conversationId, PlatformView(null))
+            callState.isCameraOn?.let {
+                if (it) {
+                    updateVideoState(conversationId, VideoState.PAUSED)
+                    setVideoPreview(conversationId, PlatformView(null))
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -150,7 +150,9 @@ class SharedCallingViewModel @Inject constructor(
     private suspend fun observeCallState() {
         allCalls().collect { calls ->
             calls.find { call ->
-                call.conversationId == conversationId && call.status != CallStatus.CLOSED
+                call.conversationId == conversationId &&
+                        call.status != CallStatus.CLOSED &&
+                        call.status != CallStatus.MISSED
             }?.let { call ->
                 callState = callState.copy(
                     callerName = call.callerName,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallVideoPreview.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallVideoPreview.kt
@@ -11,7 +11,8 @@ import com.waz.avs.VideoPreview
 @Composable
 fun CallVideoPreview(
     isCameraOn: Boolean,
-    onVideoPreviewCreated: (view: View) -> Unit
+    onVideoPreviewCreated: (view: View) -> Unit,
+    onSelfClearVideoPreview: () -> Unit
 ) {
     if (isCameraOn) {
         Box {
@@ -26,5 +27,7 @@ fun CallVideoPreview(
                 it.alpha = 0.5F
             }
         }
+    } else {
+        onSelfClearVideoPreview()
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallScreen.kt
@@ -85,7 +85,8 @@ fun IncomingCallScreen(
                     audioPermissionCheck.launch()
                 }
             },
-            onVideoPreviewCreated = ::setVideoPreview
+            onVideoPreviewCreated = ::setVideoPreview,
+            onSelfClearVideoPreview = ::clearVideoPreview
         )
     }
 }
@@ -99,7 +100,8 @@ private fun IncomingCallContent(
     toggleVideo: () -> Unit,
     declineCall: () -> Unit,
     acceptCall: () -> Unit,
-    onVideoPreviewCreated: (view: View) -> Unit
+    onVideoPreviewCreated: (view: View) -> Unit,
+    onSelfClearVideoPreview: () -> Unit
 ) {
 
     val scaffoldState = rememberBottomSheetScaffoldState()
@@ -112,8 +114,8 @@ private fun IncomingCallContent(
         sheetPeekHeight = dimensions().defaultIncomingCallSheetPeekHeight,
         sheetContent = {
             CallOptionsControls(
-                isMuted = callState.isMuted,
-                isCameraOn = callState.isCameraOn,
+                isMuted = callState.isMuted ?: true,
+                isCameraOn = callState.isCameraOn ?: false,
                 isSpeakerOn = callState.isSpeakerOn,
                 toggleSpeaker = toggleSpeaker,
                 toggleMute = toggleMute,
@@ -162,8 +164,9 @@ private fun IncomingCallContent(
     ) {
         Box {
             CallVideoPreview(
-                isCameraOn = callState.isCameraOn,
-                onVideoPreviewCreated = { onVideoPreviewCreated(it) }
+                isCameraOn = callState.isCameraOn ?: false,
+                onVideoPreviewCreated = onVideoPreviewCreated,
+                onSelfClearVideoPreview = onSelfClearVideoPreview
             )
             val isCallingString = if (callState.conversationType == ConversationType.Conference) {
                 stringResource(R.string.calling_label_incoming_call_someone_calling, callState.callerName ?: "")
@@ -171,7 +174,7 @@ private fun IncomingCallContent(
 
             CallerDetails(
                 conversationName = callState.conversationName,
-                isCameraOn = callState.isCameraOn,
+                isCameraOn = callState.isCameraOn ?: false,
                 avatarAssetId = callState.avatarAssetId,
                 conversationType = callState.conversationType,
                 membership = callState.membership,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/incoming/IncomingCallViewModel.kt
@@ -41,7 +41,9 @@ class IncomingCallViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val incomingCallConversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
-        savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)!!
+        checkNotNull(savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)) {
+            "No conversationId was provided via savedStateHandle to IncomingCallViewModel"
+        }
     )
 
     lateinit var observeIncomingCallJob: Job
@@ -126,6 +128,6 @@ class IncomingCallViewModel @Inject constructor(
     companion object {
         private const val DELAY_TIME_AFTER_ENDING_CALL = 1000L
         private val ACCEPT_CALL_DEFAULT_BACKSTACK_NODE = BackStackMode.REMOVE_CURRENT
-        private const val ACCEPT_CALL_DEFAULT_DELAY_TIME = 0L
+        private const val ACCEPT_CALL_DEFAULT_DELAY_TIME = 200L
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
@@ -44,7 +44,8 @@ fun InitiatingCallScreen(
             toggleVideo = ::toggleVideo,
             onNavigateBack = ::navigateBack,
             onHangUpCall = initiatingCallViewModel::hangUpCall,
-            onVideoPreviewCreated = ::setVideoPreview
+            onVideoPreviewCreated = ::setVideoPreview,
+            onSelfClearVideoPreview = ::clearVideoPreview
         )
     }
 }
@@ -58,7 +59,8 @@ private fun InitiatingCallContent(
     toggleVideo: () -> Unit,
     onNavigateBack: () -> Unit,
     onHangUpCall: () -> Unit,
-    onVideoPreviewCreated: (view: View) -> Unit
+    onVideoPreviewCreated: (view: View) -> Unit,
+    onSelfClearVideoPreview: () -> Unit
 ) {
 
     val scaffoldState = rememberBottomSheetScaffoldState()
@@ -75,8 +77,8 @@ private fun InitiatingCallContent(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 CallOptionsControls(
-                    isMuted = callState.isMuted,
-                    isCameraOn = callState.isCameraOn,
+                    isMuted = callState.isMuted ?: true,
+                    isCameraOn = callState.isCameraOn ?: false,
                     isSpeakerOn = callState.isSpeakerOn,
                     toggleSpeaker = toggleSpeaker,
                     toggleMute = toggleMute,
@@ -98,12 +100,13 @@ private fun InitiatingCallContent(
     ) {
         Box {
             CallVideoPreview(
-                isCameraOn = callState.isCameraOn,
-                onVideoPreviewCreated = { onVideoPreviewCreated(it) }
+                isCameraOn = callState.isCameraOn ?: false,
+                onVideoPreviewCreated = onVideoPreviewCreated,
+                onSelfClearVideoPreview = onSelfClearVideoPreview
             )
             CallerDetails(
                 conversationName = callState.conversationName,
-                isCameraOn = callState.isCameraOn,
+                isCameraOn = callState.isCameraOn ?: false,
                 avatarAssetId = callState.avatarAssetId,
                 conversationType = callState.conversationType,
                 membership = callState.membership,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
@@ -42,8 +42,10 @@ class InitiatingCallViewModel @Inject constructor(
     private val callRinger: CallRinger
 ) : ViewModel() {
 
-    val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
-        savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)!!
+    private val conversationId: QualifiedID = qualifiedIdMapper.fromStringToQualifiedID(
+        checkNotNull(savedStateHandle.get<String>(EXTRA_CONVERSATION_ID)) {
+            "No conversationId was provided via savedStateHandle to InitiatingCallViewModel"
+        }
     )
 
     private val callStartTime: Long = Calendar.getInstance().timeInMillis
@@ -62,8 +64,8 @@ class InitiatingCallViewModel @Inject constructor(
             .filterIsInstance<ObserveConversationDetailsUseCase.Result.Success>() // TODO handle StorageFailure
             .map { it.conversationDetails }
             .first { details ->
-            details.conversation.id == conversationId
-        }
+                details.conversation.id == conversationId
+            }
 
         when (conversationDetails) {
             is ConversationDetails.Group -> {

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -133,7 +133,17 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given muteOrUnMuteCall is called, when active call is muted, then un-mute the call`() {
+    fun `given isMuted value is null, when toggling microphone, then do not update microphone state`() {
+        sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = null)
+        coEvery { muteCall(conversationId) } returns Unit
+
+        runTest { sharedCallingViewModel.toggleMute() }
+
+        sharedCallingViewModel.callState.isMuted shouldBeEqualTo null
+    }
+
+    @Test
+    fun `given an un-muted call, when toggling microphone, then mute the call`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = false)
         coEvery { muteCall(conversationId) } returns Unit
 
@@ -143,13 +153,23 @@ class SharedCallingViewModelTest {
     }
 
     @Test
-    fun `given muteOrUnMuteCall is called, when active call is un-muted, then mute the call`() {
+    fun `given a muted call, when toggling microphone, then un-mute the call`() {
         sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isMuted = true)
         coEvery { unMuteCall(conversationId) } returns Unit
 
         runTest { sharedCallingViewModel.toggleMute() }
 
         sharedCallingViewModel.callState.isMuted shouldBeEqualTo false
+    }
+
+    @Test
+    fun `given isCameraOn value is null, when toggling camera, then do not update camera state`() {
+        sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = null)
+        coEvery { muteCall(conversationId) } returns Unit
+
+        runTest { sharedCallingViewModel.toggleVideo() }
+
+        sharedCallingViewModel.callState.isCameraOn shouldBeEqualTo null
     }
 
     @Test
@@ -231,8 +251,20 @@ class SharedCallingViewModelTest {
 
         runTest { sharedCallingViewModel.pauseVideo() }
 
-        coVerify(exactly = 0) { setVideoPreview(any(), any()) }
-        coVerify(exactly = 0) { updateVideoState(any(), VideoState.PAUSED) }
+        coVerify(inverse = true) { setVideoPreview(any(), any()) }
+        coVerify(inverse = true) { updateVideoState(any(), VideoState.PAUSED) }
+    }
+
+    @Test
+    fun `given an audio call with a null camera value, when pauseVideo is called, then do not pause the video`() {
+        sharedCallingViewModel.callState = sharedCallingViewModel.callState.copy(isCameraOn = null)
+        coEvery { setVideoPreview(any(), any()) } returns Unit
+        coEvery { updateVideoState(any(), any()) } returns Unit
+
+        runTest { sharedCallingViewModel.pauseVideo() }
+
+        coVerify(inverse = true) { setVideoPreview(any(), any()) }
+        coVerify(inverse = true) { updateVideoState(any(), VideoState.PAUSED) }
     }
 
     companion object {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2025" title="AR-2025" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2025</a>  New Calls Mute the ongoing Call
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

PS: The fix is done on both sides, kalium and Reloaded

### Issues

1. Incoming calls affect current call state: if you mute the incoming call, the current call will also be muted
2. call state in incoming call is not saved: if play with calling controls in the incoming call screen(mute, turn camera on) and accept the call you will not get last state of the call you have configured

### Causes (Optional)

we were calling muteCall method from AVS in incoming call screen

### Solutions

- make default value for isMuted and isCameraOn null, this way when the state is created with default values we are sure that no AVS method will be invoked

### Dependencies (Optional)

Needs to be merged with the bellow PR from kalium
[fix: New calls mute the ongoing call(AR-2025)
](https://github.com/wireapp/kalium/pull/761)

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

First you should be on an ongoing call and turn the microphone off
Receive another call
Un-mute the incoming call
You should notice that the active call is un-muted as well
### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
