### PR TITLE
fix: text ellipsis and spacing [AR-2088]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/bottomsheet/MenuBottomSheetItem.kt
@@ -4,8 +4,8 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -17,8 +17,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.android.ui.common.ArrowRightIcon
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import io.github.esentsov.PackagePrivate
@@ -33,7 +38,7 @@ fun MenuBottomSheetItem(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
-            .height(MaterialTheme.wireDimensions.conversationBottomSheetItemHeight)
+            .defaultMinSize(minHeight = MaterialTheme.wireDimensions.conversationBottomSheetItemHeight)
             .fillMaxWidth()
             .clickable { onItemClick() }
             .padding(MaterialTheme.wireDimensions.conversationBottomSheetItemPadding)
@@ -42,7 +47,8 @@ fun MenuBottomSheetItem(
         Spacer(modifier = Modifier.width(12.dp))
         MenuItemTitle(title = title)
         if (action != null) {
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.width(MaterialTheme.wireDimensions.spacing12x))
+            Spacer(modifier = Modifier.weight(1f))  // combining both in one modifier doesn't work
             action()
         }
     }
@@ -82,5 +88,32 @@ fun MenuItemIcon(
         modifier = Modifier
             .size(size)
             .then(modifier)
+    )
+}
+
+@Preview
+@Composable
+fun MenuBottomSheetItemPreview() {
+    MenuBottomSheetItem(
+        title = "very long looooooong title",
+        icon = {
+            MenuItemIcon(
+                id = R.drawable.ic_erase,
+                contentDescription = "",
+            )
+        },
+        action = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "very long looooooong action",
+                    style = MaterialTheme.wireTypography.body01,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    modifier = Modifier.weight(weight = 1f, fill = false)
+                )
+                Spacer(modifier = Modifier.size(dimensions().spacing16x))
+                ArrowRightIcon()
+            }
+        }
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/InternalContactSearchResultItem.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/search/InternalContactSearchResultItem.kt
@@ -52,7 +52,8 @@ fun InternalContactSearchResultItem(
             Row(verticalAlignment = CenterVertically) {
                 HighlightName(
                     name = name,
-                    searchQuery = searchQuery
+                    searchQuery = searchQuery,
+                    modifier = Modifier.weight(weight = 1f, fill = false)
                 )
                 UserBadge(
                     membership = membership,
@@ -103,7 +104,8 @@ fun ExternalContactSearchResultItem(
             Row(verticalAlignment = CenterVertically) {
                 HighlightName(
                     name = name,
-                    searchQuery = searchQuery
+                    searchQuery = searchQuery,
+                    modifier = Modifier.weight(weight = 1f, fill = false)
                 )
                 UserBadge(
                     membership = membership,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/HomeSheetContent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/bottomsheet/HomeSheetContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import com.wire.android.R
 import com.wire.android.model.UserAvatarData
 import com.wire.android.ui.common.ArrowRightIcon
@@ -200,13 +201,16 @@ internal fun ConversationMainSheetContent(
 }
 
 @Composable
-internal fun NotificationsOptionsItemAction(
+fun NotificationsOptionsItemAction(
     mutedStatus: MutedConversationStatus
 ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = mutedStatus.getMutedStatusTextResource(),
-            style = MaterialTheme.wireTypography.body01
+            style = MaterialTheme.wireTypography.body01,
+            overflow = TextOverflow.Ellipsis,
+            maxLines = 1,
+            modifier = Modifier.weight(weight = 1f, fill = false)
         )
         Spacer(modifier = Modifier.size(dimensions().spacing16x))
         ArrowRightIcon()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationTitle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/common/ConversationTitle.kt
@@ -30,6 +30,7 @@ fun ConversationTitle(
             style = MaterialTheme.wireTypography.body02,
             overflow = TextOverflow.Ellipsis,
             maxLines = 1,
+            modifier = Modifier.weight(weight = 1f, fill = false)
         )
         badges()
         if (isLegalHold) {

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/contacts/ContactsScreen.kt
@@ -119,7 +119,8 @@ private fun ContactItem(
                     text = name,
                     style = MaterialTheme.wireTypography.title02,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(weight = 1f, fill = false)
                 )
                 UserBadge(
                     membership = membership,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2088" title="AR-2088" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2088</a>  Texts in conversation context menu should use ellipsis
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In some places texts were taking too much space resulting in making other items invisible: user membership badges on conversation list and user search list, notification type info and right arrow on conversation bottom sheet.

### Solutions

Add weights and proper spacings.

### Testing

#### How to Test

Look at conversations list (items with badges) and conversation notification settings row (it's visible on some device screens when you have German language set).

### Attachments (Optional)

![user_label](https://user-images.githubusercontent.com/30429749/187245015-0af94d73-6d6a-4572-b255-fb380af44bfd.jpg)
![notif_menu](https://user-images.githubusercontent.com/30429749/187245068-b252cc86-7f97-41e1-943c-c31b7f4224e3.jpg)


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
