### PR TITLE
fix: new activity section scroll issue #2 [AR-2279]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/AllConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/AllConversationScreen.kt
@@ -6,14 +6,21 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversationslist.common.ConversationItemFactory
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
+import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 
@@ -62,7 +69,10 @@ private fun AllConversationContent(
          *  it so it wants to keep this dummy top item as the first one on list and show all other items below it.
          */
         item("empty-top-header") {
-            Spacer(modifier = Modifier.height(Dp.Hairline))
+            Divider(
+                thickness = Dp.Hairline,
+                color = Color.Transparent
+            )
         }
         conversations.forEach { (conversationFolder, conversationList) ->
             folderWithElements(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/AllConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/AllConversationScreen.kt
@@ -1,26 +1,19 @@
 package com.wire.android.ui.home.conversationslist
 
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.home.conversationslist.common.ConversationItemFactory
 import com.wire.android.ui.home.conversationslist.model.ConversationFolder
 import com.wire.android.ui.home.conversationslist.model.ConversationItem
-import com.wire.android.ui.theme.wireColorScheme
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/AR-2279" title="AR-2279" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />AR-2279</a>  New Activity Section does not automatically appear without scrolling
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

When the user is on the conversation list, and a new message arrives, and “new activity” section should appear, then it’s hidden until the user scrolls up on the conversation list.

### Causes (Optional)

Turns out `Dp.Hairline` doesn't work for the `Spacer` and in practice it still makes the height equal to 0, then `LazyColumn` doesn't recognise it as an item (because it doesn't take any space).

### Solutions

Use `Divider` instead of `Spacer`, because it uses `Dp.Hairline` properly (it makes the height of 1 pixel so it's as narrow as it can be).

### Testing

#### How to Test

Open the app, don't scroll (keep the conversation list scrolled to top) and receive a message to make new activity section appear.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
