### PR TITLE
fix: guest label not aligned [AR-2178]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/UserBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/UserBadge.kt
@@ -26,7 +26,8 @@ import com.wire.kalium.logic.data.user.ConnectionState
  */
 @Composable
 fun UserBadge(
-    membership: Membership, connectionState: ConnectionState? = null,
+    membership: Membership,
+    connectionState: ConnectionState? = null,
     startPadding: Dp = dimensions().spacing0x,
     topPadding: Dp = dimensions().spacing0x
 ) {

--- a/app/src/main/kotlin/com/wire/android/ui/common/UserBadge.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/UserBadge.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.conversationslist.model.hasLabel
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -26,12 +25,16 @@ import com.wire.kalium.logic.data.user.ConnectionState
  * @param startPadding - Dp of labels left padding
  */
 @Composable
-fun UserBadge(membership: Membership, connectionState: ConnectionState? = null, startPadding: Dp = 0.dp) {
+fun UserBadge(
+    membership: Membership, connectionState: ConnectionState? = null,
+    startPadding: Dp = dimensions().spacing0x,
+    topPadding: Dp = dimensions().spacing0x
+) {
     if (connectionState == ConnectionState.BLOCKED) {
         Spacer(modifier = Modifier.width(startPadding))
         BlockedLabel()
     } else if (membership.hasLabel()) {
         Spacer(modifier = Modifier.width(startPadding))
-        MembershipQualifierLabel(membership, Modifier.padding(top = dimensions().spacing8x))
+        MembershipQualifierLabel(membership, Modifier.padding(top = topPadding))
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/InternalContactSearchResultItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/InternalContactSearchResultItem.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.wire.android.appLogger
@@ -48,7 +49,7 @@ fun InternalContactSearchResultItem(
             }
         },
         title = {
-            Row {
+            Row(verticalAlignment = CenterVertically) {
                 HighlightName(
                     name = name,
                     searchQuery = searchQuery
@@ -99,7 +100,7 @@ fun ExternalContactSearchResultItem(
             }
         },
         title = {
-            Row {
+            Row(verticalAlignment = CenterVertically) {
                 HighlightName(
                     name = name,
                     searchQuery = searchQuery

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
@@ -20,21 +20,21 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.android.model.Clickable
+import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.ArrowRightIcon
 import com.wire.android.ui.common.RowItemTemplate
-import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.UserBadge
 import com.wire.android.ui.common.UserProfileAvatar
 import com.wire.android.ui.common.WireCheckbox
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.loading.CenteredCircularProgressBarIndicator
 import com.wire.android.ui.home.conversations.search.SearchPeoplePurpose
+import com.wire.android.ui.home.conversations.search.SearchResultState
+import com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
 import com.wire.android.ui.home.conversationslist.folderWithElements
 import com.wire.android.ui.home.conversationslist.model.Membership
 import com.wire.android.ui.home.newconversation.common.SelectParticipantsButtonsRow
 import com.wire.android.ui.home.newconversation.model.Contact
-import com.wire.android.ui.home.conversations.search.SearchResultState
-import com.wire.android.ui.home.conversations.search.widget.SearchFailureBox
 import com.wire.android.ui.theme.wireTypography
 import com.wire.kalium.logic.data.user.ConnectionState
 
@@ -129,7 +129,7 @@ private fun ContactItem(
             }
         },
         title = {
-            Row {
+            Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = name,
                     style = MaterialTheme.wireTypography.title02,

--- a/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/theme/WireDimensions.kt
@@ -98,6 +98,7 @@ data class WireDimensions(
     val removeDeviceItemPadding: Dp,
     val removeDeviceItemTitleVerticalPadding: Dp,
     // Spacing
+    val spacing0x: Dp,
     val spacing1x: Dp,
     val spacing2x: Dp,
     val spacing4x: Dp,
@@ -228,6 +229,7 @@ private val DefaultPhonePortraitWireDimensions: WireDimensions = WireDimensions(
     removeDeviceLabelVerticalPadding = 5.dp,
     removeDeviceItemPadding = 12.dp,
     removeDeviceItemTitleVerticalPadding = 8.dp,
+    spacing0x = 0.dp,
     spacing1x = 1.dp,
     spacing2x = 2.dp,
     spacing4x = 4.dp,

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/common/UserProfileInfo.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.constraintlayout.compose.ConstraintLayout
@@ -113,7 +112,7 @@ fun UserProfileInfo(
                     maxLines = 1,
                     color = MaterialTheme.wireColorScheme.labelText,
                 )
-                UserBadge(membership, connection)
+                UserBadge(membership, connection, topPadding = dimensions().spacing8x)
             }
 
             if (editableState is EditableState.IsEditable) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2178" title="AR-2178" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2178</a>  Guest, External etc labels not alligned
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

guest label was not aligned with the name in the search list 


### Causes (Optional)

we were passing fixed padding to the label 

### Solutions

make the user badge accept top padding argument so it we can pass different padding for different occurences 

### Attachments (Optional)
<img width="427" alt="Screenshot 2022-08-22 at 13 37 14" src="https://user-images.githubusercontent.com/34056732/185913173-3ac29943-637e-4edd-ae65-f8b67ffefa1f.png">
<img width="422" alt="Screenshot 2022-08-22 at 13 39 37" src="https://user-images.githubusercontent.com/34056732/185913181-988af687-dac1-429a-ba4a-fe61ec9717af.png">


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
