### PR TITLE
fix: handle lack of connectivity when creating group conversations (AR-2146)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationRouter.kt
@@ -62,7 +62,7 @@ fun NewConversationRouter() {
                 content = {
                     NewGroupScreen(
                         onBackPressed = newConversationNavController::popBackStack,
-                        newGroupState = newConversationViewModel.groupNameState,
+                        newGroupState = newConversationViewModel.newGroupState,
                         onGroupNameChange = newConversationViewModel::onGroupNameChange,
                         onContinuePressed = { newConversationNavController.navigate(Screen.GroupOptionsScreen.route) },
                         onGroupNameErrorAnimated = newConversationViewModel::onGroupNameErrorAnimated
@@ -82,7 +82,8 @@ fun NewConversationRouter() {
                         onReadReceiptChanged = newConversationViewModel::onReadReceiptStatusChanged,
                         onAllowGuestsDialogDismissed = newConversationViewModel::onAllowGuestsDialogDismissed,
                         onAllowGuestsClicked = newConversationViewModel::onAllowGuestsClicked,
-                        onNotAllowGuestsClicked = newConversationViewModel::onNotAllowGuestClicked
+                        onNotAllowGuestsClicked = newConversationViewModel::onNotAllowGuestClicked,
+                        onErrorDismissed = newConversationViewModel::onGroupOptionsErrorDismiss
                     )
                 }
             )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionState.kt
@@ -13,5 +13,11 @@ data class GroupOptionState(
     val isAllowServicesEnabled: Boolean = true,
     val isReadReceiptEnabled: Boolean = true,
     val showAllowGuestsDialog: Boolean = false,
-    val accessRoleState: MutableSet<Conversation.AccessRole> = mutableSetOf(TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE)
-)
+    val accessRoleState: MutableSet<Conversation.AccessRole> = mutableSetOf(TEAM_MEMBER, NON_TEAM_MEMBER, GUEST, SERVICE),
+    val error: Error? = null
+) {
+    sealed interface Error {
+        object Unknown : Error
+        object LackingConnection : Error
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -1,6 +1,9 @@
 package com.wire.android.ui.home.newconversation.groupOptions
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -18,7 +21,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
 import com.wire.android.R
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.Icon
@@ -33,6 +35,7 @@ import com.wire.android.ui.home.conversations.details.options.GroupConversationO
 import com.wire.android.ui.home.conversations.details.options.SwitchState
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
+import com.wire.android.util.DialogErrorStrings
 
 @Composable
 fun GroupOptionScreen(
@@ -44,7 +47,8 @@ fun GroupOptionScreen(
     onAllowGuestsDialogDismissed: () -> Unit,
     onNotAllowGuestsClicked: () -> Unit,
     onAllowGuestsClicked: () -> Unit,
-    onBackPressed: () -> Unit
+    onBackPressed: () -> Unit,
+    onErrorDismissed: () -> Unit,
 ) {
     GroupOptionScreenContent(
         groupOptionState = groupOptionState,
@@ -55,7 +59,8 @@ fun GroupOptionScreen(
         onBackPressed = onBackPressed,
         onAllowGuestsDialogDismissed = onAllowGuestsDialogDismissed,
         onNotAllowGuestsClicked = onNotAllowGuestsClicked,
-        onAllowGuestsClicked = onAllowGuestsClicked
+        onAllowGuestsClicked = onAllowGuestsClicked,
+        onErrorDismissed = onErrorDismissed,
     )
 }
 
@@ -72,6 +77,7 @@ fun GroupOptionScreenContent(
     onAllowGuestsDialogDismissed: () -> Unit,
     onNotAllowGuestsClicked: () -> Unit,
     onAllowGuestsClicked: () -> Unit,
+    onErrorDismissed: () -> Unit,
     onBackPressed: () -> Unit,
 ) {
     with(groupOptionState) {
@@ -82,140 +88,182 @@ fun GroupOptionScreenContent(
                 title = stringResource(id = R.string.new_group_title)
             )
         }) { internalPadding ->
-            ConstraintLayout(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(internalPadding)
-                    .background(MaterialTheme.colorScheme.background)
-            ) {
-                val (
-                    button,
-                    allowGuests, allowGuestsDescription,
-                    allowServices, allowServicesDescription,
-                    readReceipt, readReceiptDescription) = createRefs()
-
-                GroupConversationOptionsItem(
-                    title = stringResource(R.string.allow_guests),
-                    switchState = SwitchState.Enabled(value = isAllowGuestEnabled,
-                        isOnOffVisible = false,
-                        onCheckedChange = { onAllowGuestChanged.invoke(it) }),
-                    arrowType = ArrowType.NONE,
-                    clickable = Clickable(enabled = false, onClick = {}, onLongClick = {}),
-                    modifier = Modifier
-                        .background(MaterialTheme.colorScheme.surface)
-                        .constrainAs(allowGuests) {
-                            top.linkTo(parent.top)
-                        }
-                )
-
-                Text(
-                    text = stringResource(R.string.allow_guest_switch_description),
-                    fontWeight = FontWeight.Normal,
-                    color = MaterialTheme.wireColorScheme.secondaryText,
-                    modifier = Modifier
-                        .padding(MaterialTheme.wireDimensions.spacing16x)
-                        .constrainAs(allowGuestsDescription) {
-                            top.linkTo(allowGuests.bottom)
-                        },
-                    textAlign = TextAlign.Left,
-                    fontSize = 16.sp
-                )
-
-                GroupConversationOptionsItem(
-                    title = stringResource(R.string.allow_services),
-                    switchState = SwitchState.Enabled(value = isAllowServicesEnabled,
-                        isOnOffVisible = false,
-                        onCheckedChange = { onAllowServicesChanged.invoke(it) }),
-                    arrowType = ArrowType.NONE,
-                    clickable = Clickable(enabled = false, onClick = {}, onLongClick = {}),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surface)
-                        .constrainAs(allowServices) {
-                            top.linkTo(allowGuestsDescription.bottom)
-                        }
-                )
-
-                Text(
-                    text = stringResource(R.string.allow_services_description),
-                    fontWeight = FontWeight.Normal,
-                    color = MaterialTheme.wireColorScheme.secondaryText,
-                    modifier = Modifier
-                        .padding(MaterialTheme.wireDimensions.spacing16x)
-                        .constrainAs(allowServicesDescription) {
-                            top.linkTo(allowServices.bottom)
-                        },
-                    textAlign = TextAlign.Left,
-                    fontSize = 16.sp
-                )
-
-                GroupConversationOptionsItem(
-                    title = stringResource(R.string.read_receipts),
-                    switchState = SwitchState.Enabled(value = isReadReceiptEnabled,
-                        isOnOffVisible = false,
-                        onCheckedChange = { onReadReceiptChanged.invoke(it) }),
-                    arrowType = ArrowType.NONE,
-                    clickable = Clickable(enabled = false, onClick = {}, onLongClick = {}),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(MaterialTheme.colorScheme.surface)
-                        .constrainAs(readReceipt) {
-                            top.linkTo(allowServicesDescription.bottom)
-                        }
-                )
-
-                Text(
-                    text = stringResource(R.string.read_receipts_description),
-                    fontWeight = FontWeight.Normal,
-                    color = MaterialTheme.wireColorScheme.secondaryText,
-                    modifier = Modifier
-                        .padding(MaterialTheme.wireDimensions.spacing16x)
-                        .constrainAs(readReceiptDescription) {
-                            top.linkTo(readReceipt.bottom)
-                        },
-                    textAlign = TextAlign.Left,
-                    fontSize = 16.sp
-                )
-
-
-                WirePrimaryButton(
-                    text = stringResource(R.string.label_continue),
-                    onClick = onContinuePressed,
-                    fillMaxWidth = true,
-                    loading = isLoading,
-                    trailingIcon = Icons.Filled.ChevronRight.Icon(),
-                    state = if (continueEnabled) WireButtonState.Default else WireButtonState.Disabled,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(MaterialTheme.wireDimensions.spacing16x)
-                        .constrainAs(button) {
-                            bottom.linkTo(parent.bottom)
-                        }
-                )
-            }
-        }
-
-        if (showAllowGuestsDialog) {
-            WireDialog(
-                title = stringResource(R.string.disable_guests_dialoug_title),
-                text = stringResource(R.string.disable_guests_dialoug_description),
-                onDismiss = onAllowGuestsDialogDismissed,
-                buttonsHorizontalAlignment = false,
-                optionButton1Properties = WireDialogButtonProperties(
-                    onClick = onNotAllowGuestsClicked,
-                    text = stringResource(id = R.string.disable_guests_dialoug_button),
-                    type = WireDialogButtonType.Primary
-                ), optionButton2Properties = WireDialogButtonProperties(
-                    text = stringResource(R.string.allow_guests),
-                    onClick = onAllowGuestsClicked,
-                    type = WireDialogButtonType.Primary
-                ), dismissButtonProperties = WireDialogButtonProperties(
-                    text = stringResource(R.string.label_cancel),
-                    onClick = onAllowGuestsDialogDismissed
-                )
+            GroupOptionsScreenMainContent(
+                internalPadding,
+                onAllowGuestChanged,
+                onAllowServicesChanged,
+                onReadReceiptChanged,
+                onContinuePressed
             )
         }
+
+        error?.let {
+            ErrorDialog(it, onErrorDismissed)
+        }
+        if (showAllowGuestsDialog) {
+            AllowGuestsDialog(onAllowGuestsDialogDismissed, onNotAllowGuestsClicked, onAllowGuestsClicked)
+        }
     }
+}
+
+@Composable
+private fun GroupOptionState.GroupOptionsScreenMainContent(
+    internalPadding: PaddingValues,
+    onAllowGuestChanged: (Boolean) -> Unit,
+    onAllowServicesChanged: (Boolean) -> Unit,
+    onReadReceiptChanged: (Boolean) -> Unit,
+    onContinuePressed: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(internalPadding)
+            .background(MaterialTheme.colorScheme.background),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column() {
+            AllowGuestsOptions(onAllowGuestChanged)
+            AllowServicesOptions(onAllowServicesChanged)
+            ReadReceiptsOptions(onReadReceiptChanged)
+        }
+        ContinueButton(onContinuePressed)
+    }
+}
+
+@Composable
+private fun GroupOptionState.ReadReceiptsOptions(onReadReceiptChanged: (Boolean) -> Unit) {
+    GroupConversationOptionsItem(
+        title = stringResource(R.string.read_receipts),
+        switchState = SwitchState.Enabled(value = isReadReceiptEnabled,
+            isOnOffVisible = false,
+            onCheckedChange = { onReadReceiptChanged.invoke(it) }),
+        arrowType = ArrowType.NONE,
+        clickable = Clickable(enabled = false, onClick = {}, onLongClick = {}),
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+    )
+
+    Text(
+        text = stringResource(R.string.read_receipts_description),
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.wireColorScheme.secondaryText,
+        modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x),
+        textAlign = TextAlign.Left,
+        fontSize = 16.sp
+    )
+}
+
+@Composable
+private fun GroupOptionState.AllowServicesOptions(onAllowServicesChanged: (Boolean) -> Unit) {
+    GroupConversationOptionsItem(
+        title = stringResource(R.string.allow_services),
+        switchState = SwitchState.Enabled(value = isAllowServicesEnabled,
+            isOnOffVisible = false,
+            onCheckedChange = { onAllowServicesChanged.invoke(it) }),
+        arrowType = ArrowType.NONE,
+        clickable = Clickable(enabled = false, onClick = {}, onLongClick = {}),
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+    )
+
+    Text(
+        text = stringResource(R.string.allow_services_description),
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.wireColorScheme.secondaryText,
+        modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x),
+        textAlign = TextAlign.Left,
+        fontSize = 16.sp
+    )
+}
+
+@Composable
+private fun GroupOptionState.AllowGuestsOptions(onAllowGuestChanged: (Boolean) -> Unit) {
+    GroupConversationOptionsItem(
+        title = stringResource(R.string.allow_guests),
+        switchState = SwitchState.Enabled(value = isAllowGuestEnabled,
+            isOnOffVisible = false,
+            onCheckedChange = { onAllowGuestChanged.invoke(it) }),
+        arrowType = ArrowType.NONE,
+        clickable = Clickable(enabled = false, onClick = {}, onLongClick = {}),
+        modifier = Modifier.background(MaterialTheme.colorScheme.surface)
+    )
+
+    Text(
+        text = stringResource(R.string.allow_guest_switch_description),
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.wireColorScheme.secondaryText,
+        modifier = Modifier.padding(MaterialTheme.wireDimensions.spacing16x),
+        textAlign = TextAlign.Left,
+        fontSize = 16.sp
+    )
+}
+
+@Composable
+private fun GroupOptionState.ContinueButton(
+    onContinuePressed: () -> Unit
+) {
+    WirePrimaryButton(
+        text = stringResource(R.string.label_continue),
+        onClick = onContinuePressed,
+        fillMaxWidth = true,
+        loading = isLoading,
+        trailingIcon = if(isLoading) null else Icons.Filled.ChevronRight.Icon(),
+        state = if (continueEnabled && !isLoading) WireButtonState.Default else WireButtonState.Disabled,
+        modifier = Modifier.fillMaxWidth().padding(MaterialTheme.wireDimensions.spacing16x)
+    )
+}
+
+@Composable
+private fun AllowGuestsDialog(
+    onAllowGuestsDialogDismissed: () -> Unit,
+    onNotAllowGuestsClicked: () -> Unit,
+    onAllowGuestsClicked: () -> Unit
+) {
+    WireDialog(
+        title = stringResource(R.string.disable_guests_dialoug_title),
+        text = stringResource(R.string.disable_guests_dialoug_description),
+        onDismiss = onAllowGuestsDialogDismissed,
+        buttonsHorizontalAlignment = false,
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = onNotAllowGuestsClicked,
+            text = stringResource(id = R.string.disable_guests_dialoug_button),
+            type = WireDialogButtonType.Primary
+        ), optionButton2Properties = WireDialogButtonProperties(
+            text = stringResource(R.string.allow_guests),
+            onClick = onAllowGuestsClicked,
+            type = WireDialogButtonType.Primary
+        ), dismissButtonProperties = WireDialogButtonProperties(
+            text = stringResource(R.string.label_cancel),
+            onClick = onAllowGuestsDialogDismissed
+        )
+    )
+}
+
+
+@Composable
+private fun ErrorDialog(error: GroupOptionState.Error, onErrorDismissed: () -> Unit) {
+    val dialogStrings = when (error) {
+        is GroupOptionState.Error.LackingConnection -> DialogErrorStrings(
+            stringResource(R.string.error_no_network_title),
+            stringResource(R.string.error_no_network_message)
+        )
+
+        is GroupOptionState.Error.Unknown -> DialogErrorStrings(
+            stringResource(R.string.error_unknown_title),
+            stringResource(R.string.error_unknown_message)
+        )
+    }
+    WireDialog(
+        dialogStrings.title, dialogStrings.message,
+        onDismiss = onErrorDismissed,
+        optionButton1Properties = WireDialogButtonProperties(
+            onClick = onErrorDismissed,
+            text = stringResource(id = R.string.label_ok),
+            type = WireDialogButtonType.Primary,
+        )
+    )
 }
 
 @Composable
