### PR TITLE
fix: AR-2121 compose slider not syncing properly in user services screen

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModel.kt
@@ -84,6 +84,7 @@ class GroupConversationDetailsViewModel @Inject constructor(
     }
 
     fun onGuestUpdate(enableGuestAndNonTeamMember: Boolean) {
+        groupOptionsState = groupOptionsState.copy(isGuestAllowed = enableGuestAndNonTeamMember)
         when (enableGuestAndNonTeamMember) {
             true -> updateGuestStatus(enableGuestAndNonTeamMember)
             false -> showGuestConformationDialog()
@@ -95,12 +96,12 @@ class GroupConversationDetailsViewModel @Inject constructor(
     }
 
     fun onGuestDialogDismiss() {
-        updateState(groupOptionsState.copy(isGuestUpdateDialogShown = false, isGuestAllowed = groupOptionsState.isGuestAllowed))
+        updateState(groupOptionsState.copy(isGuestUpdateDialogShown = false, isGuestAllowed = !groupOptionsState.isGuestAllowed))
     }
 
     fun onGuestDialogConfirm() {
         updateGuestStatus(false)
-        onGuestDialogDismiss()
+        updateState(groupOptionsState.copy(isGuestUpdateDialogShown = false))
     }
 
     private fun updateGuestStatus(enableGuestAndNonTeamMember: Boolean) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptions.kt
@@ -34,7 +34,7 @@ fun GroupConversationOptions(
         lazyListState = lazyListState
     )
     DisableGuestConformationDialog(
-        state = viewModel.groupOptionsState.isGuestUpdateDialogShown,
+        state = viewModel.groupOptionsState.changeGuestOptionConformationRequired,
         onConform = viewModel::onGuestDialogConfirm,
         onDialogDismiss = viewModel::onGuestDialogDismiss
     )
@@ -61,6 +61,7 @@ fun GroupConversationSettings(
                 GuestOption(
                     isClickable = state.isUpdatingGuestAllowed,
                     switchState = state.isGuestAllowed,
+                    isLoading = state.loadingGuestOption,
                     onCheckedChange = onGuestSwitchClicked
                 )
             }
@@ -69,6 +70,7 @@ fun GroupConversationSettings(
                 ServicesOption(
                     isClickable = state.isUpdatingAllowed,
                     switchState = state.isServicesAllowed,
+                    isLoading = state.loadingServicesOption,
                     onCheckedChange = onServiceSwitchClicked
                 )
             }
@@ -88,21 +90,23 @@ private fun GroupNameItem(groupName: String, canBeChanged: Boolean) {
 
 
 @Composable
-private fun GuestOption(isClickable: Boolean, switchState: Boolean, onCheckedChange: (Boolean) -> Unit) {
+private fun GuestOption(isClickable: Boolean, switchState: Boolean, isLoading: Boolean, onCheckedChange: (Boolean) -> Unit) {
     GroupOptionWithSwitch(
         isClickable = isClickable,
         switchState = switchState,
         onClick = onCheckedChange,
+        isLoading = isLoading,
         title = R.string.label_membership_guest,
         subTitle = R.string.convrsation_options_guest_discriptions
     )
 }
 
 @Composable
-private fun ServicesOption(isClickable: Boolean, switchState: Boolean, onCheckedChange: (Boolean) -> Unit) {
+private fun ServicesOption(isClickable: Boolean, switchState: Boolean, isLoading: Boolean, onCheckedChange: (Boolean) -> Unit) {
     GroupOptionWithSwitch(
         isClickable = isClickable,
         switchState = switchState,
+        isLoading = isLoading,
         onClick = onCheckedChange,
         title = R.string.conversation_Option_services_lable,
         subTitle = R.string.convrsation_options_services_discriptions
@@ -113,6 +117,7 @@ private fun ServicesOption(isClickable: Boolean, switchState: Boolean, onChecked
 private fun GroupOptionWithSwitch(
     isClickable: Boolean,
     switchState: Boolean,
+    isLoading: Boolean,
     onClick: (Boolean) -> Unit,
     @StringRes title: Int,
     @StringRes subTitle: Int?
@@ -125,6 +130,7 @@ private fun GroupOptionWithSwitch(
         },
         switchState = if (isClickable) SwitchState.Enabled(
             value = switchState,
+            isLoading = isLoading,
             onCheckedChange = onClick
         ) else SwitchState.TextOnly(switchState),
         arrowType = ArrowType.NONE

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsItem.kt
@@ -77,23 +77,9 @@ fun GroupConversationOptionsItem(
                 )
                 if (titleTrailingItem != null)
                     Box(modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)) { titleTrailingItem() }
-                if (switchState is SwitchState.Visible) {
-                    if (switchState.isOnOffVisible) {
-                        Text(
-                            text = stringResource(if (switchState.value) R.string.label_on else R.string.label_off),
-                            style = MaterialTheme.wireTypography.body01,
-                            color = MaterialTheme.wireColorScheme.onBackground,
-                            modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)
-                        )
-                    }
-                    if (switchState.isSwitchVisible) {
-                        WireSwitch(
-                            checked = switchState.value,
-                            enabled = switchState is SwitchState.Enabled,
-                            onCheckedChange = (switchState as? SwitchState.Enabled)?.onCheckedChange
-                        )
-                    }
-                }
+
+                ConversationOptionSwitch(switchState)
+
                 if (arrowType == ArrowType.TITLE_ALIGNED) ArrowRight()
             }
             if (subtitle != null)
@@ -107,6 +93,29 @@ fun GroupConversationOptionsItem(
                 Box(modifier = Modifier.padding(top = MaterialTheme.wireDimensions.spacing8x)) { footer() }
         }
         if (arrowType == ArrowType.CENTER_ALIGNED) ArrowRight()
+    }
+}
+
+@Composable
+fun ConversationOptionSwitch(
+    switchState: SwitchState
+) {
+    if (switchState is SwitchState.Visible) {
+        if (switchState.isOnOffVisible) {
+            Text(
+                text = stringResource(if (switchState.value) R.string.label_on else R.string.label_off),
+                style = MaterialTheme.wireTypography.body01,
+                color = MaterialTheme.wireColorScheme.onBackground,
+                modifier = Modifier.padding(horizontal = MaterialTheme.wireDimensions.spacing8x)
+            )
+        }
+        if (switchState.isSwitchVisible) {
+            WireSwitch(
+                checked = switchState.value,
+                enabled = ((switchState is SwitchState.Enabled) && switchState.isLoading.not()),
+                onCheckedChange = (switchState as? SwitchState.Enabled)?.onCheckedChange
+            )
+        }
     }
 }
 
@@ -129,14 +138,16 @@ sealed class SwitchState {
     sealed class Visible(
         open val value: Boolean = false,
         open val isOnOffVisible: Boolean = true,
-        open val isSwitchVisible: Boolean = true
+        open val isSwitchVisible: Boolean = true,
+        open val isLoading: Boolean = false
     ) : SwitchState()
 
     data class Enabled(
         override val value: Boolean = false,
         override val isOnOffVisible: Boolean = true,
+        override val isLoading: Boolean = false,
         val onCheckedChange: (Boolean) -> Unit
-    ) : Visible(value = value, isSwitchVisible = true)
+    ) : Visible(value = value, isSwitchVisible = true, isLoading = isLoading)
 
     data class Disabled(
         override val value: Boolean = false,
@@ -145,7 +156,8 @@ sealed class SwitchState {
 
     data class TextOnly(
         override val value: Boolean = false,
-    ) : Visible(value = value, isOnOffVisible = true, isSwitchVisible = false)
+        override val isLoading: Boolean = false,
+    ) : Visible(value = value, isOnOffVisible = true, isSwitchVisible = false, isLoading = isLoading)
 }
 
 @Composable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/details/options/GroupConversationOptionsState.kt
@@ -9,7 +9,9 @@ data class GroupConversationOptionsState (
     val isServicesAllowed: Boolean = false,
     val isUpdatingAllowed: Boolean = false,
     val isUpdatingGuestAllowed: Boolean = false,
-    val isGuestUpdateDialogShown: Boolean = false,
+    val changeGuestOptionConformationRequired: Boolean = false,
+    val loadingGuestOption: Boolean = false,
+    val loadingServicesOption: Boolean = false,
     val error: Error = Error.None
 ) {
     sealed interface Error {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -188,7 +188,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         viewModel.onGuestUpdate(false)
-        assertEquals(true, viewModel.groupOptionsState.isGuestUpdateDialogShown)
+        assertEquals(true, viewModel.groupOptionsState.changeGuestOptionConformationRequired)
     }
 
     @Test
@@ -215,7 +215,7 @@ class GroupConversationDetailsViewModelTest {
             .arrange()
 
         viewModel.onGuestDialogConfirm()
-        assertEquals(false, viewModel.groupOptionsState.isGuestUpdateDialogShown)
+        assertEquals(false, viewModel.groupOptionsState.changeGuestOptionConformationRequired)
         coVerify(exactly = 1) {
             arrangement.updateConversationAccessRoleUseCase(
                 conversationId = details.conversation.id,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2121" title="AR-2121" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2121</a>  compose slider not syncing properly in user services screen
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

compose switch not syncing properly in conversation options screen

### Solutions

1. change the switch state immediately when clicked without waiting for dialog confirmation 
2. disable the switches when loading

https://drive.google.com/file/d/1aZUUPR38iFtbovrJboVMePnJUwooejkA/view?usp=sharing

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
