### PR TITLE
fix: keep receiving notifications while in background (Related to AR-1236)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -45,13 +45,13 @@ class WireNotificationManager @Inject constructor(
      */
     suspend fun fetchAndShowNotificationsOnce(userIdValue: String) {
         checkIfUserIsAuthenticated(userId = userIdValue)?.let { userId ->
-            //TODO: Move logic to Kalium.
-            //      All of this could be handled inside Kalium,
-            //      and Reloaded shouldn't need to call `waitUntilLive`.
-            //      Kalium could be smarter
             coreLogic.sessionScope(userId) {
+                // Force KEEP_ALIVE policy so we gather pending events
                 setConnectionPolicy(ConnectionPolicy.KEEP_ALIVE)
+                // Wait until the client is live and pending events are processed
                 syncManager.waitUntilLive()
+                // As the app is in the background when receiving PUSH notifications,
+                // we can downgrade the policy back
                 setConnectionPolicy(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
             }
             fetchAndShowMessageNotificationsOnce(userId)

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -45,7 +45,7 @@ class WireNotificationManager @Inject constructor(
      */
     suspend fun fetchAndShowNotificationsOnce(userIdValue: String) {
         checkIfUserIsAuthenticated(userId = userIdValue)?.let { userId ->
-            coreLogic.sessionScope(userId) {
+            coreLogic.getSessionScope(userId).run {
                 // Force KEEP_ALIVE policy so we gather pending events
                 setConnectionPolicy(ConnectionPolicy.KEEP_ALIVE)
                 // Wait until the client is live and pending events are processed

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -9,6 +9,7 @@ import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.notification.LocalNotificationConversation
+import com.wire.kalium.logic.data.sync.ConnectionPolicy
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.Call
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
@@ -48,7 +49,11 @@ class WireNotificationManager @Inject constructor(
             //      All of this could be handled inside Kalium,
             //      and Reloaded shouldn't need to call `waitUntilLive`.
             //      Kalium could be smarter
-            coreLogic.getSessionScope(userId).syncManager.waitUntilLive()
+            coreLogic.sessionScope(userId) {
+                setConnectionPolicy(ConnectionPolicy.KEEP_ALIVE)
+                syncManager.waitUntilLive()
+                setConnectionPolicy(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+            }
             fetchAndShowMessageNotificationsOnce(userId)
             fetchAndShowCallNotificationsOnce(userId)
         }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1236" title="AR-1236" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1236</a>  Display notification for ongoing calls if the app is in the background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When killing the app, it will handle only the very first push notification.
If you re-open the app, Sync won't re-start and will stay disconnected.

### Causes

While in the background, the app sets Kalium's ConnectionPolicy to `DISCONNECT_AFTER_PENDING_EVENTS`.
When coming to the foreground, the app sets it back to `KEEP_ALIVE`, but Kalium doesn't handle this upgrade.

### Solutions

1. When receiving a push notification, set the policy to `KEEP_ALIVE` and then `DISCONNECT` right afterwards, so we make Kalium re-connect for a while while we are in the background.
2. Bump Kalium version, so it contains the handling of this upgrade.

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/767

### Testing

#### How to Test

- Kill the app by sliding it out of the screen.
- Receive a push notification
- Open the app

The app should reconnect normally.

- Kill the app by sliding it out of the screen.
- Receive a push notification
- Receive more push notifications

The app should keep receiving push notifications.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
