### PR TITLE
fix: memory leaking of WireFirebaseMessagingService (AR-1812)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -4,6 +4,7 @@ import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
+import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.extension.intervalFlow
 import com.wire.android.util.lifecycle.ConnectionPolicyManager
 import com.wire.kalium.logic.CoreLogic
@@ -16,9 +17,10 @@ import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.util.toStringDate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -27,6 +29,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -38,14 +42,37 @@ class WireNotificationManager @Inject constructor(
     private val currentScreenManager: CurrentScreenManager,
     private val messagesNotificationManager: MessageNotificationManager,
     private val callNotificationManager: CallNotificationManager,
-    private val connectionPolicyManager: ConnectionPolicyManager
+    private val connectionPolicyManager: ConnectionPolicyManager,
+    dispatcherProvider: DispatcherProvider
 ) {
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.default())
+    private val fetchOnceMutex = Mutex()
+    private val fetchOnceJobs = hashMapOf<String, Job>()
+
     /**
-     * Sync all the Pending events, fetch Message notifications from DB once and show it.
-     * Can be used in Services (e.g., after receiving FCM)
+     * Become online, process all the Pending events,
+     * and display notifications for new events.
+     * Can be used in Services (e.g., after receiving FCM push).
+     *
+     * This function is asynchronous and thread-safe.
+     * It ignores successive calls with the same [userIdValue]
+     * until the first call is finished processing.
      * @param userIdValue String value param of QualifiedID of the User that need to check Notifications for
      */
-    suspend fun fetchAndShowNotificationsOnce(userIdValue: String) {
+    suspend fun fetchAndShowNotificationsOnce(userIdValue: String) = fetchOnceMutex.withLock {
+        val isJobRunningForUser = fetchOnceJobs[userIdValue]?.isActive ?: false
+        if (isJobRunningForUser) {
+            appLogger.d("Already processing notifications for user=$userIdValue, ignoring request")
+        } else {
+            appLogger.d("Starting to processing notifications for user=$userIdValue")
+            fetchOnceJobs[userIdValue] = scope.launch {
+                triggerSyncForUserIfAuthenticated(userIdValue)
+            }
+        }
+    }
+
+    private suspend fun triggerSyncForUserIfAuthenticated(userIdValue: String) {
         checkIfUserIsAuthenticated(userId = userIdValue)?.let { userId ->
             connectionPolicyManager.handleConnectionOnPushNotification(userId)
             fetchAndShowMessageNotificationsOnce(userId)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1812" title="AR-1812" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1812</a>  Memoryleak inside WireFirebaseMessagingService
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

WireFirebaseMessagingService is leaking instances.

### Causes

When the service is destroyed, there may be some coroutines still working, collecting flows, etc.
Ideally, we should consume the `onMessageReceived` quickly and don't hold onto it for long. However we do process it for _some_ time.
With the current bug on Notifications, where we keep collecting ephemeral message notifications indeterminately, this memory leak becomes more apparent.

### Solutions

Wrap the work being done by a `CoroutineScope` that is cancelled when `onDestroy` is called.

This made one existing problem more obvious: It's possible to receive multiple push notifications in a row. This will trigger multiple connection policy upgrades/downgrades (Sync Start/Stop) unnecessarily.

To solve this, `fetchAndShowNotificationsOnce` was adapted to ignore concurrent calls with the same `userIdValue`, until the first call finishes processing the notifications.

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

1. Force-close the app.
2. Send send a few messages to yourself from another device quickly one after the other.

No LeakCanary warnings after some minutes, and no Sync start/stopping multiple times in a row.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
