### PR TITLE
fix: Delete message from gallery (AR-1748)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -311,13 +311,15 @@ enum class NavigationItem(
 
     Gallery(
         primaryRoute = MEDIA_GALLERY,
-        canonicalRoute = "$MEDIA_GALLERY/{$EXTRA_IMAGE_DATA}",
+        canonicalRoute = "$MEDIA_GALLERY/{$EXTRA_CONVERSATION_ID}/{$EXTRA_IMAGE_DATA}",
         content = { MediaGalleryScreen() }
     ) {
         override fun getRouteWithArgs(arguments: List<Any>): String {
             val imageAssetId: ImageAsset.PrivateAsset? = arguments.filterIsInstance<ImageAsset.PrivateAsset>().firstOrNull()
             val mappedArgs = imageAssetId?.toString() ?: ""
-            return imageAssetId?.run { "$primaryRoute/$mappedArgs" } ?: primaryRoute
+            val conversationIdString: String = arguments.filterIsInstance<ConversationId>().firstOrNull()?.toString()
+                ?: "{$EXTRA_CONVERSATION_ID}"
+            return imageAssetId?.run { "$primaryRoute/$conversationIdString/$mappedArgs" } ?: primaryRoute
         }
     };
 

--- a/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
+++ b/app/src/main/kotlin/com/wire/android/navigation/NavigationItem.kt
@@ -311,15 +311,13 @@ enum class NavigationItem(
 
     Gallery(
         primaryRoute = MEDIA_GALLERY,
-        canonicalRoute = "$MEDIA_GALLERY/{$EXTRA_CONVERSATION_ID}/{$EXTRA_IMAGE_DATA}",
+        canonicalRoute = "$MEDIA_GALLERY/{$EXTRA_IMAGE_DATA}",
         content = { MediaGalleryScreen() }
     ) {
         override fun getRouteWithArgs(arguments: List<Any>): String {
             val imageAssetId: ImageAsset.PrivateAsset? = arguments.filterIsInstance<ImageAsset.PrivateAsset>().firstOrNull()
             val mappedArgs = imageAssetId?.toString() ?: ""
-            val conversationIdString: String = arguments.filterIsInstance<ConversationId>().firstOrNull()?.toString()
-                ?: "{$EXTRA_CONVERSATION_ID}"
-            return imageAssetId?.run { "$primaryRoute/$conversationIdString/$mappedArgs" } ?: primaryRoute
+            return imageAssetId?.run { "$primaryRoute/$mappedArgs" } ?: primaryRoute
         }
     };
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -125,7 +125,10 @@ fun ConversationScreen(
         commonTopAppBarViewModel = commonTopAppBarViewModel
     )
 
-    DeleteMessageDialog(conversationViewModel = conversationViewModel)
+    DeleteMessageDialog(
+        state = conversationViewModel.deleteMessageDialogsState,
+        actions = conversationViewModel.deleteMessageHelper
+    )
     DownloadedAssetDialog(
         downloadedAssetDialogState = conversationViewModel.conversationViewState.downloadedAssetDialogState,
         onSaveFileToExternalStorage = conversationViewModel::onSaveFile,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -561,7 +561,6 @@ class ConversationViewModel @Inject constructor(
                 command = NavigationCommand(
                     destination = NavigationItem.Gallery.getRouteWithArgs(
                         listOf(
-                            conversationId,
                             PrivateAsset(wireSessionImageLoader, conversationId, messageId, isSelfMessage)
                         )
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationViewModel.kt
@@ -28,6 +28,9 @@ import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.Error
 import com.wire.android.ui.home.conversations.ConversationSnackbarMessages.OnFileDownloaded
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState.Displayed
 import com.wire.android.ui.home.conversations.DownloadedAssetDialogVisibilityState.Hidden
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.MessageContent.AssetMessage
@@ -130,6 +133,15 @@ class ConversationViewModel @Inject constructor(
     )
 
     var establishedCallConversationId: ConversationId? = null
+
+    val deleteMessageHelper = DeleteMessageDialogHelper(
+        viewModelScope,
+        conversationId,
+        ::updateDeleteDialogState
+    ) { messageId, deleteForEveryone ->
+        deleteMessage(conversationId = conversationId, messageId = messageId, deleteForEveryone = deleteForEveryone)
+            .onFailure { onSnackbarMessage(ErrorDeletingMessage) }
+    }
 
     init {
         observeConversationDetailsAndMessages()
@@ -461,31 +473,6 @@ class ConversationViewModel @Inject constructor(
             }
         }
 
-    fun showDeleteMessageForYourselfDialog(messageId: String) {
-        updateDeleteDialogState { it.copy(forEveryone = DeleteMessageDialogActiveState.Hidden) }
-        updateDeleteDialogState {
-            it.copy(
-                forYourself = DeleteMessageDialogActiveState.Visible(
-                    messageId = messageId,
-                    conversationId = conversationId
-                )
-            )
-        }
-    }
-
-    fun onDeleteDialogDismissed() {
-        updateDeleteDialogState {
-            it.copy(
-                forEveryone = DeleteMessageDialogActiveState.Hidden,
-                forYourself = DeleteMessageDialogActiveState.Hidden
-            )
-        }
-    }
-
-    fun clearDeleteMessageError() {
-        updateStateIfDialogVisible { it.copy(error = DeleteMessageError.None) }
-    }
-
     fun joinOngoingCall() {
         viewModelScope.launch {
             answerCall(conversationId = conversationId)
@@ -500,55 +487,10 @@ class ConversationViewModel @Inject constructor(
     private fun updateDeleteDialogState(newValue: (DeleteMessageDialogsState.States) -> DeleteMessageDialogsState) =
         (deleteMessageDialogsState as? DeleteMessageDialogsState.States)?.let { deleteMessageDialogsState = newValue(it) }
 
-    private fun updateStateIfDialogVisible(newValue: (DeleteMessageDialogActiveState.Visible) -> DeleteMessageDialogActiveState) =
-        updateDeleteDialogState {
-            when {
-                it.forEveryone is DeleteMessageDialogActiveState.Visible -> it.copy(forEveryone = newValue(it.forEveryone))
-                it.forYourself is DeleteMessageDialogActiveState.Visible -> it.copy(
-                    forYourself = newValue(
-                        it.forYourself
-                    )
-                )
-                else -> it
-            }
-        }
-
     fun updateConversationReadDate(utcISO: String) {
         viewModelScope.launch(dispatchers.io()) {
             updateConversationReadDateUseCase(conversationId, Instant.parse(utcISO))
         }
-    }
-
-    fun deleteMessage(messageId: String, deleteForEveryone: Boolean) = viewModelScope.launch {
-        // update dialogs state to loading
-        if (deleteForEveryone) {
-            updateDeleteDialogState {
-                it.copy(
-                    forEveryone = DeleteMessageDialogActiveState.Visible(
-                        messageId = messageId,
-                        conversationId = conversationId,
-                        loading = true
-                    )
-                )
-            }
-        } else {
-            updateDeleteDialogState {
-                it.copy(
-                    forYourself = DeleteMessageDialogActiveState.Visible(
-                        messageId = messageId,
-                        conversationId = conversationId,
-                        loading = true
-                    )
-                )
-            }
-        }
-        deleteMessage(conversationId = conversationId, messageId = messageId, deleteForEveryone = deleteForEveryone)
-            .onFailure { onDeleteMessageError() }
-        onDeleteDialogDismissed()
-    }
-
-    private fun onDeleteMessageError() {
-        onSnackbarMessage(ErrorDeletingMessage)
     }
 
     private suspend fun assetDataPath(conversationId: ConversationId, messageId: String): Path? {
@@ -619,6 +561,7 @@ class ConversationViewModel @Inject constructor(
                 command = NavigationCommand(
                     destination = NavigationItem.Gallery.getRouteWithArgs(
                         listOf(
+                            conversationId,
                             PrivateAsset(wireSessionImageLoader, conversationId, messageId, isSelfMessage)
                         )
                     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/SnackbarMessages.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/SnackbarMessages.kt
@@ -15,4 +15,5 @@ sealed class ConversationSnackbarMessages {
 sealed class MediaGallerySnackbarMessages {
     class OnImageDownloaded(val assetName: String? = null) : MediaGallerySnackbarMessages()
     object OnImageDownloadError : MediaGallerySnackbarMessages()
+    object DeletingMessageError: MediaGallerySnackbarMessages()
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialog.kt
@@ -8,38 +8,33 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
-import com.wire.android.ui.home.conversations.ConversationViewModel
-import com.wire.android.ui.home.conversations.DeleteMessageDialogActiveState
-import com.wire.android.ui.home.conversations.DeleteMessageDialogsState
-import com.wire.android.ui.home.conversations.DeleteMessageError
 import com.wire.android.util.dialogErrorStrings
 
 @Composable
-internal fun DeleteMessageDialog(conversationViewModel: ConversationViewModel) {
-    val deleteMessageDialogsState = conversationViewModel.deleteMessageDialogsState
+internal fun DeleteMessageDialog(state: DeleteMessageDialogsState, actions: DeleteMessageDialogHelper) {
 
-    if (deleteMessageDialogsState is DeleteMessageDialogsState.States) {
+    if (state is DeleteMessageDialogsState.States) {
         when {
-            deleteMessageDialogsState.forEveryone is DeleteMessageDialogActiveState.Visible -> {
+            state.forEveryone is DeleteMessageDialogActiveState.Visible -> {
                 DeleteMessageDialog(
-                    state = deleteMessageDialogsState.forEveryone,
-                    onDialogDismiss = conversationViewModel::onDeleteDialogDismissed,
-                    onDeleteForMe = conversationViewModel::showDeleteMessageForYourselfDialog,
-                    onDeleteForEveryone = conversationViewModel::deleteMessage,
+                    state = state.forEveryone,
+                    onDialogDismiss = actions::onDeleteDialogDismissed,
+                    onDeleteForMe = actions::showDeleteMessageForYourselfDialog,
+                    onDeleteForEveryone = actions::onDeleteMessage,
                 )
-                if (deleteMessageDialogsState.forEveryone.error is DeleteMessageError.GenericError) {
-                    DeleteMessageErrorDialog(deleteMessageDialogsState.forEveryone.error, conversationViewModel::clearDeleteMessageError)
+                if (state.forEveryone.error is DeleteMessageError.GenericError) {
+                    DeleteMessageErrorDialog(state.forEveryone.error, actions::clearDeleteMessageError)
                 }
             }
-            deleteMessageDialogsState.forYourself is DeleteMessageDialogActiveState.Visible -> {
+            state.forYourself is DeleteMessageDialogActiveState.Visible -> {
 
-                if (deleteMessageDialogsState.forYourself.error is DeleteMessageError.GenericError) {
-                    DeleteMessageErrorDialog(deleteMessageDialogsState.forYourself.error, conversationViewModel::clearDeleteMessageError)
+                if (state.forYourself.error is DeleteMessageError.GenericError) {
+                    DeleteMessageErrorDialog(state.forYourself.error, actions::clearDeleteMessageError)
                 } else {
                     DeleteMessageForYourselfDialog(
-                        state = deleteMessageDialogsState.forYourself,
-                        onDialogDismiss = conversationViewModel::onDeleteDialogDismissed,
-                        onDeleteForMe = conversationViewModel::deleteMessage
+                        state = state.forYourself,
+                        onDialogDismiss = actions::onDeleteDialogDismissed,
+                        onDeleteForMe = actions::onDeleteMessage
                     )
                 }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogHelper.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogHelper.kt
@@ -1,0 +1,78 @@
+package com.wire.android.ui.home.conversations.delete
+
+import com.wire.kalium.logic.data.id.QualifiedID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class DeleteMessageDialogHelper(
+    val scope: CoroutineScope,
+    val conversationId: QualifiedID,
+    private val updateDeleteDialogState: ((DeleteMessageDialogsState.States) -> DeleteMessageDialogsState) -> Unit,
+    private val deleteMessage: suspend (String, Boolean) -> Unit
+) {
+
+    private fun updateStateIfDialogVisible(newValue: (DeleteMessageDialogActiveState.Visible) -> DeleteMessageDialogActiveState) =
+        updateDeleteDialogState {
+            when {
+                it.forEveryone is DeleteMessageDialogActiveState.Visible -> it.copy(forEveryone = newValue(it.forEveryone))
+                it.forYourself is DeleteMessageDialogActiveState.Visible -> it.copy(forYourself = newValue(it.forYourself))
+                else -> it
+            }
+        }
+
+    fun showDeleteMessageForYourselfDialog(messageId: String) {
+        updateDeleteDialogState {
+            it.copy(
+                forEveryone = DeleteMessageDialogActiveState.Hidden,
+                forYourself = DeleteMessageDialogActiveState.Visible(
+                    messageId = messageId,
+                    conversationId = conversationId
+                )
+            )
+        }
+    }
+
+    fun onDeleteDialogDismissed() {
+        updateDeleteDialogState {
+            it.copy(
+                forEveryone = DeleteMessageDialogActiveState.Hidden,
+                forYourself = DeleteMessageDialogActiveState.Hidden
+            )
+        }
+    }
+
+    fun clearDeleteMessageError() {
+        updateStateIfDialogVisible { it.copy(error = DeleteMessageError.None) }
+    }
+
+    fun onDeleteMessage(messageId: String, deleteForEveryone: Boolean) {
+        scope.launch {
+            // update dialogs state to loading
+            if (deleteForEveryone) {
+                updateDeleteDialogState {
+                    it.copy(
+                        forEveryone = DeleteMessageDialogActiveState.Visible(
+                            messageId = messageId,
+                            conversationId = conversationId,
+                            loading = true
+                        )
+                    )
+                }
+            } else {
+                updateDeleteDialogState {
+                    it.copy(
+                        forYourself = DeleteMessageDialogActiveState.Visible(
+                            messageId = messageId,
+                            conversationId = conversationId,
+                            loading = true
+                        )
+                    )
+                }
+            }
+
+            deleteMessage(messageId, deleteForEveryone)
+
+            onDeleteDialogDismissed()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogsState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/delete/DeleteMessageDialogsState.kt
@@ -1,4 +1,4 @@
-package com.wire.android.ui.home.conversations
+package com.wire.android.ui.home.conversations.delete
 
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.id.QualifiedID as ConversationId

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModel.kt
@@ -9,23 +9,26 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.model.ImageAsset
 import com.wire.android.model.parseIntoPrivateImageAsset
 import com.wire.android.navigation.EXTRA_IMAGE_DATA
-import com.wire.android.navigation.EXTRA_MESSAGE_TO_DELETE_ID
-import com.wire.android.navigation.EXTRA_MESSAGE_TO_DELETE_IS_SELF
 import com.wire.android.navigation.NavigationManager
-import com.wire.android.ui.home.conversations.ConversationViewModel
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogHelper
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.util.FileManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.getCurrentParsedDateTime
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.conversation.ConversationDetails
-import com.wire.kalium.logic.data.id.FederatedIdMapper
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult.Success
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
+import com.wire.kalium.logic.functional.onFailure
+import com.wire.kalium.logic.functional.onSuccess
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -43,16 +46,30 @@ class MediaGalleryViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val getImageData: GetMessageAssetUseCase,
     private val fileManager: FileManager,
+    private val deleteMessage: DeleteMessageUseCase,
 ) : ViewModel() {
 
     var mediaGalleryViewState by mutableStateOf(MediaGalleryViewState())
         private set
+
+    private val _snackbarMessage = MutableSharedFlow<MediaGallerySnackbarMessages>()
+    val snackbarMessage = _snackbarMessage.asSharedFlow()
 
     val imageAssetId: ImageAsset.PrivateAsset =
         savedStateHandle.get<String>(EXTRA_IMAGE_DATA)!!.parseIntoPrivateImageAsset(
             wireSessionImageLoader,
             qualifiedIdMapper
         )
+
+    val deleteMessageHelper = DeleteMessageDialogHelper(
+        viewModelScope,
+        imageAssetId.conversationId,
+        ::updateDeleteDialogState
+    ) { messageId, deleteForEveryone ->
+        deleteMessage(conversationId = imageAssetId.conversationId, messageId = messageId, deleteForEveryone = deleteForEveryone)
+            .onFailure { onSnackbarMessage(MediaGallerySnackbarMessages.DeletingMessageError) }
+            .onSuccess { navigateBack() }
+    }
 
     init {
         observeConversationDetails()
@@ -70,6 +87,7 @@ class MediaGalleryViewModel @Inject constructor(
     }
 
     private fun getScreenTitle(conversationDetails: ConversationDetails): String? {
+        println("cyka 11 $conversationDetails")
         return when (conversationDetails) {
             is ConversationDetails.OneOne -> conversationDetails.otherUser.name
             is ConversationDetails.Group -> conversationDetails.conversation.name
@@ -99,11 +117,7 @@ class MediaGalleryViewModel @Inject constructor(
 
     private fun onSnackbarMessage(messageCode: MediaGallerySnackbarMessages) {
         viewModelScope.launch {
-            // We need to reset the onSnackbarMessage state so that it doesn't show up again when going -> background -> resume back
-            // The delay added, is to ensure the snackbar message will have enough time to be shown before it is reset to null
-            mediaGalleryViewState = mediaGalleryViewState.copy(onSnackbarMessage = messageCode)
-            delay(ConversationViewModel.SNACKBAR_MESSAGE_DELAY)
-            mediaGalleryViewState = mediaGalleryViewState.copy(onSnackbarMessage = null)
+            _snackbarMessage.emit(messageCode)
         }
     }
 
@@ -121,14 +135,31 @@ class MediaGalleryViewModel @Inject constructor(
         }
     }
 
-    fun deleteCurrentImageMessage() {
-        viewModelScope.launch {
-            navigationManager.navigateBack(
-                mapOf(
-                    EXTRA_MESSAGE_TO_DELETE_ID to imageAssetId.messageId,
-                    EXTRA_MESSAGE_TO_DELETE_IS_SELF to imageAssetId.isSelfAsset
+    fun deleteCurrentImage() {
+        if (imageAssetId.isSelfAsset) {
+            updateDeleteDialogState {
+                it.copy(
+                    forEveryone = DeleteMessageDialogActiveState.Visible(
+                        messageId = imageAssetId.messageId,
+                        conversationId = imageAssetId.conversationId
+                    )
                 )
-            )
+            }
+        } else {
+            updateDeleteDialogState {
+                it.copy(
+                    forYourself = DeleteMessageDialogActiveState.Visible(
+                        messageId = imageAssetId.messageId,
+                        conversationId = imageAssetId.conversationId
+                    )
+                )
+            }
+        }
+    }
+
+    private fun updateDeleteDialogState(newValue: (DeleteMessageDialogsState.States) -> DeleteMessageDialogsState) {
+        (mediaGalleryViewState.deleteMessageDialogsState as? DeleteMessageDialogsState.States)?.let {
+            mediaGalleryViewState = mediaGalleryViewState.copy(deleteMessageDialogsState = newValue(it))
         }
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewState.kt
@@ -1,8 +1,14 @@
 package com.wire.android.ui.home.gallery
 
 import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 
 data class MediaGalleryViewState(
     val screenTitle: String? = null,
     val onSnackbarMessage: MediaGallerySnackbarMessages? = null,
+    val deleteMessageDialogsState: DeleteMessageDialogsState = DeleteMessageDialogsState.States(
+        forYourself = DeleteMessageDialogActiveState.Hidden,
+        forEveryone = DeleteMessageDialogActiveState.Hidden
+    )
 )

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationsViewModelTest.kt
@@ -5,6 +5,8 @@ import com.wire.android.navigation.NavigationCommand
 import com.wire.android.navigation.NavigationItem
 import com.wire.android.ui.home.conversations.ConversationViewModel.Companion.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import com.wire.android.ui.home.conversations.ConversationViewModel.Companion.IMAGE_SIZE_LIMIT_BYTES
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.conversations.model.AttachmentType
 import com.wire.android.ui.home.conversations.model.MessageSource
@@ -73,7 +75,7 @@ class ConversationsViewModelTest {
             .arrange()
 
         // When
-        viewModel.showDeleteMessageForYourselfDialog("")
+        viewModel.deleteMessageHelper.showDeleteMessageForYourselfDialog("")
 
         // Then
         viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
@@ -88,7 +90,7 @@ class ConversationsViewModelTest {
         val (_, viewModel) = ConversationsViewModelArrangement().arrange()
 
         // When
-        viewModel.onDeleteDialogDismissed()
+        viewModel.deleteMessageHelper.onDeleteDialogDismissed()
 
         // Then
         viewModel.deleteMessageDialogsState shouldBeEqualTo DeleteMessageDialogsState.States(
@@ -105,7 +107,7 @@ class ConversationsViewModelTest {
 
         viewModel.conversationViewState
         // When
-        viewModel.deleteMessage("messageId", true)
+        viewModel.deleteMessageHelper.onDeleteMessage("messageId", true)
 
         // Then
         assert(viewModel.conversationViewState.onSnackbarMessage is ConversationSnackbarMessages.ErrorDeletingMessage)
@@ -121,7 +123,7 @@ class ConversationsViewModelTest {
 
         viewModel.conversationViewState
         // When
-        viewModel.deleteMessage("messageId", true)
+        viewModel.deleteMessageHelper.onDeleteMessage("messageId", true)
 
         // Then
         val expectedState = DeleteMessageDialogsState.States(

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -142,8 +142,9 @@ class MediaGalleryViewModelTest {
         viewModel.deleteCurrentImage()
 
         // Then
-        assert(viewModel.mediaGalleryViewState.deleteMessageDialogsState is DeleteMessageDialogsState.States)
-        assert((viewModel.mediaGalleryViewState.deleteMessageDialogsState as DeleteMessageDialogsState.States).forEveryone is DeleteMessageDialogActiveState.Visible)
+        val deleteMessageDialogsState = viewModel.mediaGalleryViewState.deleteMessageDialogsState
+        assert(deleteMessageDialogsState is DeleteMessageDialogsState.States)
+        assert((deleteMessageDialogsState as DeleteMessageDialogsState.States).forEveryone is DeleteMessageDialogActiveState.Visible)
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/gallery/MediaGalleryViewModelTest.kt
@@ -1,13 +1,15 @@
 package com.wire.android.ui.home.gallery
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
+import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.framework.FakeKaliumFileSystem
-import com.wire.android.navigation.EXTRA_MESSAGE_TO_DELETE_ID
-import com.wire.android.navigation.EXTRA_MESSAGE_TO_DELETE_IS_SELF
 import com.wire.android.navigation.NavigationManager
+import com.wire.android.ui.home.conversations.MediaGallerySnackbarMessages
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogActiveState
+import com.wire.android.ui.home.conversations.delete.DeleteMessageDialogsState
 import com.wire.android.util.FileManager
-import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -25,6 +27,8 @@ import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.conversation.ObserveConversationDetailsUseCase
+import com.wire.kalium.logic.feature.message.DeleteMessageUseCase
+import com.wire.kalium.logic.functional.Either
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -37,7 +41,7 @@ import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
 import org.amshove.kluent.internal.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -47,19 +51,18 @@ class MediaGalleryViewModelTest {
     @Test
     fun givenCurrentSetup_whenInitialisingViewModel_thenScreenTitleMatchesTheConversationName() = runTest {
         // Given
-        val dummyTitle = "Test title"
         val dummyConversationId = QualifiedID(
             "dummy-value",
             "dummy-domain"
         )
-        val mockedConversation = mockedConversationDetails(dummyTitle, dummyConversationId)
+        val mockedConversation = mockedConversationDetails("dummyTitle", dummyConversationId)
         val (_, viewModel) = Arrangement().withConversationDetails(mockedConversation).arrange()
 
         // When
         val screenTitle = viewModel.mediaGalleryViewState.screenTitle
 
         // Then
-        assertEquals(dummyTitle, screenTitle)
+        assertEquals("Test user", screenTitle)
     }
 
     @Test
@@ -93,12 +96,12 @@ class MediaGalleryViewModelTest {
             .withFailedImageDataRequest()
             .arrange()
 
-        // When
-        viewModel.saveImageToExternalStorage()
+        viewModel.snackbarMessage.test {
+            // When
+            viewModel.saveImageToExternalStorage()
 
-        // Then
-        coVerify(exactly = 1) {
-            viewModel.onSaveError()
+            // Then
+            assertEquals(MediaGallerySnackbarMessages.OnImageDownloadError, awaitItem())
         }
     }
 
@@ -124,7 +127,27 @@ class MediaGalleryViewModelTest {
     }
 
     @Test
-    fun givenACorrectSetup_whenUserTriesToDeleteAnImage_navigateBackGetsInvokedWithImageInfo() = runTest {
+    fun givenACorrectSetup_whenUserTriesToDeleteAnImage_DeleteDialogIsShown() = runTest {
+        // Given
+        val mockedConversation = mockedConversationDetails()
+        val mockedImage = "mocked-image".toByteArray()
+        val imagePath = fakeKaliumFileSystem.providePersistentAssetPath("dummy-path")
+        val (_, viewModel) = Arrangement()
+            .withStoredData(mockedImage, imagePath)
+            .withConversationDetails(mockedConversation)
+            .withSuccessfulImageData(imagePath, mockedImage.size.toLong())
+            .arrange()
+
+        // When
+        viewModel.deleteCurrentImage()
+
+        // Then
+        assert(viewModel.mediaGalleryViewState.deleteMessageDialogsState is DeleteMessageDialogsState.States)
+        assert((viewModel.mediaGalleryViewState.deleteMessageDialogsState as DeleteMessageDialogsState.States).forEveryone is DeleteMessageDialogActiveState.Visible)
+    }
+
+    @Test
+    fun givenACorrectSetup_whenUserDeletesAnImage_navigationBackIsCalled() = runTest {
         // Given
         val mockedConversation = mockedConversationDetails()
         val mockedImage = "mocked-image".toByteArray()
@@ -136,16 +159,32 @@ class MediaGalleryViewModelTest {
             .arrange()
 
         // When
-        viewModel.deleteCurrentImageMessage()
+        viewModel.deleteMessageHelper.onDeleteMessage("", true)
 
         // Then
-        coVerify(exactly = 1) {
-            arrangement.navigationManager.navigateBack(
-                mapOf(
-                    EXTRA_MESSAGE_TO_DELETE_ID to viewModel.imageAssetId.messageId,
-                    EXTRA_MESSAGE_TO_DELETE_IS_SELF to viewModel.imageAssetId.isSelfAsset
-                )
-            )
+        coVerify(exactly = 1) { arrangement.navigationManager.navigateBack() }
+    }
+
+    @Test
+    fun givenErrorWhileDelete_whenUserDeletesAnImage_errorIsShown() = runTest {
+        // Given
+        val mockedConversation = mockedConversationDetails()
+        val mockedImage = "mocked-image".toByteArray()
+        val imagePath = fakeKaliumFileSystem.providePersistentAssetPath("dummy-path")
+        val (arrangement, viewModel) = Arrangement()
+            .withStoredData(mockedImage, imagePath)
+            .withConversationDetails(mockedConversation)
+            .withSuccessfulImageData(imagePath, mockedImage.size.toLong())
+            .withFailedMessageDeleting()
+            .arrange()
+
+        viewModel.snackbarMessage.test {
+            // When
+            viewModel.deleteMessageHelper.onDeleteMessage("", true)
+
+            // Then
+            coVerify(exactly = 0) { arrangement.navigationManager.navigateBack() }
+            assertEquals(MediaGallerySnackbarMessages.DeletingMessageError, awaitItem())
         }
     }
 
@@ -160,10 +199,7 @@ class MediaGalleryViewModelTest {
         private lateinit var wireSessionImageLoader: WireSessionImageLoader
 
         @MockK
-        private lateinit var getConversationDetails: ObserveConversationDetailsUseCase
-
-        @MockK
-        private lateinit var dispatchers: DispatcherProvider
+        lateinit var getConversationDetails: ObserveConversationDetailsUseCase
 
         @MockK
         lateinit var getImageData: GetMessageAssetUseCase
@@ -174,16 +210,17 @@ class MediaGalleryViewModelTest {
         @MockK
         private lateinit var qualifiedIdMapper: QualifiedIdMapper
 
-        lateinit var conversationDetails: ConversationDetails
+        @MockK
+        lateinit var deleteMessage: DeleteMessageUseCase
 
         init {
             // Tests setup
             val dummyPrivateAsset = "some-conversationId:some-message-id:true"
             MockKAnnotations.init(this, relaxUnitFun = true)
             every { savedStateHandle.get<String>(any()) } returns dummyPrivateAsset
+            every { qualifiedIdMapper.fromStringToQualifiedID(any()) } returns dummyConversationId
 
-            // Default empty values
-            coEvery { getConversationDetails(any()) } returns flowOf(ObserveConversationDetailsUseCase.Result.Success(conversationDetails))
+            coEvery { deleteMessage(any(), any(), any()) } returns Either.Right(Unit)
         }
 
         fun withStoredData(assetData: ByteArray, assetPath: Path): Arrangement {
@@ -194,8 +231,8 @@ class MediaGalleryViewModelTest {
             return this
         }
 
-        fun withConversationDetails(mockedConversationDetails: ConversationDetails): Arrangement {
-            conversationDetails = mockedConversationDetails
+        fun withConversationDetails(conversationDetails: ConversationDetails): Arrangement {
+            coEvery { getConversationDetails(any()) } returns flowOf(ObserveConversationDetailsUseCase.Result.Success(conversationDetails))
             return this
         }
 
@@ -209,26 +246,32 @@ class MediaGalleryViewModelTest {
             return this
         }
 
+        fun withFailedMessageDeleting(): Arrangement {
+            coEvery { deleteMessage(any(), any(), any()) } returns Either.Left(CoreFailure.Unknown(null))
+            return this
+        }
+
         fun arrange() = this to MediaGalleryViewModel(
             savedStateHandle,
             wireSessionImageLoader,
             qualifiedIdMapper,
             navigationManager,
             getConversationDetails,
-            dispatchers,
+            TestDispatcherProvider(),
             getImageData,
-            fileManager
+            fileManager,
+            deleteMessage
         )
 
     }
 
     private fun mockedConversationDetails(
         mockedConversationTitle: String = "Dummy Screen Title",
-        dummyConversationId: QualifiedID = QualifiedID("a-value", "a-domain")
+        mockedConversationId: QualifiedID = dummyConversationId
     ): ConversationDetails =
         OneOne(
             conversation = Conversation(
-                id = dummyConversationId,
+                id = mockedConversationId,
                 name = mockedConversationTitle,
                 type = Conversation.Type.ONE_ON_ONE,
                 teamId = null,
@@ -244,7 +287,7 @@ class MediaGalleryViewModelTest {
             ),
             otherUser = OtherUser(
                 QualifiedID("other-user-id", "domain-id"),
-                null, null, null, null,
+                "Test user", null, null, null,
                 1, null, ConnectionState.ACCEPTED, null, null,
                 UserType.INTERNAL,
                 UserAvailabilityStatus.AVAILABLE,
@@ -260,5 +303,6 @@ class MediaGalleryViewModelTest {
 
     companion object {
         val fakeKaliumFileSystem = FakeKaliumFileSystem()
+        val dummyConversationId = QualifiedID("a-value", "a-domain")
     }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1748" title="AR-1748" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-1748</a>  [Images] Refactor Delete Message Functionality from gallery 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

when use is trying to remove media message from the Gallery screen, app redirects him to the Conversation screen and shows the DeleteMessageDialog instead of showing that dialog in Gallery screen.

Also, all the tests in `MediaGalleryViewModelTest` were not running, because of wrong `@Test` import, it should be `org.junit.jupiter.api.Test`

### Causes (Optional)

it was implemented like this from the beginning

### Solutions

fix it

### Attachments (Optional)


