### PR TITLE
feat: display screen sharing feed (AR-1234) 

### DIFF
--- a/app/src/main/kotlin/com/wire/android/mapper/UICallParticipantMapper.kt
+++ b/app/src/main/kotlin/com/wire/android/mapper/UICallParticipantMapper.kt
@@ -17,6 +17,7 @@ class UICallParticipantMapper @Inject constructor(
         isMuted = participant.isMuted,
         isSpeaking = participant.isSpeaking,
         isCameraOn = participant.isCameraOn,
+        isSharingScreen = participant.isSharingScreen,
         avatar = participant.avatarAssetId?.let { ImageAsset.UserAvatarAsset(wireSessionImageLoader, it) },
         membership = userTypeMapper.toMembership(participant.userType)
     )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ParticipantTile.kt
@@ -92,7 +92,7 @@ fun ParticipantTile(
                     })
                 } else onClearSelfUserVideoPreview()
             } else {
-                if (participantTitleState.isCameraOn) {
+                if (participantTitleState.isCameraOn || participantTitleState.isSharingScreen) {
                     val context = LocalContext.current
                     AndroidView(factory = {
                         VideoRenderer(context, participantTitleState.id.toString(), participantTitleState.clientId, false).apply {
@@ -163,6 +163,7 @@ private fun ParticipantTilePreview() {
             isMuted = true,
             isSpeaking = true,
             isCameraOn = true,
+            isSharingScreen = false,
             avatar = null,
             membership = Membership.Admin
         ),

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/CallingGridView.kt
@@ -75,6 +75,7 @@ fun GroupCallGrid(
                 isMuted = isMuted,
                 isSpeaking = participant.isSpeaking,
                 isCameraOn = isCameraOn,
+                isSharingScreen = participant.isSharingScreen,
                 avatar = participant.avatar,
                 membership = participant.membership
             )
@@ -124,6 +125,7 @@ fun GroupCallGridPreview() {
                 isMuted = false,
                 isSpeaking = false,
                 isCameraOn = false,
+                isSharingScreen = false,
                 avatar = null,
                 membership = Membership.Admin,
             ),
@@ -134,6 +136,7 @@ fun GroupCallGridPreview() {
                 isMuted = false,
                 isSpeaking = false,
                 isCameraOn = false,
+                isSharingScreen = false,
                 avatar = null,
                 membership = Membership.Admin,
             )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/OneOnOneCallView.kt
@@ -60,6 +60,7 @@ fun OneOnOneCallView(
                 isMuted = isMuted,
                 isSpeaking = participant.isSpeaking,
                 isCameraOn = isCameraOn,
+                isSharingScreen = participant.isSharingScreen,
                 avatar = participant.avatar,
                 membership = participant.membership
             )

--- a/app/src/main/kotlin/com/wire/android/ui/calling/model/UICallParticipant.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/model/UICallParticipant.kt
@@ -11,6 +11,7 @@ data class UICallParticipant(
     val isMuted: Boolean,
     val isSpeaking: Boolean = false,
     val isCameraOn: Boolean,
+    val isSharingScreen: Boolean,
     val avatar: ImageAsset.UserAvatarAsset? = null,
     val membership: Membership,
 )

--- a/app/src/test/kotlin/com/wire/android/mapper/UICallParticipantMapperTest.kt
+++ b/app/src/test/kotlin/com/wire/android/mapper/UICallParticipantMapperTest.kt
@@ -21,6 +21,7 @@ class UICallParticipantMapperTest {
             false,
             false,
             false,
+            false,
             UserAssetId("assetvalue", "assetdomain")
         )
         // When


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-1234" title="AR-1234" target="_blank"><img alt="Story" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10815?size=medium" />AR-1234</a>  Screen sharing (receive)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Description
This PR aims to display call participants screen share

### Dependencies (Optional)

Needs to be released with wireapp/kalium/pull/848
Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

In a call request from others to share their screen
You should see their screen in the tiles

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
