### PR TITLE
fix: back press after opening message notification and initial name [AR-2057]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -86,9 +86,6 @@ class WireActivityViewModel @Inject constructor(
         when {
             shouldGoToLogin() -> NavigationItem.Login.getRouteWithArgs()
             shouldGoToWelcome() -> NavigationItem.Welcome.getRouteWithArgs()
-            shouldGoToIncomingCall() -> NavigationItem.Home.getRouteWithArgs()
-            shouldGoToConversation() -> NavigationItem.Home.getRouteWithArgs()
-            shouldGoToOtherProfile() -> NavigationItem.Home.getRouteWithArgs()
             else -> NavigationItem.Home.getRouteWithArgs()
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -86,9 +86,9 @@ class WireActivityViewModel @Inject constructor(
         when {
             shouldGoToLogin() -> NavigationItem.Login.getRouteWithArgs()
             shouldGoToWelcome() -> NavigationItem.Welcome.getRouteWithArgs()
-            shouldGoToIncomingCall() -> NavigationItem.IncomingCall.getRouteWithArgs()
-            shouldGoToConversation() -> NavigationItem.Conversation.getRouteWithArgs()
-            shouldGoToOtherProfile() -> NavigationItem.OtherUserProfile.getRouteWithArgs()
+            shouldGoToIncomingCall() -> NavigationItem.Home.getRouteWithArgs()
+            shouldGoToConversation() -> NavigationItem.Home.getRouteWithArgs()
+            shouldGoToOtherProfile() -> NavigationItem.Home.getRouteWithArgs()
             else -> NavigationItem.Home.getRouteWithArgs()
         }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -55,6 +55,7 @@ import com.wire.android.ui.home.conversationslist.common.GroupConversationAvatar
 import com.wire.android.ui.home.messagecomposer.MessageComposeInputState
 import com.wire.android.ui.home.messagecomposer.MessageComposer
 import com.wire.android.util.permission.rememberCallingRecordAudioBluetoothRequestFlow
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.user.UserId
 import kotlinx.coroutines.launch
 import okio.Path
@@ -187,7 +188,7 @@ private fun ConversationScreen(
                 Scaffold(
                     topBar = {
                         ConversationScreenTopAppBar(
-                            title = conversationName.ifEmpty { stringResource(id = R.string.member_name_deleted_label) },
+                            title = conversationName.asString(),
                             avatar = {
                                 when (conversationAvatar) {
                                     is ConversationAvatar.Group ->
@@ -371,7 +372,7 @@ fun MessageList(
 fun ConversationScreenPreview() {
     ConversationScreen(
         conversationViewState = ConversationViewState(
-            conversationName = "Some test conversation",
+            conversationName = UIText.DynamicString("Some test conversation"),
             messages = getMockedMessages(),
         ),
         onMessageChanged = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.model.ImageAsset.PrivateAsset
 import com.wire.android.model.ImageAsset.UserAvatarAsset
@@ -33,7 +34,9 @@ import com.wire.android.ui.home.conversations.usecase.GetMessagesForConversation
 import com.wire.android.util.FileManager
 import com.wire.android.util.ImageUtil
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.android.util.ui.toUIText
 import com.wire.kalium.logic.StorageFailure
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.conversation.ConversationDetails
@@ -158,6 +161,9 @@ class ConversationViewModel @Inject constructor(
         val conversationName = when (conversationDetails) {
             is ConversationDetails.OneOne -> conversationDetails.otherUser.name.orEmpty()
             else -> conversationDetails.conversation.name.orEmpty()
+        }.let {
+            if (it.isNotEmpty()) it.toUIText()
+            else UIText.StringResource(R.string.member_name_deleted_label)
         }
         val conversationAvatar = when (conversationDetails) {
             is ConversationDetails.OneOne ->

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewState.kt
@@ -2,6 +2,7 @@ package com.wire.android.ui.home.conversations
 
 import com.wire.android.model.ImageAsset.UserAvatarAsset
 import com.wire.android.ui.home.conversations.model.UIMessage
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
@@ -10,7 +11,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.id.QualifiedID as ConversationId
 
 data class ConversationViewState(
-    val conversationName: String = "",
+    val conversationName: UIText = UIText.DynamicString(""),
     val conversationDetailsData: ConversationDetailsData = ConversationDetailsData.None,
     val conversationAvatar: ConversationAvatar = ConversationAvatar.None,
     val messages: List<UIMessage> = emptyList(),

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -5,6 +5,7 @@ import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.di.AuthServerConfigProvider
+import com.wire.android.navigation.BackStackMode
 import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
@@ -13,8 +14,8 @@ import com.wire.android.util.deeplink.DeepLinkProcessor
 import com.wire.android.util.deeplink.DeepLinkResult
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.user.UserId
-import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.AuthSession
 import com.wire.kalium.logic.feature.server.GetServerConfigResult
 import com.wire.kalium.logic.feature.server.GetServerConfigUseCase
@@ -100,7 +101,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is IncomingCall`() {
+    fun `given Intent with IncomingCall, when currentSession is present, then startNavigation is Home`() {
         val (_, viewModel) = Arrangement()
             .withSomeCurrentSession()
             .withDeepLinkResult(DeepLinkResult.IncomingCall(ConversationId("val", "dom")))
@@ -108,12 +109,12 @@ class WireActivityViewModelTest {
 
         viewModel.handleDeepLink(mockedIntent())
 
-        assertEquals(NavigationItem.IncomingCall.getRouteWithArgs(), viewModel.startNavigationRoute())
+        assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
         assert(viewModel.navigationArguments().filterIsInstance<ConversationId>().isNotEmpty())
     }
 
     @Test
-    fun `given Intent with IncomingCall, when currentSession is absent, then startNavigation is IncomingCall`() {
+    fun `given Intent with IncomingCall, when currentSession is absent, then startNavigation is Welcome`() {
         val (_, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.IncomingCall(ConversationId("val", "dom")))
@@ -160,6 +161,144 @@ class WireActivityViewModelTest {
         val (arrangement, viewModel) = Arrangement()
             .withNoCurrentSession()
             .withDeepLinkResult(DeepLinkResult.IncomingCall(conversationId))
+            .arrange()
+
+        val shouldReCreate = viewModel.handleDeepLinkOnNewIntent(mockedIntent())
+
+        assert(shouldReCreate)
+        coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
+    }
+
+    @Test
+    fun `given Intent with OpenConversation, when currentSession is present, then startNavigation is Home`() {
+        val (_, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenConversation(ConversationId("val", "dom")))
+            .arrange()
+
+        viewModel.handleDeepLink(mockedIntent())
+
+        assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
+        assert(viewModel.navigationArguments().filterIsInstance<ConversationId>().isNotEmpty())
+    }
+
+    @Test
+    fun `given Intent with OpenConversation, when currentSession is absent, then startNavigation is Welcome`() {
+        val (_, viewModel) = Arrangement()
+            .withNoCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenConversation(ConversationId("val", "dom")))
+            .arrange()
+
+        viewModel.handleDeepLink(mockedIntent())
+
+        assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
+    }
+
+    @Test
+    fun `given OpenConversation Intent, when currentSession is there AND activity was created from history, then startNavigation is Home`() {
+        val (_, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenConversation(ConversationId("val", "dom")))
+            .arrange()
+
+        viewModel.handleDeepLink(mockedIntent(true))
+
+        assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
+    }
+
+    @Test
+    fun `given OpenConversation newIntent, when currentSession is present, then no recreation and navigate to Conversation is called`() {
+        val conversationId = ConversationId("val", "dom")
+        val (arrangement, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenConversation(conversationId))
+            .arrange()
+
+        val shouldReCreate = viewModel.handleDeepLinkOnNewIntent(mockedIntent())
+
+        assert(!shouldReCreate)
+        coVerify(exactly = 1) {
+            arrangement.navigationManager.navigate(
+                NavigationCommand(NavigationItem.Conversation.getRouteWithArgs(listOf(conversationId)), BackStackMode.UPDATE_EXISTED)
+            )
+        }
+    }
+
+    @Test
+    fun `given newIntent with OpenConversation, when currentSession is absent, then should recreate and navigate no any navigation`() {
+        val conversationId = ConversationId("val", "dom")
+        val (arrangement, viewModel) = Arrangement()
+            .withNoCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenConversation(conversationId))
+            .arrange()
+
+        val shouldReCreate = viewModel.handleDeepLinkOnNewIntent(mockedIntent())
+
+        assert(shouldReCreate)
+        coVerify(exactly = 0) { arrangement.navigationManager.navigate(any()) }
+    }
+
+    @Test
+    fun `given Intent with OpenOtherUser, when currentSession is present, then startNavigation is Home`() {
+        val (_, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenOtherUserProfile(QualifiedID("val", "dom")))
+            .arrange()
+
+        viewModel.handleDeepLink(mockedIntent())
+
+        assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
+        assert(viewModel.navigationArguments().filterIsInstance<QualifiedID>().isNotEmpty())
+    }
+
+    @Test
+    fun `given Intent with OpenOtherUser, when currentSession is absent, then startNavigation is Welcome`() {
+        val (_, viewModel) = Arrangement()
+            .withNoCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenOtherUserProfile(QualifiedID("val", "dom")))
+            .arrange()
+
+        viewModel.handleDeepLink(mockedIntent())
+
+        assertEquals(NavigationItem.Welcome.getRouteWithArgs(), viewModel.startNavigationRoute())
+    }
+
+    @Test
+    fun `given OpenOtherUser Intent, when currentSession is there AND activity was created from history, then startNavigation is Home`() {
+        val (_, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenConversation(QualifiedID("val", "dom")))
+            .arrange()
+
+        viewModel.handleDeepLink(mockedIntent(true))
+
+        assertEquals(NavigationItem.Home.getRouteWithArgs(), viewModel.startNavigationRoute())
+    }
+
+    @Test
+    fun `given OpenOtherUser newIntent, when currentSession is present, then no recreation and navigate to OtherUser is called`() {
+        val userId = QualifiedID("val", "dom")
+        val (arrangement, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenOtherUserProfile(userId))
+            .arrange()
+
+        val shouldReCreate = viewModel.handleDeepLinkOnNewIntent(mockedIntent())
+
+        assert(!shouldReCreate)
+        coVerify(exactly = 1) {
+            arrangement.navigationManager.navigate(
+                NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(userId)), BackStackMode.UPDATE_EXISTED)
+            )
+        }
+    }
+
+    @Test
+    fun `given newIntent with OpenOtherUser, when currentSession is absent, then should recreate and navigate no any navigation`() {
+        val userId = QualifiedID("val", "dom")
+        val (arrangement, viewModel) = Arrangement()
+            .withNoCurrentSession()
+            .withDeepLinkResult(DeepLinkResult.OpenOtherUserProfile(userId))
             .arrange()
 
         val shouldReCreate = viewModel.handleDeepLinkOnNewIntent(mockedIntent())
@@ -218,9 +357,6 @@ class WireActivityViewModelTest {
             coEvery { notificationManager.observeNotificationsAndCalls(any(), any(), any()) } returns Unit
             coEvery { navigationManager.navigate(any()) } returns Unit
         }
-
-        @MockK
-        lateinit var userSessionScope: UserSessionScope
 
         @MockK
         lateinit var currentSessionFlow: CurrentSessionFlowUseCase

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -195,7 +195,7 @@ class WireActivityViewModelTest {
     }
 
     @Test
-    fun `given OpenConversation Intent, when currentSession is there AND activity was created from history, then startNavigation is Home`() {
+    fun `given OpenConversation Intent, when currentSession is there AND activity created from history, then startNavigation is Home`() {
         val (_, viewModel) = Arrangement()
             .withSomeCurrentSession()
             .withDeepLinkResult(DeepLinkResult.OpenConversation(ConversationId("val", "dom")))

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -8,6 +8,8 @@ import com.wire.android.ui.home.conversations.ConversationViewModel.Companion.IM
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.MessageSource
+import com.wire.android.util.EMPTY
+import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.team.Team
@@ -141,7 +143,11 @@ class ConversationsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(oneToOneConversationDetails.otherUser.name, viewModel.conversationViewState.conversationName)
+        assert(viewModel.conversationViewState.conversationName is UIText.DynamicString)
+        assertEquals(
+            oneToOneConversationDetails.otherUser.name,
+            (viewModel.conversationViewState.conversationName as UIText.DynamicString).value
+        )
     }
 
     @Test
@@ -154,7 +160,11 @@ class ConversationsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(groupConversationDetails.conversation.name, viewModel.conversationViewState.conversationName)
+        assert(viewModel.conversationViewState.conversationName is UIText.DynamicString)
+        assertEquals(
+            groupConversationDetails.conversation.name,
+            (viewModel.conversationViewState.conversationName as UIText.DynamicString).value
+        )
     }
 
     @Test
@@ -170,11 +180,47 @@ class ConversationsViewModelTest {
             .arrange()
 
         // When - Then
-        assertEquals(firstConversationDetails.conversation.name, viewModel.conversationViewState.conversationName)
+        assert(viewModel.conversationViewState.conversationName is UIText.DynamicString)
+        assertEquals(
+            firstConversationDetails.conversation.name,
+            (viewModel.conversationViewState.conversationName as UIText.DynamicString).value
+        )
 
         // When - Then
         arrangement.withConversationDetailUpdate(conversationDetails = secondConversationDetails)
-        assertEquals(secondConversationDetails.conversation.name, viewModel.conversationViewState.conversationName)
+        assert(viewModel.conversationViewState.conversationName is UIText.DynamicString)
+        assertEquals(
+            secondConversationDetails.conversation.name,
+            (viewModel.conversationViewState.conversationName as UIText.DynamicString).value
+        )
+    }
+
+    @Test
+    fun `given the initial state, when solving the conversation name before the data is received, the name should be an empty string`() =
+        runTest {
+            // Given
+            val (_, viewModel) = ConversationsViewModelArrangement()
+                .withSuccessfulViewModelInit()
+                .arrange()
+
+            // When - Then
+            assert(viewModel.conversationViewState.conversationName is UIText.DynamicString)
+            assertEquals(String.EMPTY, (viewModel.conversationViewState.conversationName as UIText.DynamicString).value)
+        }
+
+    @Test
+    fun `given a 1 on 1 conversation, when the user is deleted, then the name of the conversation should be a string resource`() = runTest {
+        // Given
+        val oneToOneConversationDetails = withMockConversationDetailsOneOnOne("")
+        val (_, viewModel) = ConversationsViewModelArrangement()
+            .withSuccessfulViewModelInit()
+            .withConversationDetailUpdate(
+                conversationDetails = oneToOneConversationDetails
+            )
+            .arrange()
+
+        // When - Then
+        assert(viewModel.conversationViewState.conversationName is UIText.StringResource)
     }
 
     @Test
@@ -284,7 +330,7 @@ class ConversationsViewModelTest {
     @Test
     fun `given a 1 on 1 conversation, when solving the conversation avatar, then the avatar of the other user is used`() = runTest {
         // Given
-        val conversationDetails = withMockConversationDetailsOneOnOne("",  ConversationId("userAssetId", "domain"))
+        val conversationDetails = withMockConversationDetailsOneOnOne("", ConversationId("userAssetId", "domain"))
         val otherUserAvatar = conversationDetails.otherUser.previewPicture
         val (_, viewModel) = ConversationsViewModelArrangement()
             .withSuccessfulViewModelInit()
@@ -402,71 +448,71 @@ class ConversationsViewModelTest {
 
     @Test
     fun `given self user 1on1 message, when clicking on avatar, then open self profile`() = runTest {
-            // Given
-            val oneOneDetails = withMockConversationDetailsOneOnOne("Other User Name Goes Here")
-            val messageSource = MessageSource.Self
-            val userId = UserId("id", "domain")
-            val (arrangement, viewModel) = ConversationsViewModelArrangement()
-                .withConversationDetailUpdate(oneOneDetails)
-                .arrange()
-            // When
-            viewModel.navigateToProfile(messageSource, userId)
-            // Then
-            coVerify(exactly = 1) {
-                arrangement.navigationManager.navigate(NavigationCommand(NavigationItem.SelfUserProfile.getRouteWithArgs()))
-            }
+        // Given
+        val oneOneDetails = withMockConversationDetailsOneOnOne("Other User Name Goes Here")
+        val messageSource = MessageSource.Self
+        val userId = UserId("id", "domain")
+        val (arrangement, viewModel) = ConversationsViewModelArrangement()
+            .withConversationDetailUpdate(oneOneDetails)
+            .arrange()
+        // When
+        viewModel.navigateToProfile(messageSource, userId)
+        // Then
+        coVerify(exactly = 1) {
+            arrangement.navigationManager.navigate(NavigationCommand(NavigationItem.SelfUserProfile.getRouteWithArgs()))
         }
+    }
 
     @Test
     fun `given self user group message, when clicking on avatar, then open self profile`() = runTest {
-            // Given
-            val groupDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
-            val messageSource = MessageSource.Self
-            val userId = UserId("id", "domain")
-            val (arrangement, viewModel) = ConversationsViewModelArrangement()
-                .withConversationDetailUpdate(groupDetails)
-                .arrange()
-            // When
-            viewModel.navigateToProfile(messageSource, userId)
-            // Then
-            coVerify(exactly = 1) {
-                arrangement.navigationManager.navigate(NavigationCommand(NavigationItem.SelfUserProfile.getRouteWithArgs()))
-            }
+        // Given
+        val groupDetails = mockConversationDetailsGroup("Conversation Name Goes Here")
+        val messageSource = MessageSource.Self
+        val userId = UserId("id", "domain")
+        val (arrangement, viewModel) = ConversationsViewModelArrangement()
+            .withConversationDetailUpdate(groupDetails)
+            .arrange()
+        // When
+        viewModel.navigateToProfile(messageSource, userId)
+        // Then
+        coVerify(exactly = 1) {
+            arrangement.navigationManager.navigate(NavigationCommand(NavigationItem.SelfUserProfile.getRouteWithArgs()))
         }
+    }
 
     @Test
     fun `given other user 1on1 message, when clicking on avatar, then open other user profile without group data`() = runTest {
-            // Given
-            val oneOneDetails: ConversationDetails.OneOne = withMockConversationDetailsOneOnOne("Other User Name Goes Here")
-            val messageSource = MessageSource.OtherUser
-            val userId = UserId("id", "domain")
-            val (arrangement, viewModel) = ConversationsViewModelArrangement()
-                .withConversationDetailUpdate(oneOneDetails)
-                .arrange()
-            // When
-            viewModel.navigateToProfile(messageSource, userId)
-            // Then
-            coVerify(exactly = 1) {
-                arrangement.navigationManager.navigate(NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(userId))))
-            }
+        // Given
+        val oneOneDetails: ConversationDetails.OneOne = withMockConversationDetailsOneOnOne("Other User Name Goes Here")
+        val messageSource = MessageSource.OtherUser
+        val userId = UserId("id", "domain")
+        val (arrangement, viewModel) = ConversationsViewModelArrangement()
+            .withConversationDetailUpdate(oneOneDetails)
+            .arrange()
+        // When
+        viewModel.navigateToProfile(messageSource, userId)
+        // Then
+        coVerify(exactly = 1) {
+            arrangement.navigationManager.navigate(NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(userId))))
         }
+    }
 
     @Test
     fun `given other user group message, when clicking on avatar, then open other user profile with group data`() = runTest {
-            // Given
-            val groupDetails: ConversationDetails.Group = mockConversationDetailsGroup("Conversation Name Goes Here")
-            val messageSource = MessageSource.OtherUser
-            val userId = UserId("id", "domain")
-            val (arrangement, viewModel) = ConversationsViewModelArrangement()
-                .withConversationDetailUpdate(groupDetails)
-                .arrange()
-            // When
-            viewModel.navigateToProfile(messageSource, userId)
-            // Then
-            coVerify(exactly = 1) {
-                arrangement.navigationManager.navigate(
-                    NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(userId, arrangement.conversationId)))
-                )
-            }
+        // Given
+        val groupDetails: ConversationDetails.Group = mockConversationDetailsGroup("Conversation Name Goes Here")
+        val messageSource = MessageSource.OtherUser
+        val userId = UserId("id", "domain")
+        val (arrangement, viewModel) = ConversationsViewModelArrangement()
+            .withConversationDetailUpdate(groupDetails)
+            .arrange()
+        // When
+        viewModel.navigateToProfile(messageSource, userId)
+        // Then
+        coVerify(exactly = 1) {
+            arrangement.navigationManager.navigate(
+                NavigationCommand(NavigationItem.OtherUserProfile.getRouteWithArgs(listOf(userId, arrangement.conversationId)))
+            )
         }
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2057" title="AR-2057" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2057</a>  Strange behavior on clicking Back button
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When opening the app from the message notification and going back (by clicking on system back button or top bar back arrow button) the app closes instead of navigating to "home" screen.
The 1:1 conversation name is "Deleted User" briefly before the actual data is loaded.

### Causes (Optional)

When clicking on message notification and the app is closed, the app navigation stack is created from scratch and start screen is set to be "conversation" screen so there is no screen to navigate back to.
When the name of user is empty, "Deleted User" resource string is used.

### Solutions

Choose "home" screen to be the first one when opening the app with deep link (call, message, open user profile), this way we can go back and opening the proper destination screen is then handled by the navigation itself because we set the `NavDeepLink` for these screens.
Using empty string as an initial conversation state, only when we get the data from use case, set "Deleted User" resource string if the name is empty.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Swipe out the app, open it from the message notification and navigate back.

### Attachments (Optional)

https://user-images.githubusercontent.com/30429749/183673705-aa8aa831-f67f-4c6d-a003-53bda39362e3.mp4

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
