### PR TITLE
fix(calling): Self video stays paused when moving the app into foreground in video call (AR-1825)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -96,7 +96,8 @@ class SharedCallingViewModel @Inject constructor(
         currentScreenManager.observeCurrentScreen(viewModelScope).collect {
             if (it == CurrentScreen.InBackground) {
                 pauseVideo()
-            }
+            } else if (it == CurrentScreen.OngoingCallScreen(conversationId))
+                unPauseVideo()
         }
     }
 
@@ -230,8 +231,15 @@ class SharedCallingViewModel @Inject constructor(
         viewModelScope.launch {
             if (callState.isCameraOn) {
                 updateVideoState(conversationId, VideoState.PAUSED)
-                setVideoPreview(conversationId, PlatformView(null))
             }
+        }
+    }
+
+    private fun unPauseVideo() {
+        viewModelScope.launch {
+            // We should turn on video only for established call
+            if (callState.isCameraOn && callState.participants.isNotEmpty())
+                updateVideoState(conversationId, VideoState.STARTED)
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -42,8 +42,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("LongParameterList, TooManyFunctions")
 @HiltViewModel
+@Suppress("LongParameterList, TooManyFunctions")
 class SharedCallingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val navigationManager: NavigationManager,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -98,8 +98,9 @@ class SharedCallingViewModel @Inject constructor(
         currentScreenManager.observeCurrentScreen(viewModelScope).collect {
             if (it == CurrentScreen.InBackground) {
                 pauseVideo()
-            } else if (it == CurrentScreen.OngoingCallScreen(conversationId))
+            } else if (it == CurrentScreen.OngoingCallScreen(conversationId)) {
                 unPauseVideo()
+            }
         }
     }
 
@@ -251,8 +252,9 @@ class SharedCallingViewModel @Inject constructor(
         viewModelScope.launch {
             // We should turn on video only for established call
             callState.isCameraOn?.let {
-                if (it && callState.participants.isNotEmpty())
+                if (it && callState.participants.isNotEmpty()) {
                     updateVideoState(conversationId, VideoState.STARTED)
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList, TooManyFunctions")
 @HiltViewModel
 class SharedCallingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -250,8 +250,10 @@ class SharedCallingViewModel @Inject constructor(
     private fun unPauseVideo() {
         viewModelScope.launch {
             // We should turn on video only for established call
-            if (callState.isCameraOn && callState.participants.isNotEmpty())
-                updateVideoState(conversationId, VideoState.STARTED)
+            callState.isCameraOn?.let {
+                if (it && callState.participants.isNotEmpty())
+                    updateVideoState(conversationId, VideoState.STARTED)
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/SharedCallingViewModel.kt
@@ -42,8 +42,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
-@Suppress("LongParameterList, TooManyFunctions")
 class SharedCallingViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val navigationManager: NavigationManager,

--- a/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CurrentScreenManager.kt
@@ -62,12 +62,14 @@ class CurrentScreenManager @Inject constructor() : DefaultLifecycleObserver, Nav
 
 sealed class CurrentScreen {
 
-
     // Some Conversation is opened
     data class Conversation(val id: ConversationId) : CurrentScreen()
 
     // Another User Profile Screen is opened
     data class OtherUserProfile(val id: QualifiedID) : CurrentScreen()
+
+    // Ongoing call screen is opened
+    data class OngoingCallScreen(val id: QualifiedID) : CurrentScreen()
 
     // Some other screen is opened, kinda "do nothing screen"
     object SomeOther : CurrentScreen()
@@ -90,6 +92,12 @@ sealed class CurrentScreen {
                     arguments?.getString(EXTRA_USER_ID)
                         ?.toQualifiedID(qualifiedIdMapper)
                         ?.let { OtherUserProfile(it) }
+                        ?: SomeOther
+                }
+                NavigationItem.OngoingCall -> {
+                    arguments?.getString(EXTRA_CONVERSATION_ID)
+                        ?.toQualifiedID(qualifiedIdMapper)
+                        ?.let { OngoingCallScreen(it) }
                         ?: SomeOther
                 }
                 else -> SomeOther

--- a/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/calling/SharedCallingViewModelTest.kt
@@ -207,7 +207,6 @@ class SharedCallingViewModelTest {
 
         runTest { sharedCallingViewModel.clearVideoPreview() }
 
-        coVerify(exactly = 1) { setVideoPreview(any(), any()) }
         coVerify(exactly = 1) { updateVideoState(any(), VideoState.STOPPED) }
     }
 
@@ -219,7 +218,6 @@ class SharedCallingViewModelTest {
 
         runTest { sharedCallingViewModel.pauseVideo() }
 
-        coVerify(exactly = 1) { setVideoPreview(any(), any()) }
         coVerify(exactly = 1) { updateVideoState(any(), VideoState.PAUSED) }
     }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1825" title="AR-1825" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1825</a>  1:1 calling - Take app to background and foreground again, video stays paused
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Self video stays paused when moving the app into foreground in video call

### Causes (Optional)

We are not enabling the video again when the app return into foreground

### Solutions

Check if the app is back in the ongoing call screen and there is an established call then we turn on video


Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

Start a call
Turn on your video
Put app in background
Return it into foreground from task manager
Video should be turned on again

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
