### PR TITLE
fix: other user devices UI [AR-1195]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -1,5 +1,6 @@
 package com.wire.android.ui.userprofile.other
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -7,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -16,6 +18,7 @@ import com.wire.android.R
 import com.wire.android.ui.authentication.devices.model.Device
 import com.wire.android.ui.authentication.devices.remove.RemoveDeviceItem
 import com.wire.android.ui.common.dimensions
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
@@ -31,7 +34,11 @@ fun OtherUserDevicesScreen(
     val supportUrl = BuildConfig.SUPPORT_URL + stringResource(id = R.string.url_why_verify_conversation)
     LazyColumn(
         state = lazyListState,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                color = MaterialTheme.wireColorScheme.surface
+            )
     ) {
         item {
             LinkText(

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -28,7 +28,8 @@ import com.wire.kalium.logic.data.conversation.ClientId
 @Composable
 fun OtherUserDevicesScreen(
     otherUserClient: List<OtherUserClients>,
-    lazyListState: LazyListState = rememberLazyListState()
+    lazyListState: LazyListState = rememberLazyListState(),
+    state: OtherUserProfileState
 ) {
     val context = LocalContext.current
     val supportUrl = BuildConfig.SUPPORT_URL + stringResource(id = R.string.url_why_verify_conversation)
@@ -44,7 +45,7 @@ fun OtherUserDevicesScreen(
             LinkText(
                 linkTextData = listOf(
                     LinkTextData(
-                        text = stringResource(R.string.other_user_devices_decription),
+                        text = stringResource(R.string.other_user_devices_decription, state.fullName),
                     ),
                     LinkTextData(
                         text = stringResource(id = R.string.label_learn_more),

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserDevicesScreen.kt
@@ -22,52 +22,49 @@ import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.CustomTabsHelper
 import com.wire.android.util.ui.LinkText
 import com.wire.android.util.ui.LinkTextData
-import com.wire.kalium.logic.data.client.OtherUserClients
 import com.wire.kalium.logic.data.conversation.ClientId
 
 @Composable
 fun OtherUserDevicesScreen(
-    otherUserClient: List<OtherUserClients>,
     lazyListState: LazyListState = rememberLazyListState(),
     state: OtherUserProfileState
 ) {
     val context = LocalContext.current
     val supportUrl = BuildConfig.SUPPORT_URL + stringResource(id = R.string.url_why_verify_conversation)
-    LazyColumn(
-        state = lazyListState,
-        modifier = Modifier
-            .fillMaxSize()
-            .background(
-                color = MaterialTheme.wireColorScheme.surface
-            )
-    ) {
-        item {
-            LinkText(
-                linkTextData = listOf(
-                    LinkTextData(
-                        text = stringResource(R.string.other_user_devices_decription, state.fullName),
+    with(state) {
+        LazyColumn(
+            state = lazyListState,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = MaterialTheme.wireColorScheme.surface)
+        ) {
+            item {
+                LinkText(
+                    linkTextData = listOf(
+                        LinkTextData(
+                            text = stringResource(R.string.other_user_devices_decription, fullName),
+                        ),
+                        LinkTextData(
+                            text = stringResource(id = R.string.label_learn_more),
+                            tag = "learn_more",
+                            annotation = supportUrl,
+                            onClick = {
+                                CustomTabsHelper.launchUrl(context, supportUrl)
+                            },
+                        )
                     ),
-                    LinkTextData(
-                        text = stringResource(id = R.string.label_learn_more),
-                        tag = "learn_more",
-                        annotation = supportUrl,
-                        onClick = {
-                            CustomTabsHelper.launchUrl(context, supportUrl)
-                        },
-                    )
-                ),
-                modifier = Modifier
-                    .padding(
-                        all = dimensions().spacing16x,
-                    )
-            )
-        }
+                    modifier = Modifier
+                        .padding(
+                            all = dimensions().spacing16x,
+                        )
+                )
+            }
 
-        itemsIndexed(otherUserClient) { index, item ->
-            RemoveDeviceItem(Device(item.deviceType.name, ClientId(item.id), ""), false, null)
-            if (index < otherUserClient.lastIndex) Divider()
+            itemsIndexed(otherUserClients) { index, item ->
+                RemoveDeviceItem(Device(item.deviceType.name, ClientId(item.id), ""), false, null)
+                if (index < otherUserClients.lastIndex) Divider()
+            }
         }
-
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -381,7 +381,7 @@ private fun Content(
 
                             OtherUserProfileTabItem.DEVICES -> {
                                 getOtherUserClients()
-                                OtherUserDevicesScreen(state.otherUserClients, state = state)
+                                OtherUserDevicesScreen(state = state)
 
                             }
                         }

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -381,7 +381,7 @@ private fun Content(
 
                             OtherUserProfileTabItem.DEVICES -> {
                                 getOtherUserClients()
-                                OtherUserDevicesScreen(state.otherUserClients)
+                                OtherUserDevicesScreen(state.otherUserClients, state = state)
 
                             }
                         }

--- a/app/src/main/kotlin/com/wire/android/util/ui/StyledStringUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/ui/StyledStringUtil.kt
@@ -101,7 +101,7 @@ private fun createAnnotatedString(data: List<LinkTextData>): AnnotatedString {
                 }
                 pop()
             } else {
-                append(linkTextData.text)
+                append("${linkTextData.text} ")
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,7 +565,7 @@
     <string name="block_user_dialog_title">Block user?</string>
     <string name="block_user_dialog_body">%1$s won’t be able to contact you or add you to group conversations. You will lose access to any 1:1 conversations with them. The other user will not be notified about this.</string>
     <string name="block_user_dialog_confirm_button">Block</string>
-    <string name="other_user_devices_decription"><![CDATA[\Wire gives every device a unique fingerprint. Compare them with <other users username> and verify your conversation. \]]></string>
+    <string name="other_user_devices_decription"><![CDATA[\Wire gives every device a unique fingerprint. Compare them with %1$s and verify your conversation. \]]></string>
 
 
     <!--Settings -->


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1195" title="AR-1195" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1195</a>  Display Other User’s connected devices
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the design was not as the mocks in figma



### Solutions

updated the UI , to reflect the figma design





### Attachments (Optional)

<img width="439" alt="Screenshot 2022-08-22 at 12 49 32" src="https://user-images.githubusercontent.com/34056732/185904235-bb6c0488-5c0e-459a-abc3-c6c8e89c6d19.png">

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
