### PR TITLE
fix: Can't open conversation menu during ongoing call (AR-2276)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -25,9 +25,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -53,6 +50,7 @@ private val DEFAULT_KEYBOARD_TOP_SCREEN_OFFSET = 250.dp
 
 @Composable
 fun MessageComposer(
+    keyboardHeight: KeyboardHeight,
     content: @Composable () -> Unit,
     messageText: String,
     onMessageChanged: (String) -> Unit,
@@ -77,7 +75,7 @@ fun MessageComposer(
 
         MessageComposer(
             content = content,
-            screenHeight = with(LocalDensity.current) { constraints.maxHeight.toDp() },
+            keyboardHeight = keyboardHeight,
             messageComposerState = messageComposerState,
             messageText = messageComposerState.messageText,
             onMessageChanged = {
@@ -112,7 +110,7 @@ fun MessageComposer(
 @Composable
 private fun MessageComposer(
     content: @Composable () -> Unit,
-    screenHeight: Dp,
+    keyboardHeight: KeyboardHeight,
     messageComposerState: MessageComposerInnerState,
     messageText: TextFieldValue,
     onMessageChanged: (TextFieldValue) -> Unit,
@@ -125,16 +123,6 @@ private fun MessageComposer(
     tempCachePath: Path
 ) {
     val focusManager = LocalFocusManager.current
-    // when MessageComposer is composed for the first time we do not know the height
-    // until users opens the keyboard
-    var keyboardHeightOffSet: KeyboardHeight by remember {
-        mutableStateOf(KeyboardHeight.NotKnown)
-    }
-    // if the currentScreenHeight is smaller than the initial fullScreenHeight
-    // calculated at the first composition of the MessageComposer, then we know the keyboard size
-    if (screenHeight < messageComposerState.fullScreenHeight) {
-        keyboardHeightOffSet = KeyboardHeight.Known(messageComposerState.fullScreenHeight - screenHeight)
-    }
 
     Surface {
         val transition = updateTransition(
@@ -157,7 +145,7 @@ private fun MessageComposer(
             // AttachmentOptions, the offset is set to DEFAULT_KEYBOARD_TOP_SCREEN_OFFSET as default, whenever the keyboard pops up
             // we are able to calculate the actual needed offset, so that it is equal to the height of the keyboard the user is using
             val topOfKeyboardGuideLine = createGuidelineFromTop(
-                offset = messageComposerState.fullScreenHeight - keyboardHeightOffSet.height
+                offset = messageComposerState.fullScreenHeight - keyboardHeight.height
             )
 
             val messageComposer = createRef()
@@ -261,7 +249,7 @@ private fun MessageComposer(
             // we get the effect of overlapping it
             if (messageComposerState.attachmentOptionsDisplayed && !isUserBlocked && isConversationMember) {
                 AttachmentOptions(
-                    keyboardHeightOffSet,
+                    keyboardHeight,
                     messageComposerState,
                     onSendAttachment,
                     onMessageComposerError,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/attachment/AttachmentOptions.kt
@@ -46,7 +46,7 @@ import okio.Path.Companion.toPath
 
 @Composable
 fun AttachmentOptions(
-    keyboardHeightOffSet: KeyboardHeight,
+    keyboardHeight: KeyboardHeight,
     messageComposerState: MessageComposerInnerState,
     onSendAttachment: (AttachmentBundle?) -> Unit,
     onMessageComposerError: (ConversationSnackbarMessages) -> Unit,
@@ -56,8 +56,8 @@ fun AttachmentOptions(
     Box(
         Modifier
             .fillMaxWidth()
-            .height(keyboardHeightOffSet.height)
-            .absoluteOffset(y = messageComposerState.fullScreenHeight - keyboardHeightOffSet.height)
+            .height(keyboardHeight.height)
+            .absoluteOffset(y = messageComposerState.fullScreenHeight - keyboardHeight.height)
     ) {
         Divider()
         AttachmentOptionsComponent(


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2276" title="AR-2276" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2276</a>  If I am on a call, I can't open conversation menu(+ button)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

### Issues

`+` button on conversation doesn’t work if i am on a call

### Causes (Optional)

Conversation menu should take the same height as a keyboard, so user won't see any "jumping input" if he opens conversation menu when the keyboard is displayed.
We calculate the "accessible aria" size on each re-composition and compare it to the initial "accessible aria" (from the first composition) and if that `screenSize` is smaller than the initial we assume that the keyboard was opened and we can calculate its height. 
The problem is that this remembering and comparing screen sizes happens in `MessageComposer` and if user has some ongoing call then the message about it is shown in TopBar, which decreases "accessible aria" and app was thinking that the keyboard was opened. 

### Solutions

Move remembering and comparing screen sizes and calculating keyboard height into `ConversationScreen`

