### PR TITLE
fix: conversation screen crash when user has no conversations

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -111,17 +111,19 @@ class ConversationListViewModel @Inject constructor(
 
                     val remainingConversations = allConversations - unreadConversations.toSet()
 
-                    state = ConversationListState(
-                        newActivities = unreadConversations.toNewActivities(selfUser),
-                        conversations = remainingConversations.toConversationsFoldersMap(selfUser),
-                        missedCalls = mockMissedCalls, // TODO: needs to be implemented
-                        callHistory = mockCallHistory, // TODO: needs to be implemented
-                        unreadMentions = mockUnreadMentionList, // TODO: needs to be implemented
-                        allMentions = mockAllMentionList, // TODO: needs to be implemented
-                        newActivityCount = unreadConversationsCount,
-                        unreadMentionsCount = mentionsCount, // TODO: needs to be implemented on Kalium side
-                        missedCallsCount = missedCallsCount // TODO: needs to be implemented on Kalium side
-                    )
+                    withContext(dispatcher.main()) {
+                        state = ConversationListState(
+                            newActivities = unreadConversations.toNewActivities(selfUser),
+                            conversations = remainingConversations.toConversationsFoldersMap(selfUser),
+                            missedCalls = mockMissedCalls, // TODO: needs to be implemented
+                            callHistory = mockCallHistory, // TODO: needs to be implemented
+                            unreadMentions = mockUnreadMentionList, // TODO: needs to be implemented
+                            allMentions = mockAllMentionList, // TODO: needs to be implemented
+                            newActivityCount = unreadConversationsCount,
+                            unreadMentionsCount = mentionsCount, // TODO: needs to be implemented on Kalium side
+                            missedCallsCount = missedCallsCount // TODO: needs to be implemented on Kalium side
+                        )
+                    }
                 }
             }
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

the conversation screen state is updated from the io thread -> app crash

### Solutions

add `withContext(dispatsher.main())` 

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
