### PR TITLE
fix: connection policy being downgraded when app is in foreground

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -69,7 +69,7 @@ class ConnectionPolicyManager @Inject constructor(
             // Wait until the client is live and pending events are processed
             logger.d("Waiting until live")
             syncManager.waitUntilLive()
-            logger.d("Downgrading policy back if needed")
+            logger.d("Checking if downgrading policy is needed")
             downgradePolicyIfNeeded(userId)
         }
     }

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManager.kt
@@ -1,12 +1,17 @@
 package com.wire.android.util.lifecycle
 
+import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.sync.ConnectionPolicy
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.functional.flatMap
+import com.wire.kalium.logic.functional.fold
 import com.wire.kalium.logic.functional.map
 import com.wire.kalium.logic.functional.onSuccess
 import kotlinx.coroutines.CoroutineScope
@@ -32,6 +37,8 @@ class ConnectionPolicyManager @Inject constructor(
     private val dispatcherProvider: DispatcherProvider
 ) {
 
+    private val logger = appLogger.withFeatureId(SYNC)
+
     /**
      * Starts observing the app state and take action.
      */
@@ -43,6 +50,57 @@ class ConnectionPolicyManager @Inject constructor(
                 }
             }
         }
+    }
+
+    /**
+     * When a push notification is received for a [userId], this will
+     * upgrade the policy to [ConnectionPolicy.KEEP_ALIVE] and suspend
+     * until the client is online.
+     *
+     * Depending on the current screen and the active session,
+     * this will downgrade the policy back to [ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS].
+     */
+    suspend fun handleConnectionOnPushNotification(userId: UserId) {
+        logger.d("Handling connection policy for push notification of user=$userId")
+        coreLogic.getSessionScope(userId).run {
+            logger.d("Forcing KEEP_ALIVE policy")
+            // Force KEEP_ALIVE policy, so we gather pending events and become online
+            setConnectionPolicy(ConnectionPolicy.KEEP_ALIVE)
+            // Wait until the client is live and pending events are processed
+            logger.d("Waiting until live")
+            syncManager.waitUntilLive()
+            logger.d("Downgrading policy back if needed")
+            downgradePolicyIfNeeded(userId)
+        }
+    }
+
+    /**
+     * If the app has initialised the UI (was in the foreground at least once),
+     * and the session at hands is the currently active session, then we can keep
+     * the [ConnectionPolicy.KEEP_ALIVE] policy.
+     * Otherwise, we downgrade to [ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS].
+     */
+    private fun UserSessionScope.downgradePolicyIfNeeded(
+        userId: UserId
+    ) {
+        val isCurrentSession = isCurrentSession(userId)
+        val hasInitialisedUI = currentScreenManager.appWasVisibleAtLeastOnceFlow().value
+        logger.d("isCurrentSession = $isCurrentSession; hasInitialisedUI = $isCurrentSession")
+        val shouldKeepLivePolicy = isCurrentSession && hasInitialisedUI
+        if (!shouldKeepLivePolicy) {
+            logger.d("Downgrading policy as conditions to KEEP_ALIVE are not met")
+            setConnectionPolicy(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+        }
+    }
+
+    private fun isCurrentSession(userId: UserId): Boolean {
+        val isCurrentSession = coreLogic.sessionRepository.currentSession().fold({
+            // Assume so in case of failure
+            true
+        }, {
+            it.session.userId == userId
+        })
+        return isCurrentSession
     }
 
     private fun setPolicyForSessions(

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -67,7 +67,6 @@ class WireNotificationManagerTest {
 
         verify(atLeast = 1) { arrangement.coreLogic.getSessionScope(any()) }
         coVerify(exactly = 1) { arrangement.connectionPolicyManager.handleConnectionOnPushNotification(TEST_AUTH_SESSION.session.userId) }
-        coVerify(exactly = 1) { arrangement.syncManager.waitUntilLive() }
         verify(exactly = 1) { arrangement.messageNotificationManager.handleNotification(listOf(), any()) }
         verify(exactly = 1) { arrangement.callNotificationManager.handleNotifications(listOf(), any()) }
     }

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/ConnectionPolicyManagerTest.kt
@@ -1,0 +1,168 @@
+package com.wire.android.util.lifecycle
+
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.util.CurrentScreenManager
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.session.SessionRepository
+import com.wire.kalium.logic.data.sync.ConnectionPolicy
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.auth.AuthSession
+import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.sync.SetConnectionPolicyUseCase
+import com.wire.kalium.logic.sync.SyncManager
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class ConnectionPolicyManagerTest {
+
+    @Test
+    fun givenCurrentlyActiveSessionAndInitialisedUI_whenHandlingPushNotification_thenShouldNotDowngradePolicy() = runTest {
+        val user = USER_ID
+
+        val (arrangement, connectionPolicyManager) = Arrangement()
+            .withCurrentSession(user)
+            .withUiInitialized()
+            .arrange()
+
+        connectionPolicyManager.handleConnectionOnPushNotification(user)
+
+        coVerify(exactly = 0) { arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS) }
+    }
+
+    @Test
+    fun givenCurrentlyActiveSessionAndInitialisedUI_whenHandlingPushNotification_thenShouldUpgradePolicyThenWait() = runTest {
+        val user = USER_ID
+
+        val (arrangement, connectionPolicyManager) = Arrangement()
+            .withCurrentSession(user)
+            .withUiInitialized()
+            .arrange()
+
+        connectionPolicyManager.handleConnectionOnPushNotification(user)
+
+        coVerify(exactly = 1) {
+            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
+            arrangement.syncManager.waitUntilLive()
+        }
+    }
+
+    @Test
+    fun givenCurrentlyActiveSessionAndNotInitialisedUI_whenHandlingPushNotification_thenShouldUpgradeThenWaitThenDowngrade() = runTest {
+        val user = USER_ID
+
+        val (arrangement, connectionPolicyManager) = Arrangement()
+            .withCurrentSession(user)
+            .withUiNotInitialized()
+            .arrange()
+
+        connectionPolicyManager.handleConnectionOnPushNotification(user)
+
+        coVerify(exactly = 1) {
+            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
+            arrangement.syncManager.waitUntilLive()
+            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+        }
+    }
+
+    @Test
+    fun givenCurrentlyInactiveSessionAndInitialisedUI_whenHandlingPushNotification_thenShouldUpgradeThenWaitThenDowngrade() = runTest {
+        val user = USER_ID
+
+        val (arrangement, connectionPolicyManager) = Arrangement()
+            .withCurrentSession(USER_ID_2)
+            .withUiInitialized()
+            .arrange()
+
+        connectionPolicyManager.handleConnectionOnPushNotification(user)
+
+        coVerify(exactly = 1) {
+            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
+            arrangement.syncManager.waitUntilLive()
+            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+        }
+    }
+
+    @Test
+    fun givenNotCurrentAccountAndNotInitialisedUI_whenHandlingPushNotification_thenShouldUpgradeThenWaitThenDowngradePolicy() = runTest {
+        val user = USER_ID
+
+        val (arrangement, connectionPolicyManager) = Arrangement()
+            .withCurrentSession(USER_ID_2)
+            .withUiNotInitialized()
+            .arrange()
+
+        connectionPolicyManager.handleConnectionOnPushNotification(user)
+
+        coVerifyOrder {
+            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.KEEP_ALIVE)
+            arrangement.syncManager.waitUntilLive()
+            arrangement.setConnectionPolicyUseCase.invoke(ConnectionPolicy.DISCONNECT_AFTER_PENDING_EVENTS)
+        }
+    }
+
+    private class Arrangement {
+
+        @MockK
+        lateinit var currentScreenManager: CurrentScreenManager
+
+        @MockK
+        lateinit var coreLogic: CoreLogic
+
+        @MockK
+        lateinit var userSessionScope: UserSessionScope
+
+        @MockK
+        lateinit var setConnectionPolicyUseCase: SetConnectionPolicyUseCase
+
+        @MockK
+        lateinit var syncManager: SyncManager
+
+        @MockK
+        lateinit var sessionRepository: SessionRepository
+
+        private val connectionPolicyManager by lazy {
+            ConnectionPolicyManager(currentScreenManager, coreLogic, TestDispatcherProvider())
+        }
+
+        init {
+            MockKAnnotations.init(this, relaxUnitFun = true)
+
+            every { coreLogic.sessionRepository } returns sessionRepository
+            every { coreLogic.getSessionScope(USER_ID) } returns userSessionScope
+            every { userSessionScope.setConnectionPolicy } returns setConnectionPolicyUseCase
+            every { userSessionScope.syncManager } returns syncManager
+        }
+
+        fun withUiNotInitialized() = apply {
+            every { currentScreenManager.appWasVisibleAtLeastOnceFlow() } returns MutableStateFlow(false)
+        }
+
+        fun withUiInitialized() = apply {
+            every { currentScreenManager.appWasVisibleAtLeastOnceFlow() } returns MutableStateFlow(true)
+        }
+
+        fun withCurrentSession(userId: UserId) = apply {
+            val authSession: AuthSession = mockk()
+            val session: AuthSession.Session = mockk()
+            every { authSession.session } returns session
+            every { session.userId } returns userId
+            every { sessionRepository.currentSession() } returns Either.Right(authSession)
+        }
+
+        fun arrange() = this to connectionPolicyManager
+
+    }
+
+    companion object {
+        private val USER_ID = UserId("user", "domain")
+        private val USER_ID_2 = UserId("user2", "domain2")
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the websocket drops due to unstable internet, and we receive a push notification, the app doesn't keep the connection even if it's in the foreground.

**The same can happen if we receive a push notification and manually open the app right afterwards.**

### Causes

The `WireNotificationManager` is always upgrading the policy and then downgrading, without checking if the app is now in the foreground.

### Solutions

Delegate this responsibility to the `ConnectionPolicyManager`, which has a new function `handleConnectionOnPushNotification`:
- When a push notification is received, `handleConnectionOnPushNotification` is called.
- It will upgrade the policy, wait until live, and depending on criteria will downgrade the policy again or not.

If the user that received the push is the currently active session AND the app is in the foreground, it will keep the policy in `LIVE`.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Forcefully close the application, receive a push notification, and open the app while sync is ongoing in the background.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
