### PR TITLE
feat: implement leave group

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/MessageContentMapper.kt
@@ -79,10 +79,7 @@ class MessageContentMapper @Inject constructor(
     ): UIMessageContent.SystemMessage? {
         val sender = userList.findUser(userId = senderUserId)
         val isAuthorSelfAction = content.members.size == 1 && senderUserId == content.members.first()
-        val authorName = toSystemMessageMemberName(
-            user = sender,
-            type = SelfNameType.ResourceTitleCase
-        )
+        val authorName = toSystemMessageMemberName(user = sender, type = SelfNameType.ResourceTitleCase)
         val memberNameList = content.members.map {
             toSystemMessageMemberName(
                 user = userList.findUser(userId = it),
@@ -94,21 +91,13 @@ class MessageContentMapper @Inject constructor(
                 if (isAuthorSelfAction) {
                     null // we don't want to show "You added you to the conversation"
                 } else {
-                    UIMessageContent.SystemMessage.MemberAdded(
-                        author = authorName,
-                        memberNames = memberNameList
-                    )
+                    UIMessageContent.SystemMessage.MemberAdded(author = authorName, memberNames = memberNameList)
                 }
             is Removed ->
                 if (isAuthorSelfAction) {
-                    UIMessageContent.SystemMessage.MemberLeft(
-                        author = authorName
-                    )
+                    UIMessageContent.SystemMessage.MemberLeft(author = authorName)
                 } else {
-                    UIMessageContent.SystemMessage.MemberRemoved(
-                        author = authorName,
-                        memberNames = memberNameList
-                    )
+                    UIMessageContent.SystemMessage.MemberRemoved(author = authorName, memberNames = memberNameList)
                 }
         }
     }
@@ -116,11 +105,7 @@ class MessageContentMapper @Inject constructor(
     private suspend fun mapRegularMessage(
         message: Message.Regular,
     ) = when (val content = message.content) {
-        is Asset -> toAsset(
-            conversationId = message.conversationId,
-            messageId = message.id,
-            assetContent = content.value
-        )
+        is Asset -> toAsset(conversationId = message.conversationId, messageId = message.id, assetContent = content.value)
         is MessageContent.RestrictedAsset -> toRestrictedAsset(content.mimeType, content.sizeInBytes, content.name)
         else -> toText(content)
     }

--- a/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/UserProfileAvatar.kt
@@ -30,6 +30,7 @@ import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.util.getUriFromDrawable
+import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 
 @Composable
 fun UserProfileAvatar(
@@ -81,5 +82,5 @@ private fun painter(userAvatarAsset: UserAvatarAsset?): Painter =
 @Preview
 @Composable
 fun UserProfileAvatarPreview() {
-    UserProfileAvatar()
+    UserProfileAvatar(UserAvatarData(availabilityStatus = UserAvailabilityStatus.AVAILABLE))
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/details/GroupConversationDetailsViewModelTest.kt
@@ -303,6 +303,7 @@ class GroupConversationDetailsViewModelTest {
                 teamId = TeamId("team_id"),
                 protocol = Conversation.ProtocolInfo.Proteus,
                 mutedStatus = MutedConversationStatus.AllAllowed,
+                removedBy = null,
                 lastNotificationDate = null,
                 lastModifiedDate = null,
                 access = listOf(Conversation.Access.CODE, Conversation.Access.INVITE),

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -233,6 +233,7 @@ class MediaGalleryViewModelTest {
                 teamId = null,
                 protocol = Conversation.ProtocolInfo.Proteus,
                 mutedStatus = AllAllowed,
+                removedBy = null,
                 lastNotificationDate = null,
                 lastModifiedDate = null,
                 lastReadDate = "2022-04-04T16:11:28.388Z",

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -105,6 +105,7 @@ internal class NewConversationViewModelArrangement {
             teamId = null,
             protocol = Conversation.ProtocolInfo.Proteus,
             mutedStatus = MutedConversationStatus.AllAllowed,
+            removedBy = null,
             lastNotificationDate = null,
             lastModifiedDate = null,
             lastReadDate = "2022-04-04T16:11:28.388Z",

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -369,6 +369,7 @@ class OtherUserProfileScreenViewModelTest {
             teamId = null,
             protocol = Conversation.ProtocolInfo.Proteus,
             mutedStatus = MutedConversationStatus.AllAllowed,
+            removedBy = null,
             lastNotificationDate = null,
             lastModifiedDate = null,
             lastReadDate = "2022-04-04T16:11:28.388Z",


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ x answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

This PR updates the reference to Kalium submodule to be able to access the `removedBy` field needed to provide information on how a user left a group (voluntarily or removed by some other admin)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