@@ -223,6 +271,6 @@ fun GroupOptionScreenContent(
 private fun GroupOptionScreenPreview() {
     GroupOptionScreenContent(
         GroupOptionState(),
-        {}, {}, {}, {}, {}, {}, {}, {}
+        {}, {}, {}, {}, {}, {}, {}, {}, {}
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupScreen.kt
@@ -108,10 +108,10 @@ fun NewGroupScreenContent(
                             onValueChange = onGroupNameChange,
                             placeholderText = stringResource(R.string.group_name),
                             labelText = stringResource(R.string.group_name).uppercase(),
-                            state = if (error is NewGroupState.GroupNameError.TextFieldError) when (error) {
-                                NewGroupState.GroupNameError.TextFieldError.GroupNameEmptyError ->
+                            state = if (error is NewGroupState.NewGroupError.TextFieldError) when (error) {
+                                NewGroupState.NewGroupError.TextFieldError.GroupNameEmptyError ->
                                     WireTextFieldState.Error(stringResource(id = R.string.empty_group_name_error))
-                                NewGroupState.GroupNameError.TextFieldError.GroupNameExceedLimitError ->
+                                NewGroupState.NewGroupError.TextFieldError.GroupNameExceedLimitError ->
                                     WireTextFieldState.Error(stringResource(id = R.string.group_name_exceeded_limit_error))
                             } else WireTextFieldState.Default,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text, imeAction = ImeAction.Done),

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/newgroup/NewGroupState.kt
@@ -9,14 +9,14 @@ data class NewGroupState(
     val animatedGroupNameError: Boolean = false,
     val continueEnabled: Boolean = false,
     val mlsEnabled: Boolean = true,
-    val isLoading : Boolean = false,
-    val error: GroupNameError = GroupNameError.None
+    val isLoading: Boolean = false,
+    val error: NewGroupError = NewGroupError.None
 ) {
-    sealed class GroupNameError {
-        object None : GroupNameError()
-        sealed class TextFieldError : GroupNameError() {
-            object GroupNameEmptyError : TextFieldError()
-            object GroupNameExceedLimitError : TextFieldError()
+    sealed interface NewGroupError {
+        object None : NewGroupError
+        sealed interface TextFieldError : NewGroupError {
+            object GroupNameEmptyError : TextFieldError
+            object GroupNameExceedLimitError : TextFieldError
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -405,8 +405,8 @@
     <string name="error_unknown_message">Please try again in a moment</string>
     <string name="error_server_miscommunication_title">Server error</string>
     <string name="error_server_miscommunication_message">Please try again in a moment</string>
-    <string name="error_no_network_title">No network error</string>
-    <string name="error_no_network_message">Please check your Internet connection</string>
+    <string name="error_no_network_title">Waiting for network</string>
+    <string name="error_no_network_message">Please check your Internet connection and try again</string>
     <string name="error_downloading_user_info">There was an error downloading the user information. Please check your Internet connection</string>
     <string name="error_uploading_user_avatar">Image could not be uploaded</string>
     <string name="error_updating_muting_setting">Notifications could not be updated</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -28,7 +28,7 @@ import com.wire.kalium.logic.feature.publicuser.search.Result
 import com.wire.kalium.logic.feature.publicuser.search.SearchKnownUsersUseCase
 import com.wire.kalium.logic.feature.publicuser.search.SearchUsersUseCase
 import com.wire.kalium.logic.feature.user.IsMLSEnabledUseCase
-import com.wire.kalium.logic.functional.Either
+import com.wire.kalium.logic.CoreFailure
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.MockK
@@ -164,14 +164,22 @@ internal class NewConversationViewModelArrangement {
         )
     }
 
-    fun withFailureKnownSearchResponse(): NewConversationViewModelArrangement {
+    fun withFailureKnownSearchResponse() = apply {
         coEvery { searchKnownUsers(any()) } returns Result.Failure.InvalidRequest
-        return this
     }
 
-    fun withFailurePublicSearchResponse(): NewConversationViewModelArrangement {
+    fun withFailurePublicSearchResponse() = apply {
         coEvery { searchUsers(any()) } returns Result.Failure.InvalidRequest
-        return this
+    }
+
+    fun withSyncFailureOnCreatingGroup() = apply {
+        coEvery { createGroupConversation(any(), any(), any()) } returns CreateGroupConversationUseCase.Result.SyncFailure
+    }
+
+    fun withUnknownFailureOnCreatingGroup() = apply {
+        coEvery { createGroupConversation(any(), any(), any()) } returns CreateGroupConversationUseCase.Result.UnknownFailure(
+            CoreFailure.MissingClientRegistration
+        )
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -42,7 +42,7 @@ internal class NewConversationViewModelArrangement {
         coEvery { searchUsers(any()) } returns Result.Success(userSearchResult = UserSearchResult(listOf(PUBLIC_USER)))
         coEvery { searchKnownUsers(any()) } returns Result.Success(userSearchResult = UserSearchResult(listOf(KNOWN_USER)))
         coEvery { getAllContacts() } returns GetAllContactsResult.Success(listOf())
-        coEvery { createGroupConversation(any(), any(), any()) } returns Either.Right(CONVERSATION)
+        coEvery { createGroupConversation(any(), any(), any()) } returns CreateGroupConversationUseCase.Result.Success(CONVERSATION)
         coEvery { contactMapper.fromOtherUser(PUBLIC_USER) } returns Contact(
             id = "publicValue",
             domain = "domain",

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -3,19 +3,19 @@ package com.wire.android.ui.home.newconversation
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.UserAvatarData
-import com.wire.android.ui.home.conversationslist.model.Membership
-import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.ui.home.conversations.search.SearchResultState
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.home.newconversation.groupOptions.GroupOptionState
+import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.kalium.logic.data.user.ConnectionState
 import com.wire.kalium.logic.data.user.UserAssetId
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -78,6 +78,40 @@ class NewConversationViewModelTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `given sync failure, when creating group, then should update options state with connectivity error`() = runTest {
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withSyncFailureOnCreatingGroup()
+            .arrange()
+
+        viewModel.createGroup()
+        advanceUntilIdle()
+
+        viewModel.groupOptionsState.error shouldBeEqualTo GroupOptionState.Error.LackingConnection
+    }
+
+    @Test
+    fun `given unknown failure, when creating group, then should update options state with unknown error`() = runTest {
+        val (_, viewModel) = NewConversationViewModelArrangement()
+            .withUnknownFailureOnCreatingGroup()
+            .arrange()
+
+        viewModel.createGroup()
+        advanceUntilIdle()
+
+        viewModel.groupOptionsState.error shouldBeEqualTo GroupOptionState.Error.Unknown
+    }
+
+    @Test
+    fun `given no failure, when creating group, then options state should have no error`() = runTest {
+        val (_, viewModel) = NewConversationViewModelArrangement().arrange()
+
+        viewModel.createGroup()
+        advanceUntilIdle()
+
+        viewModel.groupOptionsState.error.shouldBeNull()
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2146" title="AR-2146" target="_blank"><img alt="Subtask" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />AR-2146</a>  Group Creation - Popup to signal offline therefore functionality is not available
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- Given the phone is offline, or Given sync has failed, 
- When attempting to create a group conversation
- Then nothing happens, no feedback.

### Solutions

Handle the new result from the `CreateGroupConversationUseCase`, introduced in https://github.com/wireapp/kalium/pull/815

I also took a bit of time to re-organise the `GroupOptionsScreen.kt` into smaller Composable functions and removing `ConstraintLayout` which was unnecessary, for the sake of simplicity and readability.

### Dependencies

Needs releases with:

- https://github.com/wireapp/kalium/pull/815

### Testing

#### Test Coverage

- [X] I have added automated test to this contribution

#### How to Test

Disconnect your internet and attempt to create a group conversation.

----
#### PR Post Merge Checklist for internal contributors

 - [X] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
