### PR TITLE
chore: double navigate back initiating call

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallScreen.kt
@@ -42,7 +42,6 @@ fun InitiatingCallScreen(
             toggleMute = ::toggleMute,
             toggleSpeaker = ::toggleSpeaker,
             toggleVideo = ::toggleVideo,
-            onNavigateBack = ::navigateBack,
             onHangUpCall = initiatingCallViewModel::hangUpCall,
             onVideoPreviewCreated = ::setVideoPreview,
             onSelfClearVideoPreview = ::clearVideoPreview
@@ -57,7 +56,6 @@ private fun InitiatingCallContent(
     toggleMute: () -> Unit,
     toggleSpeaker: () -> Unit,
     toggleVideo: () -> Unit,
-    onNavigateBack: () -> Unit,
     onHangUpCall: () -> Unit,
     onVideoPreviewCreated: (view: View) -> Unit,
     onSelfClearVideoPreview: () -> Unit

--- a/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/initiating/InitiatingCallViewModel.kt
@@ -49,6 +49,7 @@ class InitiatingCallViewModel @Inject constructor(
     )
 
     private val callStartTime: Long = Calendar.getInstance().timeInMillis
+    private var wasCallHangUp: Boolean = false
 
     init {
         viewModelScope.launch {
@@ -94,7 +95,7 @@ class InitiatingCallViewModel @Inject constructor(
             conversationId = conversationId,
             startedTime = callStartTime
         ).collect { isCurrentCallClosed ->
-            if (isCurrentCallClosed) {
+            if (isCurrentCallClosed && wasCallHangUp.not()) {
                 onCallClosed()
             }
         }
@@ -124,7 +125,10 @@ class InitiatingCallViewModel @Inject constructor(
         callRinger.ring(R.raw.ringing_from_me)
     }
 
-    fun navigateBack() = viewModelScope.launch { navigationManager.navigateBack() }
+    fun navigateBack() = viewModelScope.launch {
+        wasCallHangUp = true
+        navigationManager.navigateBack()
+    }
 
     fun hangUpCall() {
         viewModelScope.launch {


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When starting a call and hanging up the call / ending the call in InitiatingCallScreen, it would invoke `navigateBack()` twice, then sometimes either closing the app completely or just crashing.

### Causes (Optional)

`navigateBack()` is being called both in `onClosedCall` listener and when clicking the `Hang Up` button.

### Solutions

Add a private variable to check if the hang up button was clicked, if so then we don't invoke `navigateBack()` again from `onClosedCall` listener, thus invoking it only once.

### Testing

#### How to Test

- Open App
- Start a call
- Before anyone answers the call, close/hang up/end the call through the button
- InitiatingCallScreen should be closed (only InitiatingCallScreen, nothing else)