### PR TITLE
fix(logout): delete invalid logout session after navigation

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -70,7 +70,12 @@ open class LoginViewModel @Inject constructor(
                     if (it.session is AuthSession.Session.Invalid) {
                         with(it.session as AuthSession.Session.Invalid) {
                             val loginError = when (this.reason) {
-                                LogoutReason.SELF_LOGOUT -> LoginError.None
+                                LogoutReason.SELF_LOGOUT -> {
+                                    userSessionsUseCaseFactory.create().sessionsUseCase
+                                        .deleteInvalidSession(userId)
+                                    LoginError.None
+                                }
+
                                 LogoutReason.REMOVED_CLIENT -> LoginError.DialogError.InvalidSession.RemovedClient
                                 LogoutReason.DELETED_ACCOUNT -> LoginError.DialogError.InvalidSession.DeletedAccount
                                 LogoutReason.SESSION_EXPIRED -> LoginError.DialogError.InvalidSession.SessionExpired


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
When the user does the logout, we set the user-session as Invalid within the Reason that is SelfLogout, then based on the value of the Session, we redirect the user to the login page.
For other sessions like client-removed, user-deleted, and session-expired, we delete the session after showing the user a dialog and the reason. But for self-logout, since we don't show any dialogs after logout, the session will be there forever!

### Issues

The session lived forever, and when the user opened the app, the user was redirected to the login page because the session still was there.

### Causes (Optional)



### Solutions

Clear the invalid-self-logout-session after redirecting the user to the login page.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing
After self-logout and opening, the app [NOT from the background], the app should start with the welcome page, not the login page.

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
