### PR TITLE
chore: add join call button permission

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/JoinButton.kt
@@ -10,11 +10,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import com.wire.android.R
+import com.wire.android.appLogger
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.textfield.WirePrimaryButton
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.permission.rememberCallingRecordAudioBluetoothRequestFlow
 
 @Composable
 fun JoinButton(
@@ -23,8 +25,10 @@ fun JoinButton(
     minHeight: Dp = MaterialTheme.wireDimensions.buttonMinSize.height,
     minWidth: Dp = MaterialTheme.wireDimensions.buttonMinSize.width
 ) {
+    val audioPermissionCheck = AudioBluetoothPermissionCheckFlow { buttonClick() }
+
     WirePrimaryButton(
-        onClick = buttonClick,
+        onClick = { audioPermissionCheck.launch() },
         fillMaxWidth = false,
         shape = RoundedCornerShape(size = MaterialTheme.wireDimensions.corner12x),
         text = stringResource(R.string.calling_button_label_join_call),
@@ -42,6 +46,17 @@ fun JoinButton(
             vertical = dimensions().spacing4x
         )
     )
+}
+
+@Composable
+private fun AudioBluetoothPermissionCheckFlow(
+    onJoinCall: () -> Unit
+) = rememberCallingRecordAudioBluetoothRequestFlow(onAudioBluetoothPermissionGranted = {
+    appLogger.d("Join Call Button - Permissions granted")
+    onJoinCall()
+}) {
+    appLogger.d("Join Call Button - Permissions denied")
+    // TODO: Add a message that user needs permission to join call?
 }
 
 @Preview

--- a/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/JoinButton.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/controlButtons/JoinButton.kt
@@ -28,7 +28,7 @@ fun JoinButton(
     val audioPermissionCheck = AudioBluetoothPermissionCheckFlow { buttonClick() }
 
     WirePrimaryButton(
-        onClick = { audioPermissionCheck.launch() },
+        onClick = audioPermissionCheck::launch,
         fillMaxWidth = false,
         shape = RoundedCornerShape(size = MaterialTheme.wireDimensions.corner12x),
         text = stringResource(R.string.calling_button_label_join_call),

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -76,7 +76,6 @@ fun ConversationScreen(
     val startCallAudioPermissionCheck = StartCallAudioBluetoothPermissionCheckFlow {
         conversationViewModel.navigateToInitiatingCallScreen()
     }
-    val joinCallAudioPermissionCheck = JoinCallAudioBluetoothPermissionCheckFlow(conversationViewModel)
     val uiState = conversationViewModel.conversationViewState
 
     LaunchedEffect(conversationViewModel.savedStateHandle) {
@@ -120,7 +119,7 @@ fun ConversationScreen(
                 startCallAudioPermissionCheck.launch()
             }
         },
-        onJoinCall = joinCallAudioPermissionCheck::launch,
+        onJoinCall = conversationViewModel::joinOngoingCall,
         onSnackbarMessage = conversationViewModel::onSnackbarMessage,
         onSnackbarMessageShown = conversationViewModel::clearSnackbarMessage,
         onDropDownClick = conversationViewModel::navigateToDetails,
@@ -146,14 +145,6 @@ private fun StartCallAudioBluetoothPermissionCheckFlow(
 }) {
     //TODO display an error dialog
 }
-
-@Composable
-private fun JoinCallAudioBluetoothPermissionCheckFlow(conversationViewModel: ConversationViewModel) =
-    rememberCallingRecordAudioBluetoothRequestFlow(onAudioBluetoothPermissionGranted = {
-        conversationViewModel.joinOngoingCall()
-    }) {
-        //TODO display an error dialog
-    }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Suppress("LongParameterList")


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

[AR-2008 - Join call button crashes if there is no given audio permission](https://wearezeta.atlassian.net/browse/AR-2008)

### Issues

App crashed if trying to join an ongoing call through Join Call button in Home Screen (conversations list) and in Conversation list without have given audio permission.

### Causes (Optional)

There was no verification for audio permission.

### Solutions

Add audio permission verification in Join Call Button view component.