### PR TITLE
fix: Empty UserProfile for not connected user (AR-2190)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -22,7 +22,6 @@ import com.wire.android.navigation.NavigationItem
 import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.common.dialogs.BlockUserDialogState
 import com.wire.android.ui.common.dialogs.UnblockUserDialogState
-import com.wire.android.ui.home.conversations.details.participants.usecase.ConversationRoleData
 import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveConversationRoleForUserUseCase
 import com.wire.android.ui.home.conversationslist.bottomsheet.ConversationSheetContent
 import com.wire.android.ui.home.conversationslist.bottomsheet.ConversationTypeDetail
@@ -32,15 +31,14 @@ import com.wire.android.ui.userprofile.group.RemoveConversationMemberState
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.UIText
 import com.wire.android.util.ui.WireSessionImageLoader
-import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
-import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.data.user.ConnectionState
+import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.client.GetOtherUserClientsResult
 import com.wire.kalium.logic.feature.client.GetOtherUserClientsUseCase
@@ -70,9 +68,7 @@ import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -124,77 +120,98 @@ class OtherUserProfileScreenViewModel @Inject constructor(
 
     init {
         state = state.copy(isDataLoading = true)
-        viewModelScope.launch {
-            when (val conversationResult = getOrCreateOneToOneConversation(userId)) {
-                is CreateConversationResult.Failure -> {
-                    appLogger.d("Couldn't not getOrCreateOneToOneConversation for user id: $userId")
-                    showInfoMessage(InfoMessageType.LoadUserInformationError)
-                }
-                is CreateConversationResult.Success -> {
-                    val observeConversationRoleData = conversationId
-                        .let { if (it != null) observeConversationRoleForUser(it, userId) else flowOf(it) }
 
-                    val observeSucceedUserInfo = observeUserInfo(userId)
-                        .onEach {
-                            if (it is GetUserInfoResult.Failure) {
-                                appLogger.d("Couldn't not find the user with provided id: $userId")
-                                showInfoMessage(InfoMessageType.LoadUserInformationError)
-                            }
-                        }
-                        .filterIsInstance<GetUserInfoResult.Success>()
+        observeUserInfoAndUpdateViewState()
 
-                    combine(observeConversationRoleData, observeSelfUser(), observeSucceedUserInfo, ::Triple)
-                        .collect { (conversationRoleData, selfUser, userInfoResult) ->
-                            loadViewState(userInfoResult, conversationResult.conversation, conversationRoleData, selfUser.teamId)
-                        }
-                }
-            }
-        }
         viewModelScope.launch {
             persistOtherUserClients(userId)
         }
     }
 
-    private fun loadViewState(
-        getInfoResult: GetUserInfoResult.Success,
-        directConversation: Conversation,
-        conversationRoleData: ConversationRoleData?,
-        selfTeamId: TeamId?
-    ) {
-        val userAvatarAsset = getInfoResult.otherUser.completePicture
-            ?.let { pic -> ImageAsset.UserAvatarAsset(wireSessionImageLoader, pic) }
+    private fun observeUserInfoAndUpdateViewState() {
+        viewModelScope.launch {
+            observeUserInfo(userId)
+                .onEach {
+                    if (it is GetUserInfoResult.Failure) {
+                        appLogger.d("Couldn't not find the user with provided id: $userId")
+                        showInfoMessage(InfoMessageType.LoadUserInformationError)
+                    }
+                }
+                .filterIsInstance<GetUserInfoResult.Success>()
+                .collect { getInfoResult ->
+                    val userAvatarAsset = getInfoResult.otherUser.completePicture
+                        ?.let { pic -> ImageAsset.UserAvatarAsset(wireSessionImageLoader, pic) }
 
-        state = with(getInfoResult) {
-            state.copy(
-                isDataLoading = false,
-                userAvatarAsset = userAvatarAsset,
-                fullName = otherUser.name.orEmpty(),
-                userName = mapUserLabel(otherUser),
-                teamName = team?.name.orEmpty(),
-                email = otherUser.email.orEmpty(),
-                phone = otherUser.phone.orEmpty(),
-                connectionState = otherUser.connectionStatus,
-                membership = userTypeMapper.toMembership(otherUser.userType),
-                groupState = conversationRoleData?.userRole?.let { userRole ->
-                    OtherUserProfileGroupState(
-                        groupName = conversationRoleData.conversationName,
-                        role = userRole,
-                        isSelfAdmin = conversationRoleData.selfRole is Member.Role.Admin,
-                        conversationId = conversationRoleData.conversationId
+                    observeConversationSheetContentIfNeeded(getInfoResult.otherUser, userAvatarAsset)
+                    observeGroupStateIfNeeded()
+
+                    state = with(getInfoResult) {
+                        state.copy(
+                            isDataLoading = false,
+                            userAvatarAsset = userAvatarAsset,
+                            fullName = otherUser.name.orEmpty(),
+                            userName = mapUserLabel(otherUser),
+                            teamName = team?.name.orEmpty(),
+                            email = otherUser.email.orEmpty(),
+                            phone = otherUser.phone.orEmpty(),
+                            connectionState = otherUser.connectionStatus,
+                            membership = userTypeMapper.toMembership(otherUser.userType),
+                            botService = otherUser.botService,
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun observeConversationSheetContentIfNeeded(otherUser: OtherUser, userAvatarAsset: ImageAsset.UserAvatarAsset?) {
+
+        // if we are not connected with that user -> we don't have a direct conversation ->
+        // -> don't need to load data for ConversationBottomSheet
+        if (otherUser.connectionStatus != ConnectionState.ACCEPTED) return
+
+        viewModelScope.launch {
+            when (val conversationResult = getOrCreateOneToOneConversation(userId)) {
+                is CreateConversationResult.Failure -> {
+                    appLogger.d("Couldn't not getOrCreateOneToOneConversation for user id: $userId")
+                    showInfoMessage(InfoMessageType.LoadDirectConversationError)
+                }
+                is CreateConversationResult.Success -> {
+                    observeSelfUser()
+                        .collect { selfUser ->
+                            state = state.copy(
+                                conversationSheetContent = ConversationSheetContent(
+                                    title = otherUser.name.orEmpty(),
+                                    conversationId = conversationResult.conversation.id,
+                                    mutingConversationState = conversationResult.conversation.mutedStatus,
+                                    conversationTypeDetail = ConversationTypeDetail.Private(
+                                        userAvatarAsset,
+                                        userId,
+                                        otherUser.getBlockingState(selfUser.teamId)
+                                    )
+                                )
+                            )
+                        }
+                }
+            }
+        }
+    }
+
+    private fun observeGroupStateIfNeeded() {
+        conversationId?.let {
+            viewModelScope.launch {
+                observeConversationRoleForUser(it, userId).collect { conversationRoleData ->
+                    state = state.copy(
+                        groupState = conversationRoleData.userRole?.let { userRole ->
+                            OtherUserProfileGroupState(
+                                groupName = conversationRoleData.conversationName,
+                                role = userRole,
+                                isSelfAdmin = conversationRoleData.selfRole is Member.Role.Admin,
+                                conversationId = conversationRoleData.conversationId
+                            )
+                        }
                     )
-                },
-                botService = otherUser.botService,
-                conversationSheetContent = ConversationSheetContent(
-                    title = otherUser.name.orEmpty(),
-                    conversationId = directConversation.id,
-                    mutingConversationState = directConversation.mutedStatus,
-                    conversationTypeDetail = ConversationTypeDetail.Private(
-                        userAvatarAsset,
-                        userId,
-                        getInfoResult.otherUser.getBlockingState(selfTeamId)
-                    )
-                )
-            )
+                }
+            }
         }
     }
 
@@ -450,6 +467,7 @@ sealed class InfoMessageType(override val uiText: UIText) : SnackBarMessage {
     object SuccessConnectionCancelRequest : InfoMessageType(UIText.StringResource(R.string.connection_request_canceled))
     object ConnectionRequestError : InfoMessageType(UIText.StringResource(R.string.connection_request_sent_error))
     object LoadUserInformationError : InfoMessageType(UIText.StringResource(R.string.error_unknown_message))
+    object LoadDirectConversationError : InfoMessageType(UIText.StringResource(R.string.error_unknown_message))
 
     // change group role
     object ChangeGroupRoleError : InfoMessageType(UIText.StringResource(R.string.user_profile_role_change_error))
@@ -459,7 +477,9 @@ sealed class InfoMessageType(override val uiText: UIText) : SnackBarMessage {
 
     // Conversation BottomSheet
     object BlockingUserOperationError : InfoMessageType(UIText.StringResource(R.string.error_blocking_user))
-    class BlockingUserOperationSuccess(val name: String) : InfoMessageType(UIText.StringResource(R.string.blocking_user_success, name))
+    class BlockingUserOperationSuccess(val name: String) :
+        InfoMessageType(UIText.StringResource(R.string.blocking_user_success, name))
+
     object MutingOperationError : InfoMessageType(UIText.StringResource(R.string.error_updating_muting_setting))
 
     object UnblockingUserOperationError : InfoMessageType(UIText.StringResource(R.string.error_unblocking_user))

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -1,28 +1,16 @@
 package com.wire.android.ui.userprofile.other
 
-import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
-import com.wire.android.config.TestDispatcherProvider
-import com.wire.android.config.mockUri
-import com.wire.android.framework.TestUser
-import com.wire.android.mapper.UserTypeMapper
-import com.wire.android.navigation.EXTRA_CONVERSATION_ID
-import com.wire.android.navigation.EXTRA_USER_ID
-import com.wire.android.navigation.NavigationManager
 import com.wire.android.ui.home.conversations.details.participants.usecase.ConversationRoleData
-import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveConversationRoleForUserUseCase
-import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.ui.userprofile.common.UsernameMapper
 import com.wire.android.util.ui.UIText
-import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.CoreFailure.Unknown
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Member
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.PlainId
-import com.wire.kalium.logic.data.id.QualifiedID
-import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.TeamId
 import com.wire.kalium.logic.data.team.Team
 import com.wire.kalium.logic.data.user.ConnectionState
@@ -30,39 +18,19 @@ import com.wire.kalium.logic.data.user.OtherUser
 import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
-import com.wire.kalium.logic.feature.client.GetOtherUserClientsUseCase
-import com.wire.kalium.logic.feature.client.PersistOtherUserClientsUseCase
-import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCaseResult
 import com.wire.kalium.logic.feature.connection.BlockUserResult
-import com.wire.kalium.logic.feature.connection.BlockUserUseCase
-import com.wire.kalium.logic.feature.connection.CancelConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.CancelConnectionRequestUseCaseResult
-import com.wire.kalium.logic.feature.connection.IgnoreConnectionRequestUseCase
 import com.wire.kalium.logic.feature.connection.IgnoreConnectionRequestUseCaseResult
 import com.wire.kalium.logic.feature.connection.SendConnectionRequestResult
-import com.wire.kalium.logic.feature.connection.SendConnectionRequestUseCase
-import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
 import com.wire.kalium.logic.feature.conversation.CreateConversationResult
-import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
-import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
-import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
-import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
-import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
-import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
 import io.mockk.Called
-import io.mockk.MockKAnnotations
-import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.internal.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -70,125 +38,22 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(CoroutineTestExtension::class)
 class OtherUserProfileScreenViewModelTest {
 
-    lateinit var otherUserProfileScreenViewModel: OtherUserProfileScreenViewModel
-
-    @MockK
-    lateinit var navigationManager: NavigationManager
-
-    @MockK
-    private lateinit var savedStateHandle: SavedStateHandle
-
-    @MockK
-    private lateinit var getOrCreateOneToOneConversation: GetOrCreateOneToOneConversationUseCase
-
-    @MockK
-    private lateinit var observeUserInfo: ObserveUserInfoUseCase
-
-    @MockK
-    private lateinit var sendConnectionRequest: SendConnectionRequestUseCase
-
-    @MockK
-    private lateinit var cancelConnectionRequest: CancelConnectionRequestUseCase
-
-    @MockK
-    private lateinit var acceptConnectionRequest: AcceptConnectionRequestUseCase
-
-    @MockK
-    private lateinit var ignoreConnectionRequest: IgnoreConnectionRequestUseCase
-
-    @MockK
-    private lateinit var wireSessionImageLoader: WireSessionImageLoader
-
-    @MockK
-    private lateinit var observeConversationRoleForUserUseCase: ObserveConversationRoleForUserUseCase
-
-    @MockK
-    private lateinit var userTypeMapper: UserTypeMapper
-
-    @MockK
-    private lateinit var qualifiedIdMapper: QualifiedIdMapper
-
-    @MockK
-    private lateinit var updateConversationMemberRoleUseCase: UpdateConversationMemberRoleUseCase
-
-    @MockK
-    private lateinit var removeMemberFromConversationUseCase: RemoveMemberFromConversationUseCase
-
-    @MockK
-    private lateinit var observeSelfUser: GetSelfUserUseCase
-
-    @MockK
-    private lateinit var blockUser: BlockUserUseCase
-
-    @MockK
-    private lateinit var unblockUser: UnblockUserUseCase
-
-    @MockK
-    private lateinit var updateConversationMutedStatus: UpdateConversationMutedStatusUseCase
-
-    @MockK
-    private lateinit var otherUserClients: GetOtherUserClientsUseCase
-
-    @MockK
-    private lateinit var persistOtherUserClientsUseCase: PersistOtherUserClientsUseCase
-
-    @BeforeEach
-    fun setUp() {
-        MockKAnnotations.init(this, relaxUnitFun = true)
-        mockUri()
-        every { savedStateHandle.get<String>(eq(EXTRA_USER_ID)) } returns CONVERSATION_ID.toString()
-        every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns CONVERSATION_ID.toString()
-        coEvery { observeConversationRoleForUserUseCase.invoke(any(), any()) } returns flowOf(CONVERSATION_ROLE_DATA)
-        coEvery { observeUserInfo(any()) } returns flowOf(GetUserInfoResult.Success(OTHER_USER, TEAM))
-        coEvery { observeSelfUser() } returns flowOf(TestUser.SELF_USER)
-        every { userTypeMapper.toMembership(any()) } returns Membership.None
-        coEvery {
-            qualifiedIdMapper.fromStringToQualifiedID("some_value@some_domain")
-        } returns QualifiedID("some_value", "some_domain")
-        coEvery { getOrCreateOneToOneConversation(USER_ID) } returns CreateConversationResult.Success(CONVERSATION)
-        initViewModel()
-    }
-
-    private fun initViewModel() {
-        otherUserProfileScreenViewModel = OtherUserProfileScreenViewModel(
-            savedStateHandle,
-            navigationManager,
-            TestDispatcherProvider(),
-            observeSelfUser,
-            updateConversationMutedStatus,
-            blockUser,
-            unblockUser,
-            getOrCreateOneToOneConversation,
-            observeUserInfo,
-            sendConnectionRequest,
-            cancelConnectionRequest,
-            acceptConnectionRequest,
-            ignoreConnectionRequest,
-            userTypeMapper,
-            wireSessionImageLoader,
-            observeConversationRoleForUserUseCase,
-            removeMemberFromConversationUseCase,
-            updateConversationMemberRoleUseCase,
-            otherUserClients,
-            persistOtherUserClientsUseCase,
-            qualifiedIdMapper
-        )
-    }
-
     @Test
     fun `given a userId, when sending a connection request, then returns a Success result and update view state`() =
         runTest {
             // given
-            coEvery { sendConnectionRequest(any()) } returns SendConnectionRequestResult.Success
-            otherUserProfileScreenViewModel.infoMessage.test {
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withSendConnectionRequest(SendConnectionRequestResult.Success)
+                .arrange()
+            viewModel.infoMessage.test {
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onSendConnectionRequest()
+                viewModel.onSendConnectionRequest()
 
                 // then
-                coVerify { sendConnectionRequest(eq(USER_ID)) }
-                assertEquals(ConnectionState.SENT, otherUserProfileScreenViewModel.state.connectionState)
+                coVerify { arrangement.sendConnectionRequest(eq(USER_ID)) }
+                assertEquals(ConnectionState.SENT, viewModel.state.connectionState)
                 assertEquals(InfoMessageType.SuccessConnectionSentRequest.uiText, awaitItem())
             }
         }
@@ -197,17 +62,19 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a userId, when sending a connection request a fails, then returns a Failure result and show error message`() =
         runTest {
             // given
-            coEvery { sendConnectionRequest(any()) } returns SendConnectionRequestResult.Failure(Unknown(RuntimeException("some error")))
-            otherUserProfileScreenViewModel.infoMessage.test {
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withSendConnectionRequest(SendConnectionRequestResult.Failure(Unknown(RuntimeException("some error"))))
+                .arrange()
+            viewModel.infoMessage.test {
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onSendConnectionRequest()
+                viewModel.onSendConnectionRequest()
 
                 // then
                 coVerify {
-                    sendConnectionRequest(eq(USER_ID))
-                    navigationManager wasNot Called
+                    arrangement.sendConnectionRequest(eq(USER_ID))
+                    arrangement.navigationManager wasNot Called
                 }
                 assertEquals(InfoMessageType.ConnectionRequestError.uiText, awaitItem())
             }
@@ -217,32 +84,34 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a userId, when ignoring a connection request, then returns a Success result and update view state`() =
         runTest {
             // given
-            coEvery { ignoreConnectionRequest(any()) } returns IgnoreConnectionRequestUseCaseResult.Success
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withIgnoreConnectionRequest(IgnoreConnectionRequestUseCaseResult.Success)
+                .arrange()
 
             // when
-            otherUserProfileScreenViewModel.onIgnoreConnectionRequest()
+            viewModel.onIgnoreConnectionRequest()
 
             // then
-            coVerify {
-                ignoreConnectionRequest(eq(USER_ID))
-            }
-            assertEquals(ConnectionState.NOT_CONNECTED, otherUserProfileScreenViewModel.state.connectionState)
+            coVerify { arrangement.ignoreConnectionRequest(eq(USER_ID)) }
+            assertEquals(ConnectionState.NOT_CONNECTED, viewModel.state.connectionState)
         }
 
     @Test
     fun `given a userId, when canceling a connection request, then returns a Success result and update view state`() =
         runTest {
             // given
-            coEvery { cancelConnectionRequest(any()) } returns CancelConnectionRequestUseCaseResult.Success
-            otherUserProfileScreenViewModel.infoMessage.test {
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withCancelConnectionRequest(CancelConnectionRequestUseCaseResult.Success)
+                .arrange()
+            viewModel.infoMessage.test {
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onCancelConnectionRequest()
+                viewModel.onCancelConnectionRequest()
 
                 // then
-                coVerify { cancelConnectionRequest(eq(USER_ID)) }
-                assertEquals(ConnectionState.NOT_CONNECTED, otherUserProfileScreenViewModel.state.connectionState)
+                coVerify { arrangement.cancelConnectionRequest(eq(USER_ID)) }
+                assertEquals(ConnectionState.NOT_CONNECTED, viewModel.state.connectionState)
                 assertEquals(InfoMessageType.SuccessConnectionCancelRequest.uiText, awaitItem())
             }
         }
@@ -251,16 +120,18 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a userId, when accepting a connection request, then returns a Success result and update view state`() =
         runTest {
             // given
-            coEvery { acceptConnectionRequest(any()) } returns AcceptConnectionRequestUseCaseResult.Success
-            otherUserProfileScreenViewModel.infoMessage.test {
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withAcceptConnectionRequest(AcceptConnectionRequestUseCaseResult.Success)
+                .arrange()
+            viewModel.infoMessage.test {
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onAcceptConnectionRequest()
+                viewModel.onAcceptConnectionRequest()
 
                 // then
-                coVerify { acceptConnectionRequest(eq(USER_ID)) }
-                assertEquals(ConnectionState.ACCEPTED, otherUserProfileScreenViewModel.state.connectionState)
+                coVerify { arrangement.acceptConnectionRequest(eq(USER_ID)) }
+                assertEquals(ConnectionState.ACCEPTED, viewModel.state.connectionState)
                 assertEquals(InfoMessageType.SuccessConnectionAcceptRequest.uiText, awaitItem())
             }
         }
@@ -269,16 +140,17 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a conversationId, when trying to open the conversation, then returns a Success result with the conversation`() =
         runTest {
             // given
-            coEvery { getOrCreateOneToOneConversation(USER_ID) } returns CreateConversationResult.Success(CONVERSATION)
-            coEvery { navigationManager.navigate(command = any()) } returns Unit
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withGetOneToOneConversation(CreateConversationResult.Success(CONVERSATION))
+                .arrange()
 
             // when
-            otherUserProfileScreenViewModel.onOpenConversation()
+            viewModel.onOpenConversation()
 
             // then
             coVerify {
-                getOrCreateOneToOneConversation(USER_ID)
-                navigationManager.navigate(any())
+                arrangement.getOrCreateOneToOneConversation(USER_ID)
+                arrangement.navigationManager.navigate(any())
             }
         }
 
@@ -286,24 +158,27 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a conversationId, when trying to open the conversation and fails, then returns a Failure result and update error state`() =
         runTest {
             // given
-            coEvery { getOrCreateOneToOneConversation(USER_ID) } returns
-                    CreateConversationResult.Failure(Unknown(RuntimeException("some error")))
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withGetOneToOneConversation(CreateConversationResult.Failure(Unknown(RuntimeException("some error"))))
+                .arrange()
 
             // when
-            otherUserProfileScreenViewModel.onOpenConversation()
+            viewModel.onOpenConversation()
 
             // then
             coVerify {
-                getOrCreateOneToOneConversation(USER_ID)
-                navigationManager wasNot Called
+                arrangement.getOrCreateOneToOneConversation(USER_ID)
+                arrangement.navigationManager wasNot Called
             }
         }
 
     @Test
     fun `given a navigation case, when going back requested, then should delegate call to manager navigateBack`() = runTest {
-        otherUserProfileScreenViewModel.navigateBack()
+        val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+            .arrange()
+        viewModel.navigateBack()
 
-        coVerify(exactly = 1) { navigationManager.navigateBack() }
+        coVerify(exactly = 1) { arrangement.navigationManager.navigateBack() }
     }
 
     @Test
@@ -311,15 +186,18 @@ class OtherUserProfileScreenViewModelTest {
         runTest {
             // given
             val expected = OtherUserProfileGroupState("some_name", Member.Role.Member, false, CONVERSATION_ID)
-            every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns CONVERSATION_ID.toString()
-            coEvery { getOrCreateOneToOneConversation(USER_ID) } returns CreateConversationResult.Success(CONVERSATION)
-            initViewModel()
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withConversationIdInSavedState(CONVERSATION_ID.toString())
+                .withGetOneToOneConversation(CreateConversationResult.Success(CONVERSATION))
+                .arrange()
+
             // when
-            val groupState = otherUserProfileScreenViewModel.state.groupState
+            val groupState = viewModel.state.groupState
+
             // then
             coVerify {
-                observeConversationRoleForUserUseCase(CONVERSATION_ID, USER_ID)
-                navigationManager wasNot Called
+                arrangement.observeConversationRoleForUserUseCase(CONVERSATION_ID, USER_ID)
+                arrangement.navigationManager wasNot Called
             }
             assertEquals(groupState, expected)
         }
@@ -328,14 +206,17 @@ class OtherUserProfileScreenViewModelTest {
     fun `given no conversationId, when loading the data, then return null group state`() =
         runTest {
             // given
-            every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns null
-            initViewModel()
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withConversationIdInSavedState(null)
+                .arrange()
+
             // when
-            val groupState = otherUserProfileScreenViewModel.state.groupState
+            val groupState = viewModel.state.groupState
+
             // then
             coVerify {
-                observeConversationRoleForUserUseCase(any(), any()) wasNot Called
-                navigationManager wasNot Called
+                arrangement.observeConversationRoleForUserUseCase(any(), any()) wasNot Called
+                arrangement.navigationManager wasNot Called
             }
             assertEquals(groupState, null)
         }
@@ -344,19 +225,20 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a group conversationId, when changing the role, then the request should be configured correctly`() =
         runTest {
             // given
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withUpdateConversationMemberRole(UpdateConversationMemberRoleResult.Success)
+                .arrange()
             val newRole = Member.Role.Admin
-            coEvery { updateConversationMemberRoleUseCase(CONVERSATION_ID, USER_ID, any()) } returns
-                    UpdateConversationMemberRoleResult.Success
-            otherUserProfileScreenViewModel.infoMessage.test {
+            viewModel.infoMessage.test {
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onChangeMemberRole(newRole)
+                viewModel.onChangeMemberRole(newRole)
 
                 // then
                 coVerify {
-                    updateConversationMemberRoleUseCase(CONVERSATION_ID, USER_ID, newRole)
-                    navigationManager wasNot Called
+                    arrangement.updateConversationMemberRoleUseCase(CONVERSATION_ID, USER_ID, newRole)
+                    arrangement.navigationManager wasNot Called
                 }
                 expectNoEvents()
             }
@@ -366,19 +248,20 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a group conversationId and a failed response when changing the role, then show info message`() =
         runTest {
             // given
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withUpdateConversationMemberRole(UpdateConversationMemberRoleResult.Failure)
+                .arrange()
             val newRole = Member.Role.Admin
-            coEvery { updateConversationMemberRoleUseCase(CONVERSATION_ID, USER_ID, any()) } returns
-                    UpdateConversationMemberRoleResult.Failure
-            otherUserProfileScreenViewModel.infoMessage.test {
+            viewModel.infoMessage.test {
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onChangeMemberRole(newRole)
+                viewModel.onChangeMemberRole(newRole)
 
                 // then
                 coVerify {
-                    updateConversationMemberRoleUseCase(CONVERSATION_ID, USER_ID, newRole)
-                    navigationManager wasNot Called
+                    arrangement.updateConversationMemberRoleUseCase(CONVERSATION_ID, USER_ID, newRole)
+                    arrangement.navigationManager wasNot Called
                 }
                 assertEquals(InfoMessageType.ChangeGroupRoleError.uiText, awaitItem())
             }
@@ -388,48 +271,97 @@ class OtherUserProfileScreenViewModelTest {
     fun `given a userId, when blocking user fails, then show error message and dismiss BlockDialog`() =
         runTest {
             // given
-            coEvery { blockUser(any()) } returns BlockUserResult.Failure(Unknown(RuntimeException("some error")))
-            otherUserProfileScreenViewModel.infoMessage.test {
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withBlockUserResult(BlockUserResult.Failure(Unknown(RuntimeException("some error"))))
+                .arrange()
+            viewModel.infoMessage.test {
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onBlockUser(USER_ID, "some name")
+                viewModel.onBlockUser(USER_ID, "some name")
 
                 // then
-                coVerify {
-                    blockUser(eq(USER_ID))
-                }
+                coVerify { arrangement.blockUser(eq(USER_ID)) }
                 assertEquals(InfoMessageType.BlockingUserOperationError.uiText, awaitItem())
-                assertEquals(null, otherUserProfileScreenViewModel.blockUserDialogState)
+                assertEquals(null, viewModel.blockUserDialogState)
             }
         }
 
     @Test
-    fun `given a userId, when blocking user is succeed, then returns show Success message and dismiss BlockDialog`() =
+    fun `given a userId, when blocking user is succeed, then show Success message and dismiss BlockDialog`() =
         runTest {
             // given
-            coEvery { blockUser(any()) } returns BlockUserResult.Success
-            initViewModel()
-            otherUserProfileScreenViewModel.infoMessage.test {
+            val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+                .withBlockUserResult(BlockUserResult.Success)
+                .arrange()
+            viewModel.infoMessage.test {
                 val userName = "some name"
 
                 // when
                 expectNoEvents()
-                otherUserProfileScreenViewModel.onBlockUser(USER_ID, userName)
+                viewModel.onBlockUser(USER_ID, userName)
 
                 // then
-                coVerify {
-                    blockUser(eq(USER_ID))
-                }
+                coVerify { arrangement.blockUser(eq(USER_ID)) }
                 assertEquals(
                     (awaitItem() as UIText.StringResource).resId,
                     (InfoMessageType.BlockingUserOperationSuccess(userName).uiText as UIText.StringResource).resId
                 )
-                assertEquals(null, otherUserProfileScreenViewModel.blockUserDialogState)
+                assertEquals(null, viewModel.blockUserDialogState)
             }
         }
 
-    // todo: add tests for cancel request
+    @Test
+    fun `given not connected user, then direct conversation is not requested`() = runTest {
+        //giver
+        val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+            .arrange()
+
+        //then
+        coVerify {
+            arrangement.getOrCreateOneToOneConversation wasNot Called
+        }
+    }
+
+    @Test
+    fun `given connected user, then direct conversation data is requested`() = runTest {
+        //giver
+        val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+            .withUserInfo(
+                GetUserInfoResult.Success(OTHER_USER.copy(connectionStatus = ConnectionState.ACCEPTED), TEAM)
+            )
+            .arrange()
+
+        //then
+        coVerify {
+            arrangement.getOrCreateOneToOneConversation(USER_ID)
+        }
+    }
+
+    @Test
+    fun `given connected user AND direct conversation data error, then the other data is displayed`() = runTest {
+        //giver
+        val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
+            .withUserInfo(
+                GetUserInfoResult.Success(OTHER_USER.copy(connectionStatus = ConnectionState.ACCEPTED), TEAM)
+            )
+            .withGetOneToOneConversation(CreateConversationResult.Failure(Unknown(RuntimeException("some error"))))
+            .arrange()
+
+        // then
+        coVerify {
+            arrangement.getOrCreateOneToOneConversation(USER_ID)
+        }
+
+        assertEquals(false, viewModel.state.isDataLoading)
+        assertEquals(OTHER_USER.name.orEmpty(), viewModel.state.fullName)
+        assertEquals(UsernameMapper.mapUserLabel(OTHER_USER), viewModel.state.userName)
+        assertEquals(TEAM.name.orEmpty(), viewModel.state.teamName)
+        assertEquals(OTHER_USER.email.orEmpty(), viewModel.state.email)
+        assertEquals(OTHER_USER.phone.orEmpty(), viewModel.state.phone)
+        assertEquals(ConnectionState.ACCEPTED, viewModel.state.connectionState)
+        assertEquals(OTHER_USER.botService, viewModel.state.botService)
+    }
 
     companion object {
         val USER_ID = UserId("some_value", "some_domain")

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -313,11 +313,11 @@ class OtherUserProfileScreenViewModelTest {
 
     @Test
     fun `given not connected user, then direct conversation is not requested`() = runTest {
-        //giver
+        // given
         val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
             .arrange()
 
-        //then
+        // then
         coVerify {
             arrangement.getOrCreateOneToOneConversation wasNot Called
         }
@@ -325,14 +325,14 @@ class OtherUserProfileScreenViewModelTest {
 
     @Test
     fun `given connected user, then direct conversation data is requested`() = runTest {
-        //giver
+        // given
         val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
             .withUserInfo(
                 GetUserInfoResult.Success(OTHER_USER.copy(connectionStatus = ConnectionState.ACCEPTED), TEAM)
             )
             .arrange()
 
-        //then
+        // then
         coVerify {
             arrangement.getOrCreateOneToOneConversation(USER_ID)
         }
@@ -340,7 +340,7 @@ class OtherUserProfileScreenViewModelTest {
 
     @Test
     fun `given connected user AND direct conversation data error, then the other data is displayed`() = runTest {
-        //giver
+        // given
         val (arrangement, viewModel) = OtherUserProfileViewModelArrangement()
             .withUserInfo(
                 GetUserInfoResult.Success(OTHER_USER.copy(connectionStatus = ConnectionState.ACCEPTED), TEAM)

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -1,0 +1,193 @@
+package com.wire.android.ui.userprofile.other
+
+import androidx.lifecycle.SavedStateHandle
+import com.wire.android.config.TestDispatcherProvider
+import com.wire.android.config.mockUri
+import com.wire.android.framework.TestUser
+import com.wire.android.mapper.UserTypeMapper
+import com.wire.android.navigation.EXTRA_CONVERSATION_ID
+import com.wire.android.navigation.EXTRA_USER_ID
+import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.home.conversations.details.participants.usecase.ObserveConversationRoleForUserUseCase
+import com.wire.android.ui.home.conversationslist.model.Membership
+import com.wire.android.util.ui.WireSessionImageLoader
+import com.wire.kalium.logic.data.id.QualifiedID
+import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.feature.client.GetOtherUserClientsUseCase
+import com.wire.kalium.logic.feature.client.PersistOtherUserClientsUseCase
+import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCase
+import com.wire.kalium.logic.feature.connection.AcceptConnectionRequestUseCaseResult
+import com.wire.kalium.logic.feature.connection.BlockUserResult
+import com.wire.kalium.logic.feature.connection.BlockUserUseCase
+import com.wire.kalium.logic.feature.connection.CancelConnectionRequestUseCase
+import com.wire.kalium.logic.feature.connection.CancelConnectionRequestUseCaseResult
+import com.wire.kalium.logic.feature.connection.IgnoreConnectionRequestUseCase
+import com.wire.kalium.logic.feature.connection.IgnoreConnectionRequestUseCaseResult
+import com.wire.kalium.logic.feature.connection.SendConnectionRequestResult
+import com.wire.kalium.logic.feature.connection.SendConnectionRequestUseCase
+import com.wire.kalium.logic.feature.connection.UnblockUserUseCase
+import com.wire.kalium.logic.feature.conversation.CreateConversationResult
+import com.wire.kalium.logic.feature.conversation.GetOrCreateOneToOneConversationUseCase
+import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
+import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
+import com.wire.kalium.logic.feature.conversation.UpdateConversationMutedStatusUseCase
+import com.wire.kalium.logic.feature.user.GetSelfUserUseCase
+import com.wire.kalium.logic.feature.user.GetUserInfoResult
+import com.wire.kalium.logic.feature.user.ObserveUserInfoUseCase
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.flowOf
+
+internal class OtherUserProfileViewModelArrangement {
+    @MockK
+    lateinit var navigationManager: NavigationManager
+
+    @MockK
+    lateinit var savedStateHandle: SavedStateHandle
+
+    @MockK
+    lateinit var getOrCreateOneToOneConversation: GetOrCreateOneToOneConversationUseCase
+
+    @MockK
+    lateinit var observeUserInfo: ObserveUserInfoUseCase
+
+    @MockK
+    lateinit var sendConnectionRequest: SendConnectionRequestUseCase
+
+    @MockK
+    lateinit var cancelConnectionRequest: CancelConnectionRequestUseCase
+
+    @MockK
+    lateinit var acceptConnectionRequest: AcceptConnectionRequestUseCase
+
+    @MockK
+    lateinit var ignoreConnectionRequest: IgnoreConnectionRequestUseCase
+
+    @MockK
+    lateinit var wireSessionImageLoader: WireSessionImageLoader
+
+    @MockK
+    lateinit var observeConversationRoleForUserUseCase: ObserveConversationRoleForUserUseCase
+
+    @MockK
+    lateinit var userTypeMapper: UserTypeMapper
+
+    @MockK
+    lateinit var qualifiedIdMapper: QualifiedIdMapper
+
+    @MockK
+    lateinit var updateConversationMemberRoleUseCase: UpdateConversationMemberRoleUseCase
+
+    @MockK
+    lateinit var removeMemberFromConversationUseCase: RemoveMemberFromConversationUseCase
+
+    @MockK
+    lateinit var observeSelfUser: GetSelfUserUseCase
+
+    @MockK
+    lateinit var blockUser: BlockUserUseCase
+
+    @MockK
+    lateinit var unblockUser: UnblockUserUseCase
+
+    @MockK
+    lateinit var updateConversationMutedStatus: UpdateConversationMutedStatusUseCase
+
+    @MockK
+    lateinit var otherUserClients: GetOtherUserClientsUseCase
+
+    @MockK
+    lateinit var persistOtherUserClientsUseCase: PersistOtherUserClientsUseCase
+
+    private val viewModel by lazy {
+        OtherUserProfileScreenViewModel(
+            savedStateHandle,
+            navigationManager,
+            TestDispatcherProvider(),
+            observeSelfUser,
+            updateConversationMutedStatus,
+            blockUser,
+            unblockUser,
+            getOrCreateOneToOneConversation,
+            observeUserInfo,
+            sendConnectionRequest,
+            cancelConnectionRequest,
+            acceptConnectionRequest,
+            ignoreConnectionRequest,
+            userTypeMapper,
+            wireSessionImageLoader,
+            observeConversationRoleForUserUseCase,
+            removeMemberFromConversationUseCase,
+            updateConversationMemberRoleUseCase,
+            otherUserClients,
+            persistOtherUserClientsUseCase,
+            qualifiedIdMapper
+        )
+    }
+
+    init {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        mockUri()
+        every { savedStateHandle.get<String>(eq(EXTRA_USER_ID)) } returns OtherUserProfileScreenViewModelTest.CONVERSATION_ID.toString()
+        every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns OtherUserProfileScreenViewModelTest.CONVERSATION_ID.toString()
+        coEvery {
+            observeConversationRoleForUserUseCase.invoke(any(), any())
+        } returns flowOf(OtherUserProfileScreenViewModelTest.CONVERSATION_ROLE_DATA)
+        coEvery { observeUserInfo(any()) } returns flowOf(
+            GetUserInfoResult.Success(
+                OtherUserProfileScreenViewModelTest.OTHER_USER,
+                OtherUserProfileScreenViewModelTest.TEAM
+            )
+        )
+        coEvery { observeSelfUser() } returns flowOf(TestUser.SELF_USER)
+        every { userTypeMapper.toMembership(any()) } returns Membership.None
+        coEvery {
+            qualifiedIdMapper.fromStringToQualifiedID("some_value@some_domain")
+        } returns QualifiedID("some_value", "some_domain")
+        coEvery { getOrCreateOneToOneConversation(OtherUserProfileScreenViewModelTest.USER_ID) } returns CreateConversationResult.Success(
+            OtherUserProfileScreenViewModelTest.CONVERSATION
+        )
+        coEvery { navigationManager.navigate(command = any()) } returns Unit
+    }
+
+    suspend fun withBlockUserResult(result: BlockUserResult) = apply {
+        coEvery { blockUser(any()) } returns result
+    }
+
+    suspend fun withUpdateConversationMemberRole(result: UpdateConversationMemberRoleResult) = apply {
+        coEvery { updateConversationMemberRoleUseCase(any(), any(), any()) } returns result
+    }
+
+    fun withConversationIdInSavedState(conversationIdString: String?) = apply {
+        every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns conversationIdString
+    }
+
+    fun withGetOneToOneConversation(result: CreateConversationResult) = apply {
+        coEvery { getOrCreateOneToOneConversation(OtherUserProfileScreenViewModelTest.USER_ID) } returns result
+    }
+
+    fun withAcceptConnectionRequest(result: AcceptConnectionRequestUseCaseResult) = apply {
+        coEvery { acceptConnectionRequest(any()) } returns result
+    }
+
+    fun withCancelConnectionRequest(result: CancelConnectionRequestUseCaseResult) = apply {
+        coEvery { cancelConnectionRequest(any()) } returns result
+    }
+
+    fun withIgnoreConnectionRequest(result: IgnoreConnectionRequestUseCaseResult) = apply {
+        coEvery { ignoreConnectionRequest(any()) } returns result
+    }
+
+    fun withSendConnectionRequest(result: SendConnectionRequestResult) = apply {
+        coEvery { sendConnectionRequest(any()) } returns result
+    }
+
+    suspend fun withUserInfo(result: GetUserInfoResult) = apply {
+        coEvery { observeUserInfo(any()) } returns flowOf(result)
+    }
+
+    fun arrange() = this to viewModel
+}

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -132,7 +132,8 @@ internal class OtherUserProfileViewModelArrangement {
         MockKAnnotations.init(this, relaxUnitFun = true)
         mockUri()
         every { savedStateHandle.get<String>(eq(EXTRA_USER_ID)) } returns OtherUserProfileScreenViewModelTest.CONVERSATION_ID.toString()
-        every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns OtherUserProfileScreenViewModelTest.CONVERSATION_ID.toString()
+        every { savedStateHandle.get<String>(eq(EXTRA_CONVERSATION_ID)) } returns
+                OtherUserProfileScreenViewModelTest.CONVERSATION_ID.toString()
         coEvery {
             observeConversationRoleForUserUseCase.invoke(any(), any())
         } returns flowOf(OtherUserProfileScreenViewModelTest.CONVERSATION_ROLE_DATA)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2190" title="AR-2190" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2190</a>  User Profiles are empty for unconnected Users
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

UserProfile is not loaded for not connected user and error is displayed

### Causes (Optional)

when the OtherUserProfile is opened app was trying to get ALL the necessary data and combine it into  a `state`
including: 
- `getOrCreateOneToOneConversation` which is needed only for connected users for BottomSheet menu
- `observeConversationRoleForUser` which is needed only for case when user came from the ConversationScreen, to display otherUser's role in that conversation.

And when user opens OtherUserProfile Screen for not connected user `getOrCreateOneToOneConversation` returns Error, which "breaks"  the whole state.

### Solutions

Make app request `getOrCreateOneToOneConversation` only if otherUser is connected.
