### PR TITLE
fix: Conversation options doesn't open after sending app to background (AR-2177)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -222,9 +222,12 @@ private fun ConversationScreen(
                     }
 
                     // if the currentScreenHeight is smaller than the initial fullScreenHeight
+                    // and we don't know the keyboard height yet
                     // calculated at the first composition of the ConversationScreen, then we know the keyboard size
-                    if (currentScreenHeight < fullScreenHeight) {
-                        keyboardHeight = KeyboardHeight.Known(fullScreenHeight - currentScreenHeight)
+                    if (keyboardHeight is KeyboardHeight.NotKnown && currentScreenHeight < fullScreenHeight) {
+                        val difference = fullScreenHeight - currentScreenHeight
+                        if (difference > KeyboardHeight.DEFAULT_KEYBOARD_TOP_SCREEN_OFFSET)
+                            keyboardHeight = KeyboardHeight.Known(difference)
                     }
 
                     Scaffold(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/MessageComposer.kt
@@ -46,8 +46,6 @@ import com.wire.android.ui.home.conversations.model.AttachmentBundle
 import com.wire.android.ui.home.messagecomposer.attachment.AttachmentOptions
 import okio.Path
 
-private val DEFAULT_KEYBOARD_TOP_SCREEN_OFFSET = 250.dp
-
 @Composable
 fun MessageComposer(
     keyboardHeight: KeyboardHeight,
@@ -311,4 +309,8 @@ private fun CollapseIconButton(onCollapseClick: () -> Unit, modifier: Modifier =
 sealed class KeyboardHeight(open val height: Dp) {
     object NotKnown : KeyboardHeight(DEFAULT_KEYBOARD_TOP_SCREEN_OFFSET)
     data class Known(override val height: Dp) : KeyboardHeight(height)
+
+    companion object {
+        val DEFAULT_KEYBOARD_TOP_SCREEN_OFFSET = 250.dp
+    }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2177" title="AR-2177" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2177</a>  + button on conv details doesn't expand after sending app background
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

When clicking on add + button, it expands the menu. If I send back to the background, open the app again but click the app icon (not recent apps), the button gets selected, but menu is not open


### Causes (Optional)

When app just returns from the background there is some moment when "available screen" space includes Android Navigation buttons space (and we remember that as a `fullScreenHeight`). So when re-composition is called it find out that the screen size is 24.dp smaller than the remembered one and assumes that keyboard height is 24.dp :) 

### Solutions

made the keyboard height be at least `DEFAULT_KEYBOARD_TOP_SCREEN_OFFSET` 
also added some checks: if the keyboard height is already known, then do not update it 

